### PR TITLE
Fix is_installable check before prod release

### DIFF
--- a/.github/workflows/build_publish_pypi_and_draft_release.yaml
+++ b/.github/workflows/build_publish_pypi_and_draft_release.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Check version
-      run: run: cd .github/scripts && ./is_publishable.sh ${{ github.event.inputs.version }}
+      run: cd .github/scripts && ./is_publishable.sh ${{ github.event.inputs.version }}
 
   build_publish_and_release:
     needs: is_publishable


### PR DESCRIPTION
Fixes a typo and pathing of the `is_installable` check before PyPI publish and draft release creation.

Successful test run with the fixes:
https://github.com/appoptics/solarwinds-apm-python/actions/runs/3071418945

which published this: 
https://pypi.org/project/solarwinds-apm/0.0.4/

and drafted this release, which I've since published:
https://github.com/appoptics/solarwinds-apm-python/releases/tag/rel-0.0.4
