### PR TITLE
NH-30870 calculate_attributes adds existing attrs earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Init message with Python framework versions ([#94](https://github.com/solarwindscloud/solarwinds-apm-python/pull/94), [#100](https://github.com/solarwindscloud/solarwinds-apm-python/pull/100))
 - SolarWinds c-lib 11.1.0, for Init message updates ([#90](https://github.com/solarwindscloud/solarwinds-apm-python/pull/90))
 - Updated exported spans with Python framework versions ([#92](https://github.com/solarwindscloud/solarwinds-apm-python/pull/92))
+- Bugfix: existing attributes without parent context now write to spans ([#102](https://github.com/solarwindscloud/solarwinds-apm-python/pull/102))
 
 ## [0.4.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.4.0) - 2023-01-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SolarWinds c-lib 11.1.0, for Init message updates ([#90](https://github.com/solarwindscloud/solarwinds-apm-python/pull/90))
 - Updated exported spans with Python framework versions ([#92](https://github.com/solarwindscloud/solarwinds-apm-python/pull/92))
 - Bugfix: existing attributes without parent context now write to spans ([#102](https://github.com/solarwindscloud/solarwinds-apm-python/pull/102))
+- Bugfix: setting sw.w3c.tracestate is based on existence of remote parent span ([#102](https://github.com/solarwindscloud/solarwinds-apm-python/pull/102))
 
 ## [0.4.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.4.0) - 2023-01-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SolarWinds c-lib 11.1.0, for Init message updates ([#90](https://github.com/solarwindscloud/solarwinds-apm-python/pull/90))
 - Updated exported spans with Python framework versions ([#92](https://github.com/solarwindscloud/solarwinds-apm-python/pull/92))
 - Bugfix: existing attributes without parent context now write to spans ([#102](https://github.com/solarwindscloud/solarwinds-apm-python/pull/102))
-- Bugfix: setting sw.w3c.tracestate is based on existence of remote parent span ([#102](https://github.com/solarwindscloud/solarwinds-apm-python/pull/102))
+- Bugfix: setting sw.tracestate_parent_id is based on existence of remote parent span ([#102](https://github.com/solarwindscloud/solarwinds-apm-python/pull/102))
 
 ## [0.4.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.4.0) - 2023-01-03
 ### Added

--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -412,12 +412,14 @@ class _SwSampler(Sampler):
             self._INTERNAL_BUCKET_RATE
         ] = f"{decision['bucket_rate']}"
 
-        # _SW_TRACESTATE_ROOT_KEY is set once per trace, parent span context
-        # contains `sw` and it's not already in the attributes (???)
+        # sw.w3c.tracestate is set if:
+        #  1. the future span is the entry span of a service
+        #  2. there exists a (remote) parent span
+        #  3. that parent's trace state contains `sw` for SWO vendor
         sw_value = parent_span_context.trace_state.get(
             INTL_SWO_TRACESTATE_KEY, None
         )
-        if sw_value and self._SW_TRACESTATE_ROOT_KEY not in new_attributes:
+        if sw_value and parent_span_context.is_remote:
             new_attributes[
                 self._SW_TRACESTATE_ROOT_KEY
             ] = W3CTransformer.span_id_from_sw(sw_value)

--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -455,7 +455,7 @@ class _SwSampler(Sampler):
             parent_span_context,
         )
 
-        logger.warning("Setting attributes: %s", new_attributes)
+        logger.debug("Setting attributes: %s", new_attributes)
 
         # attributes must be immutable for SamplingResult
         return MappingProxyType(new_attributes)

--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -412,7 +412,7 @@ class _SwSampler(Sampler):
             self._INTERNAL_BUCKET_RATE
         ] = f"{decision['bucket_rate']}"
 
-        # sw.w3c.tracestate is set if:
+        # sw.tracestate_parent_id is set if:
         #  1. the future span is the entry span of a service
         #  2. there exists a (remote) parent span
         #  3. that parent's trace state contains `sw` for SWO vendor

--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -389,8 +389,7 @@ class _SwSampler(Sampler):
 
         if attributes:
             # Copy existing MappingProxyType KV into new_attributes for modification.
-            # These attributes may have other vendor info, customer-entered
-            # info from manual SDK calls, etc
+            # These attributes may have customer-set KVs from manual SDK calls
             for attr_k, attr_v in attributes.items():
                 new_attributes[attr_k] = attr_v
         else:

--- a/tests/unit/test_sampler/test_sampler_calculate_attributes.py
+++ b/tests/unit/test_sampler/test_sampler_calculate_attributes.py
@@ -7,7 +7,10 @@
 import pytest
 from types import MappingProxyType
 
-from opentelemetry.trace.span import TraceState
+from opentelemetry.trace.span import (
+    INVALID_SPAN_CONTEXT,
+    TraceState
+)
 
 from solarwinds_apm.sampler import _SwSampler
 
@@ -148,6 +151,14 @@ def fixture_decision_continued():
     }
 
 # XTraceOptions Fixtures ================================
+## Empty
+@pytest.fixture(name="mock_xtraceoptions_empty")
+def fixture_xtraceoptions_empty(mocker):
+    options = mocker.Mock()
+    options.sw_keys = ""
+    options.custom_kvs = {}
+    return options
+
 ## Unsigned
 
 @pytest.fixture(name="mock_xtraceoptions_sw_keys_and_custom_keys_no_tt_unsigned")
@@ -866,6 +877,30 @@ class Test_SwSampler_calculate_attributes():
             "sw.w3c.tracestate": "sw=1111222233334444-01,some=other",
             "SWKeys": "foo",
             "custom-foo": "awesome-bar",
+            "foo": "bar",
+            "baz": "qux",
+        })
+
+    def test_no_parent_update_attrs_no_tracestate(
+        self,
+        sw_sampler,
+        attributes_no_tracestate,
+        decision_record_and_sample_regular,
+        mock_xtraceoptions_empty,
+    ):
+        """Represents manual SDK start_as_current_span with attributes at root"""
+        assert sw_sampler.calculate_attributes(
+            span_name="foo",
+            attributes=attributes_no_tracestate,
+            decision=decision_record_and_sample_regular,
+            trace_state=None,
+            parent_span_context=INVALID_SPAN_CONTEXT,
+            xtraceoptions=mock_xtraceoptions_empty,
+        ) == MappingProxyType({
+            "BucketCapacity": "267.0",
+            "BucketRate": "14.7",
+            "SampleRate": 1000000,
+            "SampleSource": 6,
             "foo": "bar",
             "baz": "qux",
         })

--- a/tests/unit/test_sampler/test_sampler_calculate_attributes.py
+++ b/tests/unit/test_sampler/test_sampler_calculate_attributes.py
@@ -774,14 +774,17 @@ class Test_SwSampler_calculate_attributes():
         parent_span_context_valid_remote,
         mock_xtraceoptions_sw_keys_and_custom_keys_and_unsigned_tt
     ):
-        assert sw_sampler.calculate_attributes(
+        result = sw_sampler.calculate_attributes(
             span_name="foo",
             attributes=attributes_no_tracestate,
             decision=decision_continued,
             trace_state=tracestate_with_sw_and_others,
             parent_span_context=parent_span_context_valid_remote,
             xtraceoptions=mock_xtraceoptions_sw_keys_and_custom_keys_and_unsigned_tt,
-        ) == MappingProxyType({
+        )
+        expected = MappingProxyType({
+            "foo": "bar",
+            "baz": "qux",
             "BucketCapacity": "-1",
             "BucketRate": "-1",
             "SampleRate": -1,
@@ -790,9 +793,9 @@ class Test_SwSampler_calculate_attributes():
             "sw.w3c.tracestate": "foo=bar,sw=123,baz=qux",
             "SWKeys": "foo",
             "custom-foo": "awesome-bar",
-            "foo": "bar",
-            "baz": "qux",
         })
+        for e_key, e_val in expected.items():
+            assert result.get(e_key) == e_val
 
     def test_valid_parent_update_attrs_no_tracestate_capture_with_sw_keys_and_custom_keys_and_signed_tt(
         self,
@@ -803,14 +806,17 @@ class Test_SwSampler_calculate_attributes():
         parent_span_context_valid_remote,
         mock_xtraceoptions_sw_keys_and_custom_keys_and_signed_tt
     ):
-        assert sw_sampler.calculate_attributes(
+        result = sw_sampler.calculate_attributes(
             span_name="foo",
             attributes=attributes_no_tracestate,
             decision=decision_continued,
             trace_state=tracestate_with_sw_and_others,
             parent_span_context=parent_span_context_valid_remote,
             xtraceoptions=mock_xtraceoptions_sw_keys_and_custom_keys_and_signed_tt,
-        ) == MappingProxyType({
+        )
+        expected = MappingProxyType({
+            "foo": "bar",
+            "baz": "qux",
             "BucketCapacity": "-1",
             "BucketRate": "-1",
             "SampleRate": -1,
@@ -819,9 +825,9 @@ class Test_SwSampler_calculate_attributes():
             "sw.w3c.tracestate": "foo=bar,sw=123,baz=qux",
             "SWKeys": "foo",
             "custom-foo": "awesome-bar",
-            "foo": "bar",
-            "baz": "qux",
         })
+        for e_key, e_val in expected.items():
+            assert result.get(e_key) == e_val
 
     def test_valid_parent_update_attrs_tracestate_capture_with_sw_keys_and_custom_keys_and_unsigned_tt(
         self,
@@ -832,14 +838,17 @@ class Test_SwSampler_calculate_attributes():
         parent_span_context_valid_remote,
         mock_xtraceoptions_sw_keys_and_custom_keys_and_unsigned_tt
     ):
-        assert sw_sampler.calculate_attributes(
+        result = sw_sampler.calculate_attributes(
             span_name="foo",
             attributes=attributes_with_tracestate,
             decision=decision_continued,
             trace_state=tracestate_with_sw_and_others,
             parent_span_context=parent_span_context_valid_remote,
             xtraceoptions=mock_xtraceoptions_sw_keys_and_custom_keys_and_unsigned_tt,
-        ) == MappingProxyType({
+        )
+        expected = MappingProxyType({
+            "foo": "bar",
+            "baz": "qux",
             "BucketCapacity": "-1",
             "BucketRate": "-1",
             "SampleRate": -1,
@@ -848,9 +857,9 @@ class Test_SwSampler_calculate_attributes():
             "sw.w3c.tracestate": "sw=1111222233334444-01,some=other",
             "SWKeys": "foo",
             "custom-foo": "awesome-bar",
-            "foo": "bar",
-            "baz": "qux",
         })
+        for e_key, e_val in expected.items():
+            assert result.get(e_key) == e_val
 
     def test_valid_parent_update_attrs_tracestate_capture_with_sw_keys_and_custom_keys_and_signed_tt(
         self,
@@ -861,25 +870,28 @@ class Test_SwSampler_calculate_attributes():
         parent_span_context_valid_remote,
         mock_xtraceoptions_sw_keys_and_custom_keys_and_signed_tt
     ):
-        assert sw_sampler.calculate_attributes(
+        result = sw_sampler.calculate_attributes(
             span_name="foo",
             attributes=attributes_with_tracestate,
             decision=decision_continued,
             trace_state=tracestate_with_sw_and_others,
             parent_span_context=parent_span_context_valid_remote,
             xtraceoptions=mock_xtraceoptions_sw_keys_and_custom_keys_and_signed_tt,
-        ) == MappingProxyType({
+        )
+        expected = MappingProxyType({
+            "foo": "bar",
+            "baz": "qux",
+            "SWKeys": "foo",
+            "custom-foo": "awesome-bar",
             "BucketCapacity": "-1",
             "BucketRate": "-1",
             "SampleRate": -1,
             "SampleSource": -1,
             "TriggeredTrace": True,
             "sw.w3c.tracestate": "sw=1111222233334444-01,some=other",
-            "SWKeys": "foo",
-            "custom-foo": "awesome-bar",
-            "foo": "bar",
-            "baz": "qux",
         })
+        for e_key, e_val in expected.items():
+            assert result.get(e_key) == e_val
 
     def test_no_parent_update_attrs_no_tracestate(
         self,

--- a/tests/unit/test_sampler/test_sampler_calculate_attributes.py
+++ b/tests/unit/test_sampler/test_sampler_calculate_attributes.py
@@ -790,6 +790,7 @@ class Test_SwSampler_calculate_attributes():
             "SampleRate": -1,
             "SampleSource": -1,
             "TriggeredTrace": True,
+            "sw.tracestate_parent_id": "1111222233334444",
             "sw.w3c.tracestate": "foo=bar,sw=123,baz=qux",
             "SWKeys": "foo",
             "custom-foo": "awesome-bar",
@@ -822,6 +823,7 @@ class Test_SwSampler_calculate_attributes():
             "SampleRate": -1,
             "SampleSource": -1,
             "TriggeredTrace": True,
+            "sw.tracestate_parent_id": "1111222233334444",
             "sw.w3c.tracestate": "foo=bar,sw=123,baz=qux",
             "SWKeys": "foo",
             "custom-foo": "awesome-bar",
@@ -854,6 +856,7 @@ class Test_SwSampler_calculate_attributes():
             "SampleRate": -1,
             "SampleSource": -1,
             "TriggeredTrace": True,
+            "sw.tracestate_parent_id": "1111222233334444",
             "sw.w3c.tracestate": "sw=1111222233334444-01,some=other",
             "SWKeys": "foo",
             "custom-foo": "awesome-bar",
@@ -888,6 +891,7 @@ class Test_SwSampler_calculate_attributes():
             "SampleRate": -1,
             "SampleSource": -1,
             "TriggeredTrace": True,
+            "sw.tracestate_parent_id": "1111222233334444",
             "sw.w3c.tracestate": "sw=1111222233334444-01,some=other",
         })
         for e_key, e_val in expected.items():


### PR DESCRIPTION
Bugfix: custom sampler's `calculate_attributes` now adds existing attributes earlier. This is important for scenarios where the customer uses the SDK to start spans with custom attributes, e.g.

```
  with tracer.start_as_current_span(
      "manual_instrumentation_django_a",
      attributes={"foo-django-a": "bar-django-a"},
  ):
    # do stuff
```

Example trace with this fix: https://my.na-01.st-ssp.solarwinds.com/136444677275740160/traces/6D23EB224226CC4A59FA70D95C0BB1BE/892E8BFFDE370C5D/details/789BCA3EB9F3A9A0/rawData which was created using this WIP testbed update: https://github.com/appoptics/solarwinds-apm-python-testbed/pull/45

Add a unit tests. All are passing.