### PR TITLE
Make custom exporter use its own _report_info_event method

### DIFF
--- a/opentelemetry_distro_solarwinds/exporter.py
+++ b/opentelemetry_distro_solarwinds/exporter.py
@@ -56,7 +56,7 @@ class SolarWindsSpanExporter(SpanExporter):
                 if event.name == 'exception':
                     self._report_exception_event(event)
                 else:
-                    self.reporter().sendReport(event)
+                    self._report_info_event(event)
 
             evt = Context.stopTrace(int(span.end_time / 1000))
             evt.addInfo('Layer', span.name)


### PR DESCRIPTION
Make custom exporter use its own `_report_info_event` method. @prettycoder pointed out that the current way would give the Reporter the wrong event format.

Test distributed traces after this change:

AO staging:
- https://my-stg.appoptics.com/apm/1008/services/manual-app-ot/traces/E8026AC3441FBD381D765ACEF4B40C8C00000000/graph
- https://my-stg.appoptics.com/apm/1008/services/django-app-ot/traces/E8026AC3441FBD381D765ACEF4B40C8C00000000/graph
- https://my-stg.appoptics.com/apm/1008/services/jetty-app-ot/traces/E8026AC3441FBD381D765ACEF4B40C8C00000000/graph

NH staging (https://my.dc-01.st-ssp.solarwinds.com/common/graphql):
`C5C01B6E51862F00B879455C86666FE4`