### PR TITLE
Add sw.span_kind info at export

### DIFF
--- a/solarwinds_apm/exporter.py
+++ b/solarwinds_apm/exporter.py
@@ -23,6 +23,7 @@ class SolarWindsSpanExporter(SpanExporter):
     """
 
     _INTERNAL_TRANSACTION_NAME = "TransactionName"
+    _SW_SPAN_KIND = "sw.span_kind"
 
     def __init__(
         self,
@@ -69,6 +70,7 @@ class SolarWindsSpanExporter(SpanExporter):
                 self._add_info_transaction_name(span, evt)
 
             evt.addInfo('Layer', span.name)
+            evt.addInfo(self._SW_SPAN_KIND, span.kind.name)
             evt.addInfo('Language', 'Python')
             for k, v in span.attributes.items():
                 evt.addInfo(k, v)

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -1,7 +1,15 @@
+from enum import Enum
+
 import pytest
 
 import solarwinds_apm.exporter
 import solarwinds_apm.extension.oboe
+
+
+# Little helper =====================================================
+
+class FooNum(Enum):
+    FOO = "foo"
 
 
 # Mock Fixtures =====================================================
@@ -12,6 +20,7 @@ def get_mock_spans(mocker, valid_parent=False):
     mock_info_event.configure_mock(
         **{
             "name": "info",
+            "kind": FooNum.FOO,
             "timestamp": 1100,
             "attributes": {"foo": "bar"},
         }
@@ -20,6 +29,7 @@ def get_mock_spans(mocker, valid_parent=False):
     mock_exception_event.configure_mock(
         **{
             "name": "exception",
+            "kind": FooNum.FOO,
             "timestamp": 1200,
             "attributes": {"foo": "bar"},
         }
@@ -31,6 +41,7 @@ def get_mock_spans(mocker, valid_parent=False):
         "start_time": 1000,
         "end_time": 2000,
         "name": "foo",
+        "kind": FooNum.FOO,
         "attributes": {"foo": "bar"},
         "events": [
             mock_info_event,
@@ -210,6 +221,7 @@ class Test_SolarWindsSpanExporter():
         # addInfo calls for entry and exit events
         mock_add_info.assert_has_calls([
             mocker.call("Layer", "foo"),
+            mocker.call(solarwinds_apm.exporter.SolarWindsSpanExporter._SW_SPAN_KIND, FooNum.FOO.name),
             mocker.call("Language", "Python"),
             mocker.call("foo", "bar"),
             mocker.call("Layer", "foo"),


### PR DESCRIPTION
Adds new KV `sw.span_kind` to entry events at span export. `span.kind` is defined by OTel Python [here](https://github.com/open-telemetry/opentelemetry-python/blob/edb1391a3d29d844141b15e486cd1107e163ee0b/opentelemetry-api/src/opentelemetry/trace/__init__.py#L159-L185).

Unit tests pass. Some test traces:

Starting at `script-sdk-app-ot`, a mix of INTERNAL, CLIENT, SERVER:
https://my.na-01.st-ssp.solarwinds.com/136444677275740160/traces/6581F010B922E395FB826C93BAD6D399/39083776D159CBF8/details/manual_instrumentation_outer/39083776D159CBF8/rawData 

`fastapi-books-service POST /books/`, also a mix of INTERNAL, CLIENT, SERVER:
https://my.na-01.st-ssp.solarwinds.com/136444677275740160/traces/D53E9777743AF306B89E9EBCEC037F88/714F1D3532A0BBE5/details/%2Fbooks%2F/714F1D3532A0BBE5/rawData