### PR TITLE
NH-29063 PoC: set_transaction_name API

### DIFF
--- a/solarwinds_apm/api/__init__.py
+++ b/solarwinds_apm/api/__init__.py
@@ -1,0 +1,38 @@
+# © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+"""
+Example usage:
+
+from solarwinds_apm.api import set_transaction_name
+set_transaction_name("my-foo-name")
+"""
+
+import logging
+
+from opentelemetry.trace import get_current_span, get_tracer_provider
+
+from solarwinds_apm.inbound_metrics_processor import SolarWindsInboundMetricsSpanProcessor
+
+logger = logging.getLogger(__name__)
+
+def set_transaction_name(name: str) -> None:
+    # Assumes TracerProvider's active span processor is SynchronousMultiSpanProcessor
+    # or ConcurrentMultiSpanProcessor
+    span_processors = get_tracer_provider()._active_span_processor._span_processors
+    inbound_processor = None
+    for spr in span_processors:
+        if type(spr) == SolarWindsInboundMetricsSpanProcessor:
+            inbound_processor = spr
+    
+    if not inbound_processor:
+        logger.error("Could not find configured InboundMetricsSpanProcessor.")
+        return
+
+    current_span = get_current_span()
+    trace_id = current_span.get_span_context().trace_id
+    inbound_processor._apm_txname_customizer[trace_id] = name
+    logger.debug("Cached custom transaction name as %s", name)

--- a/solarwinds_apm/apm_txname_customizer.py
+++ b/solarwinds_apm/apm_txname_customizer.py
@@ -10,9 +10,11 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-class SolarWindsTxnNameManager:
-    """SolarWinds Transaction Name Manager
-    Stores "<trace_id>-<span_id>" with associated transaction name"""
+class SolarWindsTxnNameCustomizer:
+    """SolarWinds Transaction Name Customizer
+    Stores "<trace_id>" with customized transaction name
+    
+    TODO: consolidate this with SolarWindsTxnNameManager"""
 
     def __init__(self, **kwargs: int) -> None:
         self.__cache = {}

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -144,10 +144,12 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         apm_config: SolarWindsApmConfig,
     ) -> None:
         """Configure SolarWindsInboundMetricsSpanProcessor"""
+        custom_transaction_naming = os.environ.get("SW_APM_TRANSACTION_NAMING")
         trace.get_tracer_provider().add_span_processor(
             SolarWindsInboundMetricsSpanProcessor(
                 apm_txname_manager,
                 apm_config.agent_enabled,
+                custom_transaction_naming,
             )
         )
 

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -144,12 +144,10 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         apm_config: SolarWindsApmConfig,
     ) -> None:
         """Configure SolarWindsInboundMetricsSpanProcessor"""
-        custom_transaction_naming = os.environ.get("SW_APM_TRANSACTION_NAMING")
         trace.get_tracer_provider().add_span_processor(
             SolarWindsInboundMetricsSpanProcessor(
                 apm_txname_manager,
                 apm_config.agent_enabled,
-                custom_transaction_naming,
             )
         )
 

--- a/solarwinds_apm/inbound_metrics_processor.py
+++ b/solarwinds_apm/inbound_metrics_processor.py
@@ -151,11 +151,31 @@ class SolarWindsInboundMetricsSpanProcessor(SpanProcessor):
         trans_name = None
 
         # TODO
-        # Base case: always use single custom name if set
+        # TODO What about SpanKind.INTERNAL?
+        # Base case: use single custom name, if set, for manual SDK-started spans
+        # Recall: this only called for service entry spans
         if self.custom_transaction_naming:
-            trans_name = self.custom_transaction_naming
+            if span.instrumentation_scope is not None:
+                logger.warning("Got this scope name: %s", span.instrumentation_scope.name)  # temp higher priority to avoid noise
 
-        elif http_route:
+                # If instrumentation scope of span is opentelemetry.instrumentation.*
+                # then the span was(?) created by an OTel instrumentation library automatically.
+                # name is always string in Otel Python
+                if "opentelemetry.instrumentation." not in span.instrumentation_scope.name:
+                    logger.warning(  # temp higher priority to avoid noise
+                        "Span instrumentation scope is not Otel instrumentation; using custom transaction naming."
+                    )
+                    trans_name = self.custom_transaction_naming
+                    return trans_name, url_tran
+            else:
+                # Not sure when scope would be None - non-Otel? broken Otel?
+                logger.warning(  # temp higher priority to avoid noise
+                    "Span instrumentation scope is None; using custom transaction naming."
+                )
+                trans_name = self.custom_transaction_naming
+                return trans_name, url_tran
+
+        if http_route:
             trans_name = http_route
         elif span.name:
             trans_name = span.name

--- a/solarwinds_apm/inbound_metrics_processor.py
+++ b/solarwinds_apm/inbound_metrics_processor.py
@@ -36,19 +36,12 @@ class SolarWindsInboundMetricsSpanProcessor(SpanProcessor):
         self,
         apm_txname_manager: "SolarWindsTxnNameManager",
         agent_enabled: bool,
-        custom_transaction_naming: Any = None,
     ) -> None:
         self._apm_txname_manager = apm_txname_manager
         if agent_enabled:
             self._span = Span
         else:
             self._span = NoopSpan
-        self.custom_transaction_naming = self._calculate_custom_transaction_naming(custom_transaction_naming)
-
-    def _calculate_custom_transaction_naming(self, naming) -> str:
-        """Calculates custom transaction name"""
-        # TODO: return a mapping instead?
-        return naming
 
     def on_end(self, span: "ReadableSpan") -> None:
         """Calculates and reports inbound trace metrics,
@@ -149,13 +142,7 @@ class SolarWindsInboundMetricsSpanProcessor(SpanProcessor):
         url_tran = span.attributes.get(self._HTTP_URL, None)
         http_route = span.attributes.get(self._HTTP_ROUTE, None)
         trans_name = None
-
-        # TODO
-        # Base case: always use single custom name if set
-        if self.custom_transaction_naming:
-            trans_name = self.custom_transaction_naming
-
-        elif http_route:
+        if http_route:
             trans_name = http_route
         elif span.name:
             trans_name = span.name

--- a/solarwinds_apm/inbound_metrics_processor.py
+++ b/solarwinds_apm/inbound_metrics_processor.py
@@ -158,12 +158,14 @@ class SolarWindsInboundMetricsSpanProcessor(SpanProcessor):
     def calculate_custom_transaction_name(
         self, span: "ReadableSpan"
     ) -> Any:
-        """Get custom transaction name for trace, if any"""
+        """Get custom transaction name for trace by trace_id, if any"""
         trans_name = None
         custom_name = self._apm_txname_customizer.get(span.context.trace_id)
         if custom_name:
             trans_name = self._apm_txname_customizer[span.context.trace_id]
-            # Clean up customizer if at root span
+            # Clean up customizer if at root span.
+            # Assumes OTel root span is ended last.
+            # Exporter will receive custom name through txname manager.
             if not span.parent or not span.parent.is_valid:
                 del self._apm_txname_customizer[span.context.trace_id]
         return trans_name

--- a/solarwinds_apm/inbound_metrics_processor.py
+++ b/solarwinds_apm/inbound_metrics_processor.py
@@ -151,31 +151,11 @@ class SolarWindsInboundMetricsSpanProcessor(SpanProcessor):
         trans_name = None
 
         # TODO
-        # TODO What about SpanKind.INTERNAL?
-        # Base case: use single custom name, if set, for manual SDK-started spans
-        # Recall: this only called for service entry spans
+        # Base case: always use single custom name if set
         if self.custom_transaction_naming:
-            if span.instrumentation_scope is not None:
-                logger.warning("Got this scope name: %s", span.instrumentation_scope.name)  # temp higher priority to avoid noise
+            trans_name = self.custom_transaction_naming
 
-                # If instrumentation scope of span is opentelemetry.instrumentation.*
-                # then the span was(?) created by an OTel instrumentation library automatically.
-                # name is always string in Otel Python
-                if "opentelemetry.instrumentation." not in span.instrumentation_scope.name:
-                    logger.warning(  # temp higher priority to avoid noise
-                        "Span instrumentation scope is not Otel instrumentation; using custom transaction naming."
-                    )
-                    trans_name = self.custom_transaction_naming
-                    return trans_name, url_tran
-            else:
-                # Not sure when scope would be None - non-Otel? broken Otel?
-                logger.warning(  # temp higher priority to avoid noise
-                    "Span instrumentation scope is None; using custom transaction naming."
-                )
-                trans_name = self.custom_transaction_naming
-                return trans_name, url_tran
-
-        if http_route:
+        elif http_route:
             trans_name = http_route
         elif span.name:
             trans_name = span.name


### PR DESCRIPTION
Proof-of-concept/conversation starter for how we might try to set up a `set_transaction_name` method for customers to use. Run using this testbed update: https://github.com/appoptics/solarwinds-apm-python-testbed/pull/47

**Summary of changes:**
1. Adds new `SolarWindsTxnNameCustomizer`, which for now is separate and used slightly differently than the existing `SolarWindsTxnNameManager`
2. `SolarWindsTxnNameCustomizer` is initialized by Configurator and linked to the Inbound Metrics Processor
3. Inbound Metrics Processor uses TxnNameCustomizer to retrieve any cached custom txn names by `trace_id` (versus by `trace_id` and `span_id` when setting in TxnNameManager)
4. Inbound Metrics Processor prioritizes custom txn name over http/regular span name for liboboe call and for caching for exporter to use later.
5. TxnNameCustomizer is updated by new API call `set_transaction_name`, by getting the current TracerProvider at execution time and finding the Inbound Metrics Processor.

**Single example trace:**
* under Django A transaction "my-foo-name": https://my.na-01.st-ssp.solarwinds.com/136444677275740160/traces/5FEB13C065A5F33BAA17608F140478B7/3F1C9D6B963B0182/details
* under Django B transaction "my-bar-name": https://my.na-01.st-ssp.solarwinds.com/136444677275740160/traces/5FEB13C065A5F33BAA17608F140478B7/DD9AB8C89BB3E79C/details

**Thoughts**
I don't think we can use this approach alone to e.g. call `set_transaction_name` in Django B then get the root server span of Django A to have a customize txn name in distributed trace. (Example trace where Django B calls API but Django A does not: [at Django B service](https://my.na-01.st-ssp.solarwinds.com/136444677275740160/traces/6D8D9F2122A33C171F78DAE5D0193E4F/5F00494FC1F20D62/details), [at Django A service](https://my.na-01.st-ssp.solarwinds.com/136444677275740160/traces/6D8D9F2122A33C171F78DAE5D0193E4F/9759D277BF8E48E4/details).)

This makes sense since each service will have its own inbound metrics processor and exporter running. If we wanted them to talk to each other, instrumented services would have to read response headers(???)