### PR TITLE
NH-29970 NH-31311 Testrelease 0.5.0.2 with fix for install tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.5.0...HEAD)
 
-## [0.5.0.1](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.5.0) - 2023-01-17
+## [0.5.0.2](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.5.0) - 2023-01-17
 ### Added
 - Add support for OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES environment variables ([#90](https://github.com/solarwindscloud/solarwinds-apm-python/pull/90))
 - Add prioritization of OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES, SW_APM_SERVICE_KEY for setting service.name ([#103](https://github.com/solarwindscloud/solarwinds-apm-python/pull/103))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.4.0...HEAD)
+## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.5.0...HEAD)
+
+## [0.5.0.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.5.0) - 2023-01-17
 ### Added
 - Add support for OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES environment variables ([#90](https://github.com/solarwindscloud/solarwinds-apm-python/pull/90))
 - Add prioritization of OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES, SW_APM_SERVICE_KEY for setting service.name ([#103](https://github.com/solarwindscloud/solarwinds-apm-python/pull/103))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.5.0...HEAD)
 
-## [0.5.0.2](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.5.0) - 2023-01-17
+## [0.5.0.2](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.5.0) - 2023-01-18
 ### Added
 - Add support for OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES environment variables ([#90](https://github.com/solarwindscloud/solarwinds-apm-python/pull/90))
 - Add prioritization of OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES, SW_APM_SERVICE_KEY for setting service.name ([#103](https://github.com/solarwindscloud/solarwinds-apm-python/pull/103))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.5.0...HEAD)
 
-## [0.5.0.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.5.0) - 2023-01-17
+## [0.5.0.1](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.5.0) - 2023-01-17
 ### Added
 - Add support for OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES environment variables ([#90](https://github.com/solarwindscloud/solarwinds-apm-python/pull/90))
 - Add prioritization of OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES, SW_APM_SERVICE_KEY for setting service.name ([#103](https://github.com/solarwindscloud/solarwinds-apm-python/pull/103))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated exported spans with Python framework versions ([#92](https://github.com/solarwindscloud/solarwinds-apm-python/pull/92))
 - Bugfix: existing attributes without parent context now write to spans ([#102](https://github.com/solarwindscloud/solarwinds-apm-python/pull/102))
 - Bugfix: setting sw.tracestate_parent_id is based on existence of remote parent span ([#102](https://github.com/solarwindscloud/solarwinds-apm-python/pull/102))
+- Fix install tests on Ubuntu with Python 3.10/3.11 using older setuptools version ([#104](https://github.com/solarwindscloud/solarwinds-apm-python/pull/104))
 
 ## [0.4.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.4.0) - 2023-01-03
 ### Added

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.5.0.1"
+__version__ = "0.5.0.2"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.5.0.0"
+__version__ = "0.5.0.1"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.4.0"
+__version__ = "0.5.0.0"

--- a/tests/docker/install/install_tests.sh
+++ b/tests/docker/install/install_tests.sh
@@ -147,9 +147,14 @@ function check_agent_startup(){
 
 function install_test_app_dependencies(){
     pip install flask requests
-    # setuptools 66.0.0 breaks opentelemetry-bootstrap
-    pip uninstall -y setuptools
-    pip install setuptools==65.7.0
+    # setuptools 66.0.0 breaks opentelemetry-bootstrap on Ubuntu 18.04+, Python 3.10+ from deadsnakes
+    if grep Ubuntu /etc/os-release; then
+        ubuntu_version=$(grep VERSION_ID /etc/os-release | sed 's/VERSION_ID="//' | sed 's/"//')
+        if [ "$ubuntu_version" = "18.04" ] || [ "$ubuntu_version" = "20.04" ]; then
+            pip uninstall -y setuptools
+            pip install setuptools==65.7.0
+        fi
+    fi
     opentelemetry-bootstrap --action=install
 }
 

--- a/tests/docker/install/install_tests.sh
+++ b/tests/docker/install/install_tests.sh
@@ -151,9 +151,11 @@ function install_test_app_dependencies(){
     if grep Ubuntu /etc/os-release; then
         ubuntu_version=$(grep VERSION_ID /etc/os-release | sed 's/VERSION_ID="//' | sed 's/"//')
         if [ "$ubuntu_version" = "18.04" ] || [ "$ubuntu_version" = "20.04" ]; then
+            echo "Installing test app deps on ubuntu_version $ubuntu_version"
             # get Python version from container hostname, e.g. "3.7", "3.10"
             python_version=$(grep -Eo 'py3.[0-9]+[0-9]*' /etc/hostname | grep -Eo '3.[0-9]+[0-9]*')
             if [ "$python_version" = "3.10" ] || [ "$python_version" = "3.11" ]; then
+                echo "Re-installing setuptools for Python $python_version"
                 pip uninstall -y setuptools
                 pip install setuptools==65.7.0
             fi

--- a/tests/docker/install/install_tests.sh
+++ b/tests/docker/install/install_tests.sh
@@ -156,8 +156,8 @@ function install_test_app_dependencies(){
             python_version=$(grep -Eo 'py3.[0-9]+[0-9]*' /etc/hostname | grep -Eo '3.[0-9]+[0-9]*')
             if [ "$python_version" = "3.10" ] || [ "$python_version" = "3.11" ]; then
                 echo "Re-installing setuptools for Python $python_version"
-                pip uninstall -y setuptools
-                pip install setuptools==65.7.0
+                apt-get remove python-setuptools
+                pip install --ignore-installed setuptools==65.7.0
             fi
         fi
     fi

--- a/tests/docker/install/install_tests.sh
+++ b/tests/docker/install/install_tests.sh
@@ -147,6 +147,9 @@ function check_agent_startup(){
 
 function install_test_app_dependencies(){
     pip install flask requests
+    # setuptools 66.0.0 breaks opentelemetry-bootstrap
+    pip uninstall -y setuptools
+    pip install setuptools==65.7.0
     opentelemetry-bootstrap --action=install
 }
 

--- a/tests/docker/install/install_tests.sh
+++ b/tests/docker/install/install_tests.sh
@@ -151,8 +151,12 @@ function install_test_app_dependencies(){
     if grep Ubuntu /etc/os-release; then
         ubuntu_version=$(grep VERSION_ID /etc/os-release | sed 's/VERSION_ID="//' | sed 's/"//')
         if [ "$ubuntu_version" = "18.04" ] || [ "$ubuntu_version" = "20.04" ]; then
-            pip uninstall -y setuptools
-            pip install setuptools==65.7.0
+            # get Python version from container hostname, e.g. "3.7", "3.10"
+            python_version=$(grep -Eo 'py3.[0-9]+[0-9]*' /etc/hostname | grep -Eo '3.[0-9]+[0-9]*')
+            if [ "$python_version" = "3.10" ] || [ "$python_version" = "3.11" ]; then
+                pip uninstall -y setuptools
+                pip install setuptools==65.7.0
+            fi
         fi
     fi
     opentelemetry-bootstrap --action=install


### PR DESCRIPTION
Testrelease of [solarwinds-apm 0.5.0.2](https://test.pypi.org/project/solarwinds-apm/0.5.0.2/) (https://swicloud.atlassian.net/browse/NH-29970), which I also released to test the fix for the install tests (https://swicloud.atlassian.net/browse/NH-31311).

Before this `install_tests.sh` update, install tests were failing for Python 3.10 and 3.11 on Ubuntu 18.04 and 20.04. There is something in the recent major release of `setuptools 66.0.0` this month that breaks with `InvalidVersion` errors at the call to `opentelemetry-bootstrap`. I will continue investigating whether this is a SolarWinds issue or an OTel issue for these Python versions on Ubuntu (https://swicloud.atlassian.net/browse/NH-31430). I just want to get this release out first!

SWO test trace: https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/B8381EA00D76D2BA9E5EA772109E3A60/CB40ECF30C3E2346/details

AO test trace: https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/9DD0C4ED3195E5FCA6EDCD15C54622BA00000000/graph

Install tests with 0.5.0.2 passed: https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/3952055936
