### PR TITLE
NH-30511 Fix init msg framework KVs

### DIFF
--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -273,7 +273,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
 
         return NoopReporter(**reporter_kwargs)
 
-    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches,too-many-statements
     def _add_all_instrumented_python_framework_versions(
         self,
         version_keys,
@@ -326,20 +326,20 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
 
             # Set up Instrumented Library Versions KVs with several special cases
             entry_point_name = entry_point.name
+            # Some OTel instrumentation libraries are named not exactly
+            # the same as the instrumented libraries!
+            # https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/README.md
+            if entry_point_name == "aiohttp-client":
+                entry_point_name = "aiohttp"
+            elif "grpc_" in entry_point_name:
+                entry_point_name = "grpc"
+            elif entry_point_name == "system_metrics":
+                entry_point_name = "psutil"
+            elif entry_point_name == "tortoiseorm":
+                entry_point_name = "tortoise"
+
             instr_key = f"Python.{entry_point_name}.Version"
             try:
-                # Some OTel instrumentation libraries are named not exactly
-                # the same as the instrumented libraries!
-                # https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/README.md
-                if entry_point_name == "aiohttp-client":
-                    entry_point_name = "aiohttp"
-                elif "grpc_" in entry_point_name:
-                    entry_point_name = "grpc"
-                elif entry_point_name == "system_metrics":
-                    entry_point_name = "psutil"
-                elif entry_point_name == "tortoiseorm":
-                    entry_point_name = "tortoise"
-
                 # There is no mysql version, but mysql.connector version
                 if entry_point_name == "mysql":
                     importlib.import_module(f"{entry_point_name}.connector")


### PR DESCRIPTION
Minor fixes of some of the __Init message Python framework KVs. There are a few keys where `<component>` in `Python.<component>.Version` are Python frameworks that have corresponding OTel instrumentation libraries named differently.  In other words, `<component>` should be from the Python framework name, not the OTel instrumentation library name, if there is a difference.

Updates:
- `Python.aiohttp-client.Version` --> `Python.aiohttp.Version`
- `Python.grpc_aio_client.Version` --> `Python.grpc.Version`, and there is only one
- `Python.system_metrics.Version` --> `Python.psutil.Version`
- `Python.tortoiseorm.Version` --> `Python.tortoise.Version`

Full __Init message with these updates:

```
{
    "_V": "1",
    "sw.trace_context": "00-aef7cce25fc8e5571f1c541454b732d1-1eda3592830f2f6b-01",
    "X-Trace": "2BAEF7CCE25FC8E5571F1C541454B732D1000000001EDA3592830F2F6B01",
    "sw.parent_span_id": "4faec74149bd4871",
    "Edge": [
        "4FAEC74149BD4871"
    ],
    "Layer": "Python",
    "__Init": true,
    "telemetry.sdk.language": "python",
    "telemetry.sdk.name": "opentelemetry",
    "telemetry.sdk.version": "1.15.0",
    "process.runtime.version": "3.9.16",
    "process.runtime.name": "cpython",
    "process.runtime.description": "3.9.16 (main, Dec 21 2022, 19:18:44) \n[GCC 10.2.1 20210110]",
    "process.executable.path": "/usr/local/bin/python",
    "APM.Version": "0.4.0",
    "APM.Extension.Version": "11.1.0",
    "Python.falcon.Version": "3.1.1",
    "Python.asyncpg.Version": "0.27.0",
    "Python.jinja2.Version": "3.1.2",
    "Python.redis.Version": "4.4.0",
    "Python.botocore.Version": "1.29.43",
    "Python.mysql.Version": "8.0.29",
    "Python.pymongo.Version": "4.3.3",
    "Python.urllib.Version": "3.9",
    "Python.psutil.Version": "5.9.4",
    "Python.requests.Version": "2.28.1",
    "Python.flask.Version": "2.2.2",
    "Python.sqlalchemy.Version": "1.4.46",
    "Python.boto.Version": "2.49.0",
    "Python.elasticsearch.Version": "7.17.0",
    "Python.django.Version": "4.1.5",
    "Python.tornado.Version": "6.2",
    "Python.fastapi.Version": "0.88.0",
    "Python.pymysql.Version": "1.0.2",
    "Python.psycopg2.Version": "2.9.5 (dt dec pq3 ext lo64)",
    "Python.kafka.Version": "2.0.2",
    "Python.sqlite3.Version": "3.34.1",
    "Python.confluent_kafka.Version": "1.9.2",
    "Python.grpc.Version": "1.51.1",
    "Python.pika.Version": "1.3.1",
    "Python.tortoise.Version": "0.19.2",
    "Python.logging.Version": "0.5.1.2",
    "Python.pyramid.Version": "2.0",
    "Python.aiohttp.Version": "3.8.3",
    "Python.remoulade.Version": "0.54.2",
    "Python.celery.Version": "5.2.7",
    "Python.boto3.Version": "1.26.43",
    "Timestamp_u": 1672943258209168,
    "TID": 1,
    "Hostname": "dfd787789e46"
}
```

Please let me know what you think!