### PR TITLE
NH-23330 Support multiple traces exporters

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -130,15 +130,20 @@ class SolarWindsApmConfig:
 
     def _calculate_agent_enabled(self) -> bool:
         """Checks if agent is enabled/disabled based on config:
-        - OTEL_PROPAGATORS
-        - OTEL_TRACES_EXPORTER
-        - SW_APM_SERVICE_KEY
-        - SW_APM_AGENT_ENABLED
+        - SW_APM_SERVICE_KEY   (required)
+        - OTEL_PROPAGATORS     (optional)
+        - OTEL_TRACES_EXPORTER (optional)
+        - SW_APM_AGENT_ENABLED (optional)
         """
         agent_enabled = True
 
         try:
-            environ_propagators = os.environ.get(OTEL_PROPAGATORS).split(",")
+            # SolarWindsDistro._configure does setdefault so this shouldn't
+            # be None, but safer and more explicit this way
+            environ_propagators = os.environ.get(
+                OTEL_PROPAGATORS,
+                ",".join(INTL_SWO_DEFAULT_PROPAGATORS),
+            ).split(",")
             # If not using the default propagators,
             # can any arbitrary list BUT
             # (1) must include tracecontext and solarwinds_propagator
@@ -157,7 +162,12 @@ class SolarWindsApmConfig:
             agent_enabled = False
 
         try:
-            environ_exporters = os.environ.get(OTEL_TRACES_EXPORTER).split(",")
+            # SolarWindsDistro._configure does setdefault so this shouldn't
+            # be None, but safer and more explicit this way
+            environ_exporters = os.environ.get(
+                OTEL_TRACES_EXPORTER,
+                INTL_SWO_DEFAULT_TRACES_EXPORTER,
+            ).split(",")
             # If not using the default propagators,
             # can any arbitrary list BUT
             # (1) must include solarwinds_exporter

--- a/tests/unit/test_apm_config.py
+++ b/tests/unit/test_apm_config.py
@@ -20,11 +20,14 @@ def fixture_mock_env_vars(mocker):
 
 
 class TestSolarWindsApmConfig:
+    """
+    Note: _calculate_agent_enabled sets defaults for OTEL_PROPAGATORS
+    and OTEL_TRACES_EXPORTER. SW_APM_SERVICE_KEY is required.
+    SW_APM_AGENT_ENABLED is optional.
+    """
 
