### PR TITLE
NH-14860 Publish to PyPI is manual

### DIFF
--- a/.github/workflows/build_publish_pypi.yaml
+++ b/.github/workflows/build_publish_pypi.yaml
@@ -1,8 +1,7 @@
 name: Publish to PyPi
 
 on:
-  release:
-    types: [ published ]
+  workflow_dispatch:
 jobs:
   build_publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I've updated the [prod publish how-to](https://swicloud.atlassian.net/wiki/spaces/NIT/pages/3137996006/NH+Python+packaging+and+distribution#How-To.2) so that both Create Release and Publish to PyPI are manual actions, and this PR is for that change. Merging this depends on whether we want to try this out or not 😃 Please let me know what you think.

This is so:
1. the Changelog can be added to or updated manually in between
2. the version + changelog updates are included in the PyPI publish
3. the commit of the GH release is the same as the commit of the PyPI publish