### PR TITLE
NH-23042 Internal version 0.0.5.0

### DIFF
--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -1,2 +1,2 @@
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.0.3"
+__version__ = "0.0.5.0"


### PR DESCRIPTION
Hi @cheempz ! I'm putting in this PR because I want internal testing version `0.0.5.0` to be on `main` branch -- it should be, based on the [Dev How-To](https://swicloud.atlassian.net/wiki/spaces/NIT/pages/3137996006/NH+Python+packaging+and+distribution#How-To) we came up with and so I stop confusing myself. I am not making `0.0.5` an official release for PyPI yet, therefore I have not updated the Changelog. Instead, changes between `0.0.5.0` and the last internal version `0.0.3.6` are listed in this ticket: https://swicloud.atlassian.net/browse/NH-22658

The version numbering going on right now is indeed a bit of a mess, but I anticipated this with release pipeline building and early agent testing. As long as we stay under `0.1.0` before a true GA release then I think this is ok. I've described the versions in the registries so far in this new section of the Packaging doc, which I will not upkeep once we start doing "real" releases to PyPI with associated Changelog updates: https://swicloud.atlassian.net/wiki/spaces/NIT/pages/3137996006/NH+Python+packaging+and+distribution#Key-internal-development-versions-(%3C-0.1.0)

Version `0.0.5.0` was published to TestPyPI and PackageCloud yesterday:

TestPyPI: https://test.pypi.org/project/solarwinds-apm/0.0.5.0/
Install tests passed: https://github.com/appoptics/solarwinds-apm-python/actions/runs/3186651142

PackageCloud: https://packagecloud.io/solarwinds/solarwinds-apm-python
Install tests passed: https://github.com/appoptics/solarwinds-apm-python/actions/runs/3186702620

I hope this makes sense and I haven't muddied things 😅 Please let me know if I should do this any differently!