### PR TITLE
NH-14860 fix Packagecloud tests

### DIFF
--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -1,2 +1,2 @@
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.0.3.6"
+__version__ = "0.0.3"


### PR DESCRIPTION
This fixes the PackageCloud install test issues that were happening in Ubuntu and Alpine, as mentioned on a previous PR: https://github.com/appoptics/solarwinds-apm-python/pull/46

Successful test run (on test version `0.0.3.6`): https://github.com/appoptics/solarwinds-apm-python/actions/runs/3084247374