### PR TITLE
NH-28675 Bump to Otel 1.15.0/0.36b0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/appoptics/solarwinds-apm-python/compare/rel-0.3.0...HEAD)
 ### Changed
+- OpenTelemetry API/SDK 1.15.0 ([#91](https://github.com/appoptics/solarwinds-apm-python/pull/76))
+- OpenTelemetry Instrumentation 0.36b0 ([#91](https://github.com/appoptics/solarwinds-apm-python/pull/76))
 - x-trace-options header `custom-*` KVs written to entry span attributes ([#85](https://github.com/appoptics/solarwinds-apm-python/pull/85))
 - Fix `x-trace-options-signature` extraction ([#85](https://github.com/appoptics/solarwinds-apm-python/pull/85))
 - Fix validation of `x-trace-options` header ([#87](https://github.com/appoptics/solarwinds-apm-python/pull/87))

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
-opentelemetry-test-utils~=0.35b0
-opentelemetry-instrumentation-flask~=0.35b0
-opentelemetry-instrumentation-requests~=0.35b0
+opentelemetry-test-utils==0.36b0
+opentelemetry-instrumentation-flask==0.36b0
+opentelemetry-instrumentation-requests==0.36b0
 pytest
 pytest-cov
 pytest-mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,9 +23,9 @@ classifiers =
 [options]
 python_requires = >=3.7
 install_requires =
-    opentelemetry-api == 1.14.0
-    opentelemetry-sdk == 1.14.0
-    opentelemetry-instrumentation == 0.35b0
+    opentelemetry-api == 1.15.0
+    opentelemetry-sdk == 1.15.0
+    opentelemetry-instrumentation == 0.36b0
 packages = solarwinds_apm, solarwinds_apm.certs, solarwinds_apm.extension
 
 [options.package_data]


### PR DESCRIPTION
Bumps OTel SDK and Instrumentation version used by Python APM library to 1.15.0-0.36b.

Unit tests pass. Test trace: https://my.na-01.st-ssp.solarwinds.com/136444677275740160/traces/D7007146EEFCE6C8B532DD1D34EB1C39/1685B7394F7CBBDC/details