### PR TITLE
NH-15460 Update constants and readme with new SW doc urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ SolarWinds Observability distribution of OpenTelemetry Python, providing automat
 
 ----
 ## Requirements
-All published artifacts support Python 3.6 or higher. See [CONTRIBUTING.md](https://github.com/appoptics/solarwinds-apm-python/blob/main/CONTRIBUTING.md) for how to build for development.
+All published artifacts support Python 3.6 or higher. A full list of system requirements is available at: https://documentation.solarwinds.com/en/success_center/observability/default.htm#cshid=app-sysreqs-python-agent
+
+See [CONTRIBUTING.md](https://github.com/appoptics/solarwinds-apm-python/blob/main/CONTRIBUTING.md) for how to build for development.
 
 ## Getting Started
 SolarWinds APM captures distributed traces and metrics from your application and sends them to SolarWinds Observability for analysis and visualization.
@@ -31,4 +33,5 @@ with tracer.start_as_current_span("my_custom_span"):
 
 ## Documentation
 
-Online documentation on SolarWinds APM features, configuration, and more is coming soon.
+Online documentation on SolarWinds APM features, configuration, and more is available at https://documentation.solarwinds.com/en/success_center/observability/default.htm#cshid=app-add-python-agent
+

--- a/solarwinds_apm/apm_constants.py
+++ b/solarwinds_apm/apm_constants.py
@@ -16,6 +16,6 @@ INTL_SWO_DEFAULT_PROPAGATORS = [
     INTL_SWO_PROPAGATOR,
 ]
 # TODO: Update support doc urls and email alias for SWO
-INTL_SWO_DOC_SUPPORTED_PLATFORMS = 'https://docs.appoptics.com/kb/apm_tracing/supported_platforms/'
-INTL_SWO_DOC_TRACING_PYTHON = 'https://docs.appoptics.com/kb/apm_tracing/python/'
+INTL_SWO_DOC_SUPPORTED_PLATFORMS = 'https://documentation.solarwinds.com/en/success_center/observability/default.htm#cshid=app-sysreqs-python-agent'
+INTL_SWO_DOC_TRACING_PYTHON = 'https://documentation.solarwinds.com/en/success_center/observability/default.htm#cshid=app-add-python-agent'
 INTL_SWO_SUPPORT_EMAIL = 'SWO-support@solarwinds.com'


### PR DESCRIPTION
Update in-code constants and repo Readme with the new SolarWinds python agent docs URLs, as outlined in
* https://swicloud.atlassian.net/browse/NH-15460
* https://swicloud.atlassian.net/browse/NH-16822
* https://swicloud.atlassian.net/browse/NH-16823