-    def _mock_with_service_key(self, mocker, service_key):
+    def _mock_service_key(self, mocker, service_key):
         mocker.patch.dict(os.environ, {
-            "OTEL_PROPAGATORS": ",".join(INTL_SWO_DEFAULT_PROPAGATORS),
-            "OTEL_TRACES_EXPORTER": INTL_SWO_DEFAULT_TRACES_EXPORTER,
             "SW_APM_SERVICE_KEY": service_key,
         })
         mock_iter_entry_points = mocker.patch(
@@ -38,8 +41,6 @@ class TestSolarWindsApmConfig:
 
     def test_calculate_agent_enabled_ok_defaults(self, mocker):
         mocker.patch.dict(os.environ, {
-            "OTEL_PROPAGATORS": ",".join(INTL_SWO_DEFAULT_PROPAGATORS),
-            "OTEL_TRACES_EXPORTER": INTL_SWO_DEFAULT_TRACES_EXPORTER,
             "SW_APM_SERVICE_KEY": "valid:key",
         })
         mock_iter_entry_points = mocker.patch(
@@ -72,7 +73,6 @@ class TestSolarWindsApmConfig:
     def test_calculate_agent_enabled_no_sw_propagator(self, mocker):
         mocker.patch.dict(os.environ, {
             "OTEL_PROPAGATORS": "tracecontext,baggage",
-            "OTEL_TRACES_EXPORTER": INTL_SWO_DEFAULT_TRACES_EXPORTER,
             "SW_APM_SERVICE_KEY": "valid:key",
         })
         assert not apm_config.SolarWindsApmConfig()._calculate_agent_enabled()
@@ -80,7 +80,6 @@ class TestSolarWindsApmConfig:
     def test_calculate_agent_enabled_no_tracecontext_propagator(self, mocker):
         mocker.patch.dict(os.environ, {
             "OTEL_PROPAGATORS": "solarwinds_propagator",
-            "OTEL_TRACES_EXPORTER": INTL_SWO_DEFAULT_TRACES_EXPORTER,
             "SW_APM_SERVICE_KEY": "valid:key",
         })
         assert not apm_config.SolarWindsApmConfig()._calculate_agent_enabled()
@@ -88,14 +87,12 @@ class TestSolarWindsApmConfig:
     def test_calculate_agent_enabled_sw_before_tracecontext_propagator(self, mocker):
         mocker.patch.dict(os.environ, {
             "OTEL_PROPAGATORS": "solarwinds_propagator,tracecontext",
-            "OTEL_TRACES_EXPORTER": INTL_SWO_DEFAULT_TRACES_EXPORTER,
             "SW_APM_SERVICE_KEY": "valid:key",
         })
         assert not apm_config.SolarWindsApmConfig()._calculate_agent_enabled()
 
     def test_calculate_agent_enabled_valid_other_but_missing_sw_exporter(self, mocker):
         mocker.patch.dict(os.environ, {
-            "OTEL_PROPAGATORS": ",".join(INTL_SWO_DEFAULT_PROPAGATORS),
             "OTEL_TRACES_EXPORTER": "foo",
             "SW_APM_SERVICE_KEY": "valid:key",
         })
@@ -111,7 +108,6 @@ class TestSolarWindsApmConfig:
 
     def test_calculate_agent_enabled_sw_but_no_such_other_exporter(self, mocker):
         mocker.patch.dict(os.environ, {
-            "OTEL_PROPAGATORS": ",".join(INTL_SWO_DEFAULT_PROPAGATORS),
             "OTEL_TRACES_EXPORTER": "solarwinds_exporter,not-valid",
             "SW_APM_SERVICE_KEY": "valid:key",
         })
@@ -125,7 +121,6 @@ class TestSolarWindsApmConfig:
 
     def test_calculate_agent_enabled_sw_and_two_other_valid_exporters(self, mocker):
         mocker.patch.dict(os.environ, {
-            "OTEL_PROPAGATORS": ",".join(INTL_SWO_DEFAULT_PROPAGATORS),
             "OTEL_TRACES_EXPORTER": "foo,solarwinds_exporter,bar",
             "SW_APM_SERVICE_KEY": "valid:key",
         })
@@ -141,8 +136,6 @@ class TestSolarWindsApmConfig:
 
     def test_calculate_agent_enabled_set_false(self, mocker):
         mocker.patch.dict(os.environ, {
-            "OTEL_PROPAGATORS": "foo,tracecontext,bar,solarwinds_propagator",
-            "OTEL_TRACES_EXPORTER": "foo",
             "SW_APM_SERVICE_KEY": "valid:key",
             "SW_APM_AGENT_ENABLED": "false",
         })
@@ -162,8 +155,6 @@ class TestSolarWindsApmConfig:
         if old_service_key:
             del os.environ["SW_APM_SERVICE_KEY"]
         mocker.patch.dict(os.environ, {
-            "OTEL_PROPAGATORS": "foo,tracecontext,bar,solarwinds_propagator",
-            "OTEL_TRACES_EXPORTER": "foo",
             "SW_APM_AGENT_ENABLED": "true",
         })
         mock_iter_entry_points = mocker.patch(
@@ -181,8 +172,6 @@ class TestSolarWindsApmConfig:
 
     def test_calculate_agent_enabled_service_key_bad_format(self, mocker):
         mocker.patch.dict(os.environ, {
-            "OTEL_PROPAGATORS": "foo,tracecontext,bar,solarwinds_propagator",
-            "OTEL_TRACES_EXPORTER": "foo",
             "SW_APM_SERVICE_KEY": "invalidkey",
             "SW_APM_AGENT_ENABLED": "true",
         })
@@ -201,10 +190,6 @@ class TestSolarWindsApmConfig:
         old_collector = os.environ.get("SW_APM_COLLECTOR", None)
         if old_collector:
             del os.environ["SW_APM_COLLECTOR"]
-        mocker.patch.dict(os.environ, {
-            "OTEL_PROPAGATORS": ",".join(INTL_SWO_DEFAULT_PROPAGATORS),
-            "OTEL_TRACES_EXPORTER": INTL_SWO_DEFAULT_TRACES_EXPORTER,
-        })
         assert apm_config.SolarWindsApmConfig()._calculate_metric_format() == 0
         # Restore old collector
         if old_collector:
@@ -212,32 +197,24 @@ class TestSolarWindsApmConfig:
 
     def test_calculate_metric_format_not_ao(self, mocker):
         mocker.patch.dict(os.environ, {
-            "OTEL_PROPAGATORS": ",".join(INTL_SWO_DEFAULT_PROPAGATORS),
-            "OTEL_TRACES_EXPORTER": INTL_SWO_DEFAULT_TRACES_EXPORTER,
             "SW_APM_COLLECTOR": "foo-collector-not-ao"
         })
         assert apm_config.SolarWindsApmConfig()._calculate_metric_format() == 0
 
     def test_calculate_metric_format_ao_prod(self, mocker):
         mocker.patch.dict(os.environ, {
-            "OTEL_PROPAGATORS": ",".join(INTL_SWO_DEFAULT_PROPAGATORS),
-            "OTEL_TRACES_EXPORTER": INTL_SWO_DEFAULT_TRACES_EXPORTER,
             "SW_APM_COLLECTOR": INTL_SWO_AO_COLLECTOR
         })
         assert apm_config.SolarWindsApmConfig()._calculate_metric_format() == 1
 
     def test_calculate_metric_format_ao_staging(self, mocker):
         mocker.patch.dict(os.environ, {
-            "OTEL_PROPAGATORS": ",".join(INTL_SWO_DEFAULT_PROPAGATORS),
-            "OTEL_TRACES_EXPORTER": INTL_SWO_DEFAULT_TRACES_EXPORTER,
             "SW_APM_COLLECTOR": INTL_SWO_AO_STG_COLLECTOR
         })
         assert apm_config.SolarWindsApmConfig()._calculate_metric_format() == 1
 
     def test_calculate_metric_format_ao_prod_with_port(self, mocker):
         mocker.patch.dict(os.environ, {
-            "OTEL_PROPAGATORS": ",".join(INTL_SWO_DEFAULT_PROPAGATORS),
-            "OTEL_TRACES_EXPORTER": INTL_SWO_DEFAULT_TRACES_EXPORTER,
             "SW_APM_COLLECTOR": "{}:123".format(INTL_SWO_AO_COLLECTOR)
         })
         assert apm_config.SolarWindsApmConfig()._calculate_metric_format() == 1
@@ -246,11 +223,6 @@ class TestSolarWindsApmConfig:
         old_service_key = os.environ.get("SW_APM_SERVICE_KEY", None)
         if old_service_key:
             del os.environ["SW_APM_SERVICE_KEY"]
-        mocker.patch.dict(os.environ, {
-            "OTEL_PROPAGATORS": ",".join(INTL_SWO_DEFAULT_PROPAGATORS),
-            "OTEL_TRACES_EXPORTER": INTL_SWO_DEFAULT_TRACES_EXPORTER,
-            "OTEL_TRACES_EXPORTER": INTL_SWO_DEFAULT_TRACES_EXPORTER,
-        })
         mock_iter_entry_points = mocker.patch(
             "solarwinds_apm.apm_config.iter_entry_points"
         )
@@ -265,65 +237,65 @@ class TestSolarWindsApmConfig:
             os.environ["SW_APM_SERVICE_KEY"] = old_service_key
 
     def test_mask_service_key_empty_key(self, mocker):
-        self._mock_with_service_key(mocker, "")
+        self._mock_service_key(mocker, "")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == ""
 
     def test_mask_service_key_whitespace_key(self, mocker):
-        self._mock_with_service_key(mocker, " ")
+        self._mock_service_key(mocker, " ")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == " "
 
     def test_mask_service_key_invalid_format_no_colon(self, mocker):
-        self._mock_with_service_key(mocker, "a")
+        self._mock_service_key(mocker, "a")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "a<invalid_format>"
-        self._mock_with_service_key(mocker, "abcd")
+        self._mock_service_key(mocker, "abcd")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "abcd<invalid_format>"
-        self._mock_with_service_key(mocker, "abcde")
+        self._mock_service_key(mocker, "abcde")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "abcd...<invalid_format>"
-        self._mock_with_service_key(mocker, "abcdefgh")
+        self._mock_service_key(mocker, "abcdefgh")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "abcd...<invalid_format>"
-        self._mock_with_service_key(mocker, "abcd1efgh")
+        self._mock_service_key(mocker, "abcd1efgh")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "abcd...<invalid_format>"
-        self._mock_with_service_key(mocker, "CyUuit1W--8RVmUXX6_cVjTWemaUyBh1ruL0nMPiFdrPo1iiRnO31_pwiUCPzdzv9UMHK6I")
+        self._mock_service_key(mocker, "CyUuit1W--8RVmUXX6_cVjTWemaUyBh1ruL0nMPiFdrPo1iiRnO31_pwiUCPzdzv9UMHK6I")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "CyUu...<invalid_format>"
 
     def test_mask_service_key_less_than_9_char_token(self, mocker):
-        self._mock_with_service_key(mocker, ":foo-bar")
+        self._mock_service_key(mocker, ":foo-bar")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == ":foo-bar"
-        self._mock_with_service_key(mocker, "a:foo-bar")
+        self._mock_service_key(mocker, "a:foo-bar")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "a:foo-bar"
-        self._mock_with_service_key(mocker, "ab:foo-bar")
+        self._mock_service_key(mocker, "ab:foo-bar")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "ab:foo-bar"
-        self._mock_with_service_key(mocker, "abc:foo-bar")
+        self._mock_service_key(mocker, "abc:foo-bar")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "abc:foo-bar"
-        self._mock_with_service_key(mocker, "abcd:foo-bar")
+        self._mock_service_key(mocker, "abcd:foo-bar")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "abcd:foo-bar"
-        self._mock_with_service_key(mocker, "abcde:foo-bar")
+        self._mock_service_key(mocker, "abcde:foo-bar")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "abcde:foo-bar"
-        self._mock_with_service_key(mocker, "abcdef:foo-bar")
+        self._mock_service_key(mocker, "abcdef:foo-bar")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "abcdef:foo-bar"
-        self._mock_with_service_key(mocker, "abcdefg:foo-bar")
+        self._mock_service_key(mocker, "abcdefg:foo-bar")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "abcdefg:foo-bar"
-        self._mock_with_service_key(mocker, "abcdefgh:foo-bar")
+        self._mock_service_key(mocker, "abcdefgh:foo-bar")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "abcdefgh:foo-bar"
 
     def test_mask_service_key_9_or_more_char_token(self, mocker):
-        self._mock_with_service_key(mocker, "abcd1efgh:foo-bar")
+        self._mock_service_key(mocker, "abcd1efgh:foo-bar")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "abcd...efgh:foo-bar"
-        self._mock_with_service_key(mocker, "abcd12efgh:foo-bar")
+        self._mock_service_key(mocker, "abcd12efgh:foo-bar")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "abcd...efgh:foo-bar"
-        self._mock_with_service_key(mocker, "abcd123efgh:foo-bar")
+        self._mock_service_key(mocker, "abcd123efgh:foo-bar")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "abcd...efgh:foo-bar"
-        self._mock_with_service_key(mocker, "abcd1234567890efgh:foo-bar")
+        self._mock_service_key(mocker, "abcd1234567890efgh:foo-bar")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "abcd...efgh:foo-bar"
-        self._mock_with_service_key(mocker, "CyUuit1W--8RVmUXX6_cVjTWemaUyBh1ruL0nMPiFdrPo1iiRnO31_pwiUCPzdzv9UMHK6I:foo-bar")
+        self._mock_service_key(mocker, "CyUuit1W--8RVmUXX6_cVjTWemaUyBh1ruL0nMPiFdrPo1iiRnO31_pwiUCPzdzv9UMHK6I:foo-bar")
         assert apm_config.SolarWindsApmConfig().mask_service_key() == "CyUu...HK6I:foo-bar"
 
     def test_config_mask_service_key(self, mocker):
-        self._mock_with_service_key(mocker, "valid-and-long:key")
+        self._mock_service_key(mocker, "valid-and-long:key")
         assert apm_config.SolarWindsApmConfig()._config_mask_service_key().get("service_key") == "vali...long:key"
 
     def test_str(self, mocker):
-        self._mock_with_service_key(mocker, "valid-and-long:key")
+        self._mock_service_key(mocker, "valid-and-long:key")
         result = str(apm_config.SolarWindsApmConfig())
         assert "vali...long:key" in result
         assert "agent_enabled" in result


### PR DESCRIPTION
Lets customer set `OTEL_TRACES_EXPORTER` as a comma-separated list, like for customizing propagators. Order of exporters does not matter because there's no composite.

If `OTEL_TRACES_EXPORTER` is not provided, the distro defaults to our `solarwinds_exporter` only.

If `OTEL_TRACES_EXPORTER` is set, the customer needs to include `solarwinds_exporter` in the list. I chose this so it resembles customizing propagators. (Let me know if a different way is better, e.g. always automatically use `solarwinds_exporter` even if not in `OTEL_TRACES_EXPORTER`.) Currently the distro will go `agent_enabled: False` if:

1. `solarwinds_exporter` is not in `OTEL_TRACES_EXPORTER`, if set
2. Any other exporter in `OTEL_TRACES_EXPORTER` cannot be loaded by entrypoint

Updated unit tests pass. With testbed updates ([other PR](https://github.com/appoptics/solarwinds-apm-python-testbed/pull/34)), traces get exported and also print to console. Example success trace: https://my.na-01.st-ssp.solarwinds.com/136444677275740160/traces/13F38D150923A9EE60774F78733C1C41/37CB54D40CE475BE/details

I'll be updating the Troubleshooting doc now with this info. EDIT: Updated this section: https://swicloud.atlassian.net/wiki/spaces/NIT/pages/2867726621/NH+Python+Troubleshooting#Customizing-OTel-Exporter