### PR TITLE
[AO-20302] Add Otel attributes to AO event data

### DIFF
--- a/opentelemetry_distro_solarwinds/exporter.py
+++ b/opentelemetry_distro_solarwinds/exporter.py
@@ -48,6 +48,8 @@ class SolarWindsSpanExporter(SpanExporter):
                 evt = Context.startTrace(md, int(span.start_time / 1000))
             evt.addInfo('Layer', span.name)
             evt.addInfo('Language', 'Python')
+            for k, v in span.attributes.items():
+                evt.addInfo(k, v)
             self.reporter.sendReport(evt)
 
             for event in span.events:


### PR DESCRIPTION
This PR adds the Otel-attributes of a span as KV pairs to the (AO) start event.