### PR TITLE
NH-23781 Fix Log_Forging vulnerability from Checkmarx

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -98,6 +98,7 @@ class SolarWindsApmConfig:
             'inst': defaultdict(lambda: True),
             'is_grpc_clean_hack_enabled': False,
         }
+        self.__config['transaction']['prepend_domain_name'] = False
         self.agent_enabled = self._calculate_agent_enabled()
 
         if self.agent_enabled:


### PR DESCRIPTION
This fixes a Log_Forging vulnerability found by Checkmarx where the environment variable `OTEL_TRACES_EXPORTER` could be logged. The user with appropriate permissions can check the actual value themselves!

This also fixes a little bug I found when Checkmarx reported another Log_Forging vulnerability (which I ultimately marked Not Exploitlable; see [this comment](https://swicloud.atlassian.net/browse/NH-23781?focusedCommentId=2229466)). The nested `'transaction.prepend_domain_name'` couldn't get assigned by `update_with_env_var` without the line I added here, which was quietly being ignored the few times I did set it in the testbed.

Unit tests pass. Test trace here: https://my.na-01.st-ssp.solarwinds.com/136444677275740160/traces/32EEB7A818654F7AA20A3BA87C4338C7/2F9B72D186DE8975/details