### PR TITLE
NH-26617 add Python framework versions to init msg

### DIFF
--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -326,7 +326,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
 
             # Set up Instrumented Library Versions KVs with several special cases
             entry_point_name = entry_point.name
-            instr_key = f"Python.{entry_point_name.capitalize()}.Version"
+            instr_key = f"Python.{entry_point_name}.Version"
             try:
                 # Some OTel instrumentation libraries are named not exactly
                 # the same as the instrumented libraries!


### PR DESCRIPTION
Here is one way to add instrumented Python framework versions to the init message. It duplicates some parts of autoinstrumentation's [_load_instrumentors method](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py#L56-L88) by checking available instrumentation entry points, skipping if in `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS` or if conflict or if not importable/checkable. If we can check a framework's `__version__` or equivalent (special cases added in a1fc5ee and more), then it is added to the __Init message as `Python.*.Version`

Regarding special cases: Some of Python packages don't have `__version__` ☹️ ~~and there's probably more than just urllib and sqlite3~~ so there are several elifs here.

The approach is different than using `InstrumentScope` of finished spans (#92) because that can only hold one instrumentation library per span and there is no meaningful completed span at time of distro configuration. See also doc for "APM Python InstrumentationScope".

EDIT: Some other approaches I thought about but didn't do: (A) Maintain a version-controlled map of all `opentelemetry.instrumention.*` libraries and their corresponding Python frameworks, with expressions of how to check framework version (seems very manual but could cut down on cases in code). (B) Override `BaseDistro.load_instrumentor` to check Python framework versions as instrumentation libraries are loaded, then store that info for the Configurator to use at __Init message. I couldn't figure out if there is a smart way to share info between Distro and Configurator (see also how they're loaded in doc for startup).

Example __Init message from test collector (EDIT: updated 2023-01-04 x2):

```
{
    "_V": "1",
    "sw.trace_context": "00-40407385fb180d076092ee6b1c41ccdf-0c0afed155292d1c-01",
    "X-Trace": "2B40407385FB180D076092EE6B1C41CCDF000000000C0AFED155292D1C01",
    "sw.parent_span_id": "2ea6d6c124b75f83",
    "Edge": [
        "2EA6D6C124B75F83"
    ],
    "Layer": "Python",
    "__Init": true,
    "telemetry.sdk.language": "python",
    "telemetry.sdk.name": "opentelemetry",
    "telemetry.sdk.version": "1.15.0",
    "process.runtime.version": "3.9.16",
    "process.runtime.name": "cpython",
    "process.runtime.description": "3.9.16 (main, Dec 21 2022, 19:18:44) \n[GCC 10.2.1 20210110]",
    "process.executable.path": "/usr/local/bin/python",
    "APM.Version": "0.4.0",
    "APM.Extension.Version": "11.1.0",
    "Python.falcon.Version": "3.1.1",
    "Python.asyncpg.Version": "0.27.0",
    "Python.jinja2.Version": "3.1.2",
    "Python.redis.Version": "4.4.0",
    "Python.botocore.Version": "1.29.43",
    "Python.mysql.Version": "8.0.29",
    "Python.pymongo.Version": "4.3.3",
    "Python.urllib.Version": "3.9",
    "Python.system_metrics.Version": "5.9.4",
    "Python.requests.Version": "2.28.1",
    "Python.flask.Version": "2.2.2",
    "Python.sqlalchemy.Version": "1.4.46",
    "Python.boto.Version": "2.49.0",
    "Python.elasticsearch.Version": "7.17.0",
    "Python.django.Version": "4.1.5",
    "Python.tornado.Version": "6.2",
    "Python.fastapi.Version": "0.88.0",
    "Python.pymysql.Version": "1.0.2",
    "Python.psycopg2.Version": "2.9.5 (dt dec pq3 ext lo64)",
    "Python.kafka.Version": "2.0.2",
    "Python.sqlite3.Version": "3.34.1",
    "Python.confluent_kafka.Version": "1.9.2",
    "Python.grpc_aio_client.Version": "1.51.1",
    "Python.grpc_aio_server.Version": "1.51.1",
    "Python.grpc_client.Version": "1.51.1",
    "Python.grpc_server.Version": "1.51.1",
    "Python.pika.Version": "1.3.1",
    "Python.tortoiseorm.Version": "0.19.2",
    "Python.logging.Version": "0.5.1.2",
    "Python.pyramid.Version": "2.0",
    "Python.aiohttp-client.Version": "3.8.3",
    "Python.remoulade.Version": "0.54.2",
    "Python.celery.Version": "5.2.7",
    "Python.boto3.Version": "1.26.43",
    "Timestamp_u": 1672876626017494,
    "TID": 1,
    "Hostname": "de6a05f7288a"
}
```

Please let me know if any questions or suggestions!