### PR TITLE
NH-2313 Bugfixes: propagator gets tracestate from carrier; from_header usage fix

### DIFF
--- a/opentelemetry_distro_solarwinds/propagator.py
+++ b/opentelemetry_distro_solarwinds/propagator.py
@@ -83,7 +83,7 @@ class SolarWindsPropagator(textmap.TextMapPropagator):
 
         # Prepare carrier with carrier's or new tracestate
         if trace_state_header:
-            trace_state = TraceState.from_header(trace_state_header)
+            trace_state = TraceState.from_header([trace_state_header])
             # Check if trace_state already contains sw KV
             if SW_TRACESTATE_KEY in trace_state.keys():
                 # If so, modify current span_id and trace_flags, and move to beginning of list

--- a/opentelemetry_distro_solarwinds/sampler.py
+++ b/opentelemetry_distro_solarwinds/sampler.py
@@ -348,9 +348,9 @@ class _SwSampler(Sampler):
             trace_state_no_response = self.remove_response_from_sw(trace_state)
         else:
             # Must retain all potential tracestate pairs for attributes
-            attr_trace_state = TraceState.from_header(
+            attr_trace_state = TraceState.from_header([
                 tracestate_capture
-            )
+            ])
             new_attr_trace_state = attr_trace_state.update(
                 SW_TRACESTATE_KEY,
                 W3CTransformer.sw_from_span_and_decision(


### PR DESCRIPTION
Bugfixes:

(1)
OTel Python `TraceState.from_header` accepts a list of header strings, not a single header string. Using the latter results in quiet dropping of input values! 😦 

(2)
SW Propagator should get and update tracestate header from the carrier before (re-)injection, not the span context. This is because the current span context's tracestate doesn't change during the loop through of all propagators' `inject` as part of `CompositePropagator.inject`. Currently, tracestate header injected by a first propagator (e.g. `tracecontext`) is being completely overwritten by a later propagator (e.g. `solarwinds_propagator`). To capture tracestate header changes made by a first propagator in the composite, later propagators should update that and re-inject.

In another PR (https://github.com/appoptics/opentelemetry-python-testbed/pull/22), we are restricting `OTEL_PROPAGATORS` so that `tracecontext` must always precede `solarwinds_propagator`. `tracecontext` maps to `TraceContextTextMapPropagator` which injects tracestate into the carrier: https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-api/src/opentelemetry/trace/propagation/tracecontext.py#L89-L109 Therefore, tracestate should always be available in the carrier for SW Propagator to use.

Manual test results on the upper half of the table on this doc: https://swicloud.atlassian.net/wiki/spaces/NIT/pages/2909569037/2022-04-27+to+28+propagators+combinations+testing

Customer documentation draft updated here: https://swicloud.atlassian.net/wiki/spaces/NIT/pages/2867726621/NH+Python+Troubleshooting#Customizing-OTel-Propagators