### PR TITLE
NH-12591 Always add service kvs

### DIFF
--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -308,15 +308,14 @@ class _SwSampler(Sampler):
         if internal_sw_keys:
             new_attributes[self._INTERNAL_SW_KEYS] = internal_sw_keys
     
-        # If not a liboboe continued trace, set service entry internal KVs       
-        if not self.is_decision_continued(decision):
-            new_attributes[self._INTERNAL_BUCKET_CAPACITY] = "{}".format(decision["bucket_cap"])
-            new_attributes[self._INTERNAL_BUCKET_RATE] = "{}".format(decision["bucket_rate"])
-            new_attributes[self._INTERNAL_SAMPLE_RATE] = decision["rate"]
-            new_attributes[self._INTERNAL_SAMPLE_SOURCE] = decision["source"]
-            logger.debug(
-                "Set attributes with service entry internal KVs: {}".format(new_attributes)
-            )
+        # Always (root or is_remote) set service entry internal KVs       
+        new_attributes[self._INTERNAL_BUCKET_CAPACITY] = "{}".format(decision["bucket_cap"])
+        new_attributes[self._INTERNAL_BUCKET_RATE] = "{}".format(decision["bucket_rate"])
+        new_attributes[self._INTERNAL_SAMPLE_RATE] = decision["rate"]
+        new_attributes[self._INTERNAL_SAMPLE_SOURCE] = decision["source"]
+        logger.debug(
+            "Set attributes with service entry internal KVs: {}".format(new_attributes)
+        )
 
         # Trace's root span has no valid traceparent nor tracestate
         # so we can't calculate remaining attributes

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -574,7 +574,13 @@ class Test_SwSampler():
             trace_state=None,
             parent_span_context=parent_span_context_invalid,
             xtraceoptions=mock_xtraceoptions_sw_keys,
-        ) == MappingProxyType({"SWKeys": "foo"})
+        ) == MappingProxyType({
+            "BucketCapacity": "-1",
+            "BucketRate": "-1",
+            "SampleRate": -1,
+            "SampleSource": -1,
+            "SWKeys": "foo",
+        })
 
     def test_calculate_attributes_contd_decision_no_sw_keys(
         self,
@@ -588,7 +594,12 @@ class Test_SwSampler():
             trace_state=None,
             parent_span_context=parent_span_context_invalid,
             xtraceoptions=mock_xtraceoptions_no_sw_keys,
-        ) == None
+        ) == MappingProxyType({
+            "BucketCapacity": "-1",
+            "BucketRate": "-1",
+            "SampleRate": -1,
+            "SampleSource": -1,
+        })
 
     def test_calculate_attributes_not_contd_decision_sw_keys(
         self,
@@ -643,6 +654,10 @@ class Test_SwSampler():
             parent_span_context=parent_span_context_valid_remote,
             xtraceoptions=mock_xtraceoptions_sw_keys,
         ) == MappingProxyType({
+            "BucketCapacity": "-1",
+            "BucketRate": "-1",
+            "SampleRate": -1,
+            "SampleSource": -1,
             "sw.tracestate_parent_id": "1111222233334444",
             "sw.w3c.tracestate": "foo=bar,sw=123,baz=qux",
             'SWKeys': 'foo',
@@ -663,6 +678,10 @@ class Test_SwSampler():
             parent_span_context=parent_span_context_valid_remote,
             xtraceoptions=mock_xtraceoptions_sw_keys,
         ) == MappingProxyType({
+            "BucketCapacity": "-1",
+            "BucketRate": "-1",
+            "SampleRate": -1,
+            "SampleSource": -1,
             "sw.w3c.tracestate": "foo=bar,sw=123,baz=qux",
             'SWKeys': 'foo',
             "foo": "bar",
@@ -684,6 +703,10 @@ class Test_SwSampler():
             parent_span_context=parent_span_context_valid_remote,
             xtraceoptions=mock_xtraceoptions_sw_keys,
         ) == MappingProxyType({
+            "BucketCapacity": "-1",
+            "BucketRate": "-1",
+            "SampleRate": -1,
+            "SampleSource": -1,
             "sw.w3c.tracestate": "sw=1111222233334444-01,some=other",
             'SWKeys': 'foo',
             "foo": "bar",


### PR DESCRIPTION
Always (root or is_remote spans) set service entry internal KVs on spans, as per spec update in https://github.com/librato/trace/pull/306/files.

Test trace before change:
- Only the `home_a/` span's Raw Data has BucketCapacity, etc
- https://my.dc-01.st-ssp.solarwinds.com/136444677275740160/traces/41C1A109A3949380ECD68E1D52949D99/14195F184EA2A3A1/details

Test trace after change:
- Both `home_a/` and `home_b/` span Raw Data have BucketCapacity, etc
- For `home_a/`, the values are from the remote collector's settings
- For `home_b/`, the values are `-1`.
https://my.dc-01.st-ssp.solarwinds.com/136444677275740160/traces/2C8C1EBB4C91E83F96176CBBCEDFC1B7/3CB6A48D1C15A99A/details
