### PR TITLE
NH-26169 Testrelease 0.2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/appoptics/solarwinds-apm-python/compare/v0.1.0...HEAD)
+## [0.2.1.0](https://github.com/appoptics/solarwinds-apm-python/releases/tag/v0.2.1) - 2022-11-08
+Version bump for rebuild of 0.2.0.
 
-## [0.2.0](https://github.com/appoptics/solarwinds-apm-python/releases/tag/v0.1.0) - 2022-11-07
+## [0.2.0](https://github.com/appoptics/solarwinds-apm-python/releases/tag/v0.2.0) - 2022-11-07
 ### Added
 - Added `solarwinds_ready` method ([#64](https://github.com/appoptics/solarwinds-apm-python/pull/64))
 - Added startup `__Init` with SWO ([#64](https://github.com/appoptics/solarwinds-apm-python/pull/64))

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -1,2 +1,2 @@
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.2.0"
+__version__ = "0.2.1.0"


### PR DESCRIPTION
## Testrelease solarwinds-apm 0.2.1.0

Version bump to trigger a new PyPI publish. Code is the same as version 0.2.0

----

## tox

Last unit test run: https://github.com/appoptics/solarwinds-apm-python/actions/runs/3423808093

## TestPyPI

Published at: https://test.pypi.org/project/solarwinds-apm/0.2.1.0/

Install tests: https://github.com/appoptics/solarwinds-apm-python/actions/runs/3423609327

Sample traces:
- NH prod trace: https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/5BB60BAB2D594BF21563B540E8B103E3/723DBA4447A9B336/details
- NH staging trace: _(again no love from staging today)_
- AO prod trace: https://my.appoptics.com/apm/123092/services/apm-python-install-testing-py3.10-alpine3.13/traces/7A46231D12C02D41D18E75618E6EF42100000000/graph

## PackageCloud

Published at: https://packagecloud.io/solarwinds/solarwinds-apm-python

Install tests: https://github.com/appoptics/solarwinds-apm-python/actions/runs/3423740442
^^ only `py311_install_ubuntu2004` is unhappy and it doesn't say why besides exit code 1 😕 This didn't happen in the TestPyPI install tests.

```
Run ./_helper_run_install_tests.sh
  ./_helper_run_install_tests.sh
  shell: sh -e {0}
  env:
    SOLARWINDS_APM_VERSION: 0.[2](https://github.com/appoptics/solarwinds-apm-python/actions/runs/3423740442/jobs/5702763509#step:4:2).1.0
    SW_APM_COLLECTOR_AO_PROD: ***
    SW_APM_COLLECTOR_PROD: ***
    SW_APM_COLLECTOR_STAGING: ***
    SW_APM_SERVICE_KEY_AO_PROD: ***
    SW_APM_SERVICE_KEY_PROD: ***
    SW_APM_SERVICE_KEY_STAGING: ***
    MODE: packagecloud
Installing test dependencies for Python [3](https://github.com/appoptics/solarwinds-apm-python/actions/runs/3423740442/jobs/5702763509#step:4:3).11 on Ubuntu 20.0[4](https://github.com/appoptics/solarwinds-apm-python/actions/runs/3423740442/jobs/5702763509#step:4:4).[5](https://github.com/appoptics/solarwinds-apm-python/actions/runs/3423740442/jobs/5702763509#step:4:5) LTS
debconf: delaying package configuration, since apt-utils is not installed
Error: Process completed with exit code 1.
```

Sample traces:
- NH prod trace: https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/B38342ACD48ACFF7E7A6E54F1CA4389F/60606C9F0D06C02E/details
- NH staging trace: _(again no love from staging today)_
- AO prod trace: https://my.appoptics.com/apm/123092/services/apm-python-install-testing-py3.7-debian9/traces/9B97D0A9CFAFD7898D78ED42CA676BFE00000000/graph