### PR TITLE
[AO-20302] Post-pad trace ID

### DIFF
--- a/opentelemetry_distro_solarwinds/ot_ao_transformer.py
+++ b/opentelemetry_distro_solarwinds/ot_ao_transformer.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__file__)
 
 def transform_id(span_context):
     """Generates an AppOptics X-Trace ID from the provided OpenTelemetry span context."""
-    xtr = "2B00000000{0:032X}{1:016X}0{2}".format(span_context.trace_id,
+    xtr = "2B{0:032X}00000000{1:016X}0{2}".format(span_context.trace_id,
                                                   span_context.span_id,
                                                   span_context.trace_flags)
     logger.debug("Generated X-Trace %s from span context %s", xtr,


### PR DESCRIPTION
Previously, when converting the Otel trace and span ID to the AO X-Trace, we were pre-padding the task ID with 0. In order to be compatible with other language agents (e.g. Java), we now post-pad the task ID.