### PR TITLE
NH-29850 unify OTel service name with SW_APM service key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.4.0...HEAD)
 ### Added
 - Add support for OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES environment variables ([#90](https://github.com/solarwindscloud/solarwinds-apm-python/pull/90))
+- Add prioritization of OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES, SW_APM_SERVICE_KEY for setting service.name ([#103](https://github.com/solarwindscloud/solarwinds-apm-python/pull/103))
 
 ### Changed
 - Update Init message with HostID ([#90](https://github.com/solarwindscloud/solarwinds-apm-python/pull/90))

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -121,11 +121,6 @@ class SolarWindsApmConfig:
             self.agent_enabled,
             otel_resource,
         )
-        self.__config["service_key"] = self._update_service_key_name(
-            self.agent_enabled,
-            self.__config["service_key"],
-            self.service_name,
-        )
 
         if self.agent_enabled:
             self.context = Context
@@ -139,6 +134,11 @@ class SolarWindsApmConfig:
 
         self.update_with_env_var()
 
+        self.__config["service_key"] = self._update_service_key_name(
+            self.agent_enabled,
+            self.__config["service_key"],
+            self.service_name,
+        )
         self.metric_format = self._calculate_metric_format()
         self.certificates = self._calculate_certificates()
 
@@ -356,9 +356,9 @@ class SolarWindsApmConfig:
         service_name: str,
     ) -> str:
         """Update service key with service name"""
-        if agent_enabled and service_name:
-            # When agent_enabled, assume service_key exists and is formatted correctly.
-            # Only update if service_name exists, which should be the case if agent_enabled.
+        if agent_enabled and service_key and service_name:
+            # Only update if service_name and service_key exist and non-empty.
+            # When agent_enabled, assume service_key is formatted correctly.
             return ":".join([service_key.split(":")[0], service_name])
 
         # Else no need to update service_key when not reporting

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -115,8 +115,13 @@ class SolarWindsApmConfig:
 
         if self.agent_enabled:
             self.context = Context
+            # We know service_key exists and is formatted correctly
+            self.service_name = os.environ.get(
+                "SW_APM_SERVICE_KEY", ":"
+            ).split(":")[1]
         else:
             self.context = NoopContext
+            self.service_name = ""
 
         # TODO Implement config with cnf_file after alpha
         # cnf_file = os.environ.get('SW_APM_APM_CONFIG_PYTHON', os.environ.get('SW_APM_PYCONF', None))

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -424,6 +424,7 @@ class SolarWindsApmConfig:
             "__config": self._config_mask_service_key(),
             "agent_enabled": self.agent_enabled,
             "context": self.context,
+            "service_name": self.service_name,
         }
         return f"{apm_config}"
 

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -105,16 +105,6 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
             # Warning: This may still set OTEL_PROPAGATORS if set because OTel API
             logger.error("Tracing disabled. Not setting propagators.")
 
-    def _configure_resource(
-        self,
-    ) -> Resource:
-        """Configure OTel Resource for setting attributes. Any attributes from
-        OTEL_RESOURCE_ATTRIBUTES are merged with lower priority.
-
-        See also OTel SDK env vars:
-        https://github.com/open-telemetry/opentelemetry-python/blob/8a0ce154ae27a699598cbf3ccc6396eb012902d6/opentelemetry-sdk/src/opentelemetry/sdk/environment_variables.py#L15-L39"""
-        return Resource.create({})
-
     def _configure_sampler(
         self,
         apm_config: SolarWindsApmConfig,
@@ -142,7 +132,9 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         trace.set_tracer_provider(
             TracerProvider(
                 sampler=sampler,
-                resource=self._configure_resource(),
+                resource=Resource.create(
+                    {"service.name": apm_config.service_name}
+                ),
             ),
         )
 

--- a/tests/unit/test_apm_config.py
+++ b/tests/unit/test_apm_config.py
@@ -57,7 +57,9 @@ class TestSolarWindsApmConfig:
         mock_iter_entry_points.configure_mock(
             return_value=mock_points
         )
-        assert apm_config.SolarWindsApmConfig()._calculate_agent_enabled()
+        resulting_config = apm_config.SolarWindsApmConfig()
+        assert resulting_config._calculate_agent_enabled()
+        assert resulting_config.service_name == "key"
 
     def test_calculate_agent_enabled_ok_explicit(self, mocker):
         mocker.patch.dict(os.environ, {
@@ -74,28 +76,36 @@ class TestSolarWindsApmConfig:
         mock_iter_entry_points.configure_mock(
             return_value=mock_points
         )
-        assert apm_config.SolarWindsApmConfig()._calculate_agent_enabled()
+        resulting_config = apm_config.SolarWindsApmConfig()
+        assert resulting_config._calculate_agent_enabled()
+        assert resulting_config.service_name == "key"
 
     def test_calculate_agent_enabled_no_sw_propagator(self, mocker):
         mocker.patch.dict(os.environ, {
             "OTEL_PROPAGATORS": "tracecontext,baggage",
             "SW_APM_SERVICE_KEY": "valid:key",
         })
-        assert not apm_config.SolarWindsApmConfig()._calculate_agent_enabled()
+        resulting_config = apm_config.SolarWindsApmConfig()
+        assert not resulting_config._calculate_agent_enabled()
+        assert resulting_config.service_name == ""
 
     def test_calculate_agent_enabled_no_tracecontext_propagator(self, mocker):
         mocker.patch.dict(os.environ, {
             "OTEL_PROPAGATORS": "solarwinds_propagator",
             "SW_APM_SERVICE_KEY": "valid:key",
         })
-        assert not apm_config.SolarWindsApmConfig()._calculate_agent_enabled()
+        resulting_config = apm_config.SolarWindsApmConfig()
+        assert not resulting_config._calculate_agent_enabled()
+        assert resulting_config.service_name == ""
 
     def test_calculate_agent_enabled_sw_before_tracecontext_propagator(self, mocker):
         mocker.patch.dict(os.environ, {
             "OTEL_PROPAGATORS": "solarwinds_propagator,tracecontext",
             "SW_APM_SERVICE_KEY": "valid:key",
         })
-        assert not apm_config.SolarWindsApmConfig()._calculate_agent_enabled()
+        resulting_config = apm_config.SolarWindsApmConfig()
+        assert not resulting_config._calculate_agent_enabled()
+        assert resulting_config.service_name == ""
 
     def test_calculate_agent_enabled_valid_other_but_missing_sw_exporter(self, mocker):
         mocker.patch.dict(os.environ, {
@@ -110,7 +120,9 @@ class TestSolarWindsApmConfig:
         mock_iter_entry_points.configure_mock(
             return_value=mock_points
         )
-        assert not apm_config.SolarWindsApmConfig()._calculate_agent_enabled()
+        resulting_config = apm_config.SolarWindsApmConfig()
+        assert not resulting_config._calculate_agent_enabled()
+        assert resulting_config.service_name == ""
 
     def test_calculate_agent_enabled_sw_but_no_such_other_exporter(self, mocker):
         mocker.patch.dict(os.environ, {
@@ -123,7 +135,9 @@ class TestSolarWindsApmConfig:
         mock_iter_entry_points.configure_mock(
             side_effect=StopIteration("mock error")
         )
-        assert not apm_config.SolarWindsApmConfig()._calculate_agent_enabled()
+        resulting_config = apm_config.SolarWindsApmConfig()
+        assert not resulting_config._calculate_agent_enabled()
+        assert resulting_config.service_name == ""
 
     def test_calculate_agent_enabled_sw_and_two_other_valid_exporters(self, mocker):
         mocker.patch.dict(os.environ, {
@@ -138,7 +152,9 @@ class TestSolarWindsApmConfig:
         mock_iter_entry_points.configure_mock(
             return_value=mock_points
         )
-        assert apm_config.SolarWindsApmConfig()._calculate_agent_enabled()
+        resulting_config = apm_config.SolarWindsApmConfig()
+        assert resulting_config._calculate_agent_enabled()
+        assert resulting_config.service_name == "key"
 
     def test_calculate_agent_enabled_set_false(self, mocker):
         mocker.patch.dict(os.environ, {
@@ -153,7 +169,9 @@ class TestSolarWindsApmConfig:
         mock_iter_entry_points.configure_mock(
             return_value=mock_points
         )
-        assert not apm_config.SolarWindsApmConfig()._calculate_agent_enabled()
+        resulting_config = apm_config.SolarWindsApmConfig()
+        assert not resulting_config._calculate_agent_enabled()
+        assert resulting_config.service_name == ""
 
     def test_calculate_agent_enabled_service_key_missing(self, mocker):
         # Save any service key in os for later
@@ -171,7 +189,9 @@ class TestSolarWindsApmConfig:
         mock_iter_entry_points.configure_mock(
             return_value=mock_points
         )
-        assert not apm_config.SolarWindsApmConfig()._calculate_agent_enabled()
+        resulting_config = apm_config.SolarWindsApmConfig()
+        assert not resulting_config._calculate_agent_enabled()
+        assert resulting_config.service_name == ""
         # Restore that service key
         if old_service_key:
             os.environ["SW_APM_SERVICE_KEY"] = old_service_key
@@ -189,7 +209,9 @@ class TestSolarWindsApmConfig:
         mock_iter_entry_points.configure_mock(
             return_value=mock_points
         )
-        assert not apm_config.SolarWindsApmConfig()._calculate_agent_enabled()
+        resulting_config = apm_config.SolarWindsApmConfig()
+        assert not resulting_config._calculate_agent_enabled()
+        assert resulting_config.service_name == ""
 
     def test_calculate_metric_format_no_collector(self, mocker):
         # Save any collector in os for later

--- a/tests/unit/test_apm_config.py
+++ b/tests/unit/test_apm_config.py
@@ -621,3 +621,39 @@ class TestSolarWindsApmConfig:
             Resource.create({"service.name": "foobar"})
         )
         assert result == "foobar"
+
+    def test__update_service_key_name_not_agent_enabled(self):
+        test_config = apm_config.SolarWindsApmConfig()
+        result = test_config._update_service_key_name(
+            False,
+            "foo",
+            "bar"
+        )
+        assert result == "foo"
+
+    def test__update_service_key_name_empty_service_name(self):
+        test_config = apm_config.SolarWindsApmConfig()
+        result = test_config._update_service_key_name(
+            True,
+            "foo",
+            ""
+        )
+        assert result == "foo"
+
+    def test__update_service_key_name_not_agent_enabled_and_empty_service_name(self):
+        test_config = apm_config.SolarWindsApmConfig()
+        result = test_config._update_service_key_name(
+            False,
+            "foo",
+            ""
+        )
+        assert result == "foo"
+
+    def test__update_service_key_name_agent_enabled_and_service_name_ok(self):
+        test_config = apm_config.SolarWindsApmConfig()
+        result = test_config._update_service_key_name(
+            True,
+            "valid_key_with:foo-service",
+            "bar-service"
+        )
+        assert result == "valid_key_with:bar-service"


### PR DESCRIPTION
This implements `"Idea #2"`, the unification of `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`, and `SW_APM_SERVICE_KEY` for setting `service.name` in OTel resource attributes used by the configured TracerProvider. Details are here: https://swicloud.atlassian.net/wiki/spaces/NIT/pages/3379855366/OTel+vs+SWO+Service+Name?focusedCommentId=3388899356#Idea-#2:-Unify-OTEL_SERVICE_NAME-and-SW_APM_SERVICE_KEY

Summary: `SolarWindsApmConfig` is responsible for `_calculate_service_name` and uses a fresh OTel `Resource.create` (by default) to get OTel's calculation of `service.name` based on the `OTEL_*` env vars if provided. If there isn't an OTel service name, we use `SW_APM_SERVICE_KEY` instead. ApmConfig also updates its `service_key` value using that name. Then the Configurator uses ApmConfig to (1) init liboboe reporter with the updated `service_key`, and (2) `Resource.create` again with the updated `service_name` and send that one to TracerProvider.

I've done some manual testing and documented results here: https://swicloud.atlassian.net/wiki/spaces/NIT/pages/3388801105/2023-01-12+Unification+of+OTEL+and+SW+APM+service.name More unit tests added too.

Please let me know what you think!