### PR TITLE
NH-11751 OTel 1.12.0rc1

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-opentelemetry-test-utils==0.30b0
+opentelemetry-test-utils==0.31b0
 pytest
 pytest-cov
 pytest-mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,9 +20,9 @@ python_requires = >=3.6
 zip_safe = False
 include_package_data = True
 install_requires =
-    opentelemetry-api == 1.11.0
-    opentelemetry-sdk == 1.11.0
-    opentelemetry-instrumentation == 0.30b0
+    opentelemetry-api == 1.12.0rc1
+    opentelemetry-sdk == 1.12.0rc1
+    opentelemetry-instrumentation == 0.31b0
 
 [options.entry_points]
 opentelemetry_distro =


### PR DESCRIPTION
Update to use OTel Python `1.12.0rc1-0.31b0` from 2022-05-17.

* https://github.com/open-telemetry/opentelemetry-python/blob/main/CHANGELOG.md
* https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CHANGELOG.md

Regression/tox tests now says `instrumentation_info` is deprecated. But our test script isn't making that call. I think OTel Python `ReadableSpan` class needs an update to its init:

```
tests/test_span_attributes.py::TestFunctionalSpanAttributesAllSpans::test_attrs_no_input_headers
  /code/solarwinds_apm/.tox/py36-nh-staging/lib/python3.6/site-packages/opentelemetry/sdk/trace/__init__.py:1147: DeprecationWarning: Call to deprecated method __init__. (You should use InstrumentationScope) -- Deprecated since version 1.11.1.
    schema_url,
```

Testbed still runs and logs span export after curl when it also updates to `1.12.0rc1-0.31b0`. PR including that change coming soon.