### PR TITLE
NH-15462 (v2) Mask service key in logs

### DIFF
--- a/tests/test_apm_config.py
+++ b/tests/test_apm_config.py
@@ -190,9 +190,19 @@ class TestSolarWindsApmConfig:
         self._mock_with_service_key(mocker, " ")
         assert apm_config.SolarWindsApmConfig()._mask_service_key() == " "
 
-    def test_mask_service_key_missing_service_name(self, mocker):
+    def test_mask_service_key_invalid_format_no_colon(self, mocker):
+        self._mock_with_service_key(mocker, "a")
+        assert apm_config.SolarWindsApmConfig()._mask_service_key() == "a<invalid_format>"
+        self._mock_with_service_key(mocker, "abcd")
+        assert apm_config.SolarWindsApmConfig()._mask_service_key() == "abcd<invalid_format>"
+        self._mock_with_service_key(mocker, "abcde")
+        assert apm_config.SolarWindsApmConfig()._mask_service_key() == "abcd...<invalid_format>"
+        self._mock_with_service_key(mocker, "abcdefgh")
+        assert apm_config.SolarWindsApmConfig()._mask_service_key() == "abcd...<invalid_format>"
+        self._mock_with_service_key(mocker, "abcd1efgh")
+        assert apm_config.SolarWindsApmConfig()._mask_service_key() == "abcd...<invalid_format>"
         self._mock_with_service_key(mocker, "CyUuit1W--8RVmUXX6_cVjTWemaUyBh1ruL0nMPiFdrPo1iiRnO31_pwiUCPzdzv9UMHK6I")
-        assert apm_config.SolarWindsApmConfig()._mask_service_key() == "CyUuit1W--8RVmUXX6_cVjTWemaUyBh1ruL0nMPiFdrPo1iiRnO31_pwiUCPzdzv9UMHK6I"
+        assert apm_config.SolarWindsApmConfig()._mask_service_key() == "CyUu...<invalid_format>"
 
     def test_mask_service_key_less_than_9_char_token(self, mocker):
         self._mock_with_service_key(mocker, ":foo-bar")


### PR DESCRIPTION
This update will mask the `service_key` when:

1. an entire ApmConfig object is logged
2. `ApmConfig.get("service_key")` is logged

Python doesn't have truly private attributes, and customers that know Python will be able to dissect the `ApmConfig` code, so someone could still get the full `service_key`. But this is better practice than before when `ApmConfig` init was logging the full key.

I tested this with the updated unit tests included and manual testing by adding this to the Sampler, i.e. outside of the `ApmConfig` class:

```
logger.debug("Sampler apm_config: {}".format(self.apm_config))
logger.debug("Sampler apm_config.get(service_key): {}".format(self.apm_config.get("service_key")))
try:
    logger.debug("Sampler apm_config.__config: {}".format(self.apm_config.__config))
except AttributeError:
    logger.debug("Got AttributeError when calling self.apm_config.__config")
```

Example log:

```
opentelemetry-python-testbed-django-app-a-ot-1  | DEBUG | Sampler apm_config: {'__config': {'tracing_mode': None, 'trigger_trace': 'enabled', 'collector': 'apm.collector.na-01.cloud.solarwinds.com', 'reporter': '', 'debug_level': 6, 'service_key': 'Guxp...SW0Y:django-app-a-ot', 'hostname_alias': '', 'trustedpath': '/pathy/path', 'events_flush_interval': -1, 'max_request_size_bytes': -1, 'ec2_metadata_timeout': 1000, 'max_flush_wait_time': -1, 'max_transactions': -1, 'logname': '', 'trace_metrics': 1, 'token_bucket_capacity': -1, 'token_bucket_rate': -1, 'bufsize': -1, 'histogram_precision': -1, 'reporter_file_single': 0, 'enable_sanitize_sql': True, 'inst_enabled': defaultdict(<function SolarWindsApmConfig.__init__.<locals>.<lambda> at 0x7f8a91416550>, {}), 'log_trace_id': 'never', 'proxy': '', 'transaction': defaultdict(<function SolarWindsApmConfig.__init__.<locals>.<lambda> at 0x7f8a913bcd30>, {}), 'inst': defaultdict(<function SolarWindsApmConfig.__init__.<locals>.<lambda> at 0x7f8a91262ca0>, {}), 'is_grpc_clean_hack_enabled': False}, 'agent_enabled': True, 'context': <class 'solarwinds_apm.extension.oboe.Context'>}
opentelemetry-python-testbed-django-app-a-ot-1  | DEBUG | Sampler apm_config.get(service_key): Guxp...SW0Y:django-app-a-ot
opentelemetry-python-testbed-django-app-a-ot-1  | DEBUG | Got AttributeError when calling self.apm_config.__config
```