### PR TITLE
Update gpg keyserver

### DIFF
--- a/dev_tools/Dockerfile
+++ b/dev_tools/Dockerfile
@@ -27,7 +27,7 @@ RUN yum install -y \
     && yum clean all && rm -rf /var/cache/yum
 
 # install Ruby2.5 which is needed for package cloud cli
-RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 \
+RUN gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 \
         7D2BAF1CF37B13E2069D6956105BD0E739499BDB && \
     curl -sSL https://get.rvm.io | bash -s stable && source /etc/profile.d/rvm.sh && \
     /usr/local/rvm/bin/rvm install 2.5.1 --disable-binary


### PR DESCRIPTION
Update gpg keyserver for this too because around June 2021 hkp://keys.gnupg.net can no longer be used.

hkps://keys.openpgp.org is supposed to be the new default, but that also seems to be out. The next best seems to be the ubuntu host.

Some talk around it:

https://lists.gnupg.org/pipermail/gnupg-users/2021-June/065261.html
https://unix.stackexchange.com/questions/656205/sks-keyservers-gone-what-to-use-instead/664651#664651
gpgkeys: HTTP fetch error 6: Could not resolve host: pool.sks-keyservers.net rvm/rvm#5096