### PR TITLE
NH-11402 Bump OTel to 1.12.0-0.33b0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-opentelemetry-test-utils==0.30b1
+opentelemetry-test-utils==0.33b0
 pytest
 pytest-cov
 pytest-mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,9 +23,9 @@ classifiers =
 [options]
 python_requires = >=3.6
 install_requires =
-    opentelemetry-api == 1.11.1
-    opentelemetry-sdk == 1.11.1
-    opentelemetry-instrumentation == 0.30b1
+    opentelemetry-api == 1.12.0
+    opentelemetry-sdk == 1.12.0
+    opentelemetry-instrumentation == 0.33b0
 packages = solarwinds_apm, solarwinds_apm.extension
 
 [options.package_data]


### PR DESCRIPTION
Bumps Python Otel version to 1.12.0-0.33b0 (latest!)

Test trace (with corresponding testbed PR changes): https://my.na-01.st-ssp.solarwinds.com/136444677275740160/traces/F68D42430652A1AE0A3D487AE5853F8D/E74911997AA490F9/details?duration=3600