### PR TITLE
Internal version 0.1.0.0 and Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/appoptics/solarwinds-apm-python/compare/v0.1.0...HEAD)
 
-## [0.1.0](https://github.com/appoptics/solarwinds-apm-python/releases/tag/v0.1.0) - 2022-XX-XX
+## [0.1.0.0](https://github.com/appoptics/solarwinds-apm-python/releases/tag/v0.1.0) - 2022-10-12
 ### Added
-- Initial release
+- Initial release for GA (alpha)
+- OpenTelemetry API/SDK 1.13.0, for trace generation
+- OpenTelemetry Instrumentation 0.34b, for (auto-)instrumentation of common Python frameworks
+- SolarWinds c-lib 10.6.1, for unified inbound metrics generation, trace sample decision, and export to SWO
+- W3C trace context propagation
+- OTel, APM instrumentation startup, and trigger trace configurable with environment variables

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -1,2 +1,2 @@
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.0.6.0"
+__version__ = "0.1.0.0"


### PR DESCRIPTION
This is the branch I used to publish version `0.1.0.0` to TestPyPI and PackageCloud today:

* https://test.pypi.org/project/solarwinds-apm/0.1.0.0/
* https://packagecloud.io/solarwinds/solarwinds-apm-python

"Verify Installation" workflows all passed for both, with some spot checked traces linked:
* TestPyPI https://github.com/appoptics/solarwinds-apm-python/actions/runs/3238025133
  * https://my.na-01.st-ssp.solarwinds.com/136444677275740160/traces/C6DF81F8B1BC14AAAFD623116E13AE84/0B7768F085F8B6A1/details
  * https://my.na-01.st-ssp.solarwinds.com/136444677275740160/traces/4DE2D4B0058D1ABF586A284A9E11424A/D06312FACA5F6CA9/details
* PackageCloud: https://github.com/appoptics/solarwinds-apm-python/actions/runs/3238187128
  * https://my.na-01.st-ssp.solarwinds.com/136444677275740160/traces/2499121CA69C01DCF9EDCEFAEE937AA4/0FB3FA25FF72CEAD/details
  * https://my.na-01.st-ssp.solarwinds.com/136444677275740160/traces/1962AE0948D32BA614AC41C66E07162C/B683359541C1D81A/details

I also manually tested using installs from TestPyPI. Traces:
* testbed flask-from-testpypi: https://my.na-01.st-ssp.solarwinds.com/136444677275740160/traces/4cd54a789f798dbbe261b934f0893d41/3a83726df1102fc2/details
* NHDemo fastapi: https://my.na-01.st-ssp.solarwinds.com/136444677275740160/traces/2d934a31b65bbad72fb4663c519ba23f/8b4ae17117fe5b31/details

Next: After merging this, I will `Create Release PR` and prepare to `Publish to PyPI and Create Release` as `0.1.0` for APM Python instrumentation library GA/alpha!

Please let me know if anything should change.