### PR TITLE
NH-11538 Add GH workflow to run all tox tests

### DIFF
--- a/.github/workflows/run_tox_tests.yaml
+++ b/.github/workflows/run_tox_tests.yaml
@@ -1,0 +1,19 @@
+name: Run tox tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    type: [opened, reopened]
+
+jobs:
+  run_tox_tests:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/pypa/manylinux2014_x86_64:latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run tox
+      run: make tox


### PR DESCRIPTION
This adds a new GitHub workflow to run all unit tests with `make tox`. This will run for all Python versions as per `tox.ini`: https://github.com/appoptics/solarwinds-apm-python/blob/main/tox.ini

This is WIP but I want to merge this to `main` so that I can run this in Actions and add to it from there on another branch. (I can't run it yet from this branch until it's been on `main`).