### PR TITLE
NH-32409 Fix failed ASGI version lookup logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - SolarWinds c-lib 12.0.0, for gRPC upgrade ([#107](https://github.com/solarwindscloud/solarwinds-apm-python/pull/107))
+- Bugfix: fix version lookup failures for instrumented ASGI libraries ([#108](https://github.com/solarwindscloud/solarwinds-apm-python/pull/108))
 
 ### Removed
 - Drop centos7 support ([#107](https://github.com/solarwindscloud/solarwinds-apm-python/pull/107))

--- a/solarwinds_apm/exporter.py
+++ b/solarwinds_apm/exporter.py
@@ -16,6 +16,7 @@ import sys
 from typing import Any
 
 from opentelemetry.sdk.trace.export import SpanExporter
+from opentelemetry.trace import SpanKind
 from pkg_resources import get_distribution
 
 from solarwinds_apm.apm_constants import (
@@ -36,17 +37,19 @@ class SolarWindsSpanExporter(SpanExporter):
     Initialization requires a liboboe reporter.
     """
 
-    _ASGI_IMPLEMENTATIONS = [
-        "fastapi",
+    _ASGI_APP_IMPLEMENTATIONS = [
+        "fastapi",  # based on starlette, so higher up
         "starlette",
-        "uvicorn",
-        "daphne",
-        "hypercorn",
         "channels",
         "quart",
         "sanic",
         "rpc.py",
         "a2wsgi",
+    ]
+    _ASGI_SERVER_IMPLEMENTATIONS = [
+        "uvicorn",
+        "hypercorn",
+        "daphne",
     ]
     _INTERNAL_TRANSACTION_NAME = "TransactionName"
     _SW_SPAN_KIND = "sw.span_kind"
@@ -173,20 +176,36 @@ class SolarWindsSpanExporter(SpanExporter):
                 framework = "tortoise"
             # asgi is implemented over multiple frameworks
             # https://asgi.readthedocs.io/en/latest/implementations.html
-            # Use the framework for name and version
+            # Use the first best guess framework for name and version
+            # TODO Increase precision
             elif framework == "asgi":
-                for asgi_impl in self._ASGI_IMPLEMENTATIONS:
-                    try:
-                        importlib.import_module(asgi_impl)
-                    except (AttributeError, ImportError):
-                        continue
-                    else:
-                        logger.debug(
-                            "Setting %s as instrumented ASGI framework span KV",
-                            asgi_impl,
-                        )
-                        framework = asgi_impl
-                        break
+                if span.kind == SpanKind.SERVER:
+                    for asgi_impl in self._ASGI_SERVER_IMPLEMENTATIONS:
+                        try:
+                            importlib.import_module(asgi_impl)
+                        except (AttributeError, ImportError):
+                            continue
+                        else:
+                            logger.debug(
+                                "Setting %s as instrumented ASGI server framework span KV",
+                                asgi_impl,
+                            )
+                            framework = asgi_impl
+                            break
+                else:
+                    # SpanKind.INTERNAL might be common for async
+                    for asgi_impl in self._ASGI_APP_IMPLEMENTATIONS:
+                        try:
+                            importlib.import_module(asgi_impl)
+                        except (AttributeError, ImportError):
+                            continue
+                        else:
+                            logger.debug(
+                                "Setting %s as instrumented ASGI application framework span KV",
+                                asgi_impl,
+                            )
+                            framework = asgi_impl
+                            break
 
             instr_key = f"Python.{framework}.Version"
             if "grpc_" in framework:


### PR DESCRIPTION
This fixes a framework lookup at `Python.*.Version` span KV calculation and removes excessive warning logs as reported by customer, which are logging once per span, 3 spans per trace created by a very simple FastAPI app (their code [attached to ticket](https://swicloud.atlassian.net/browse/NH-32409), similar in [testbed PR here](https://github.com/appoptics/solarwinds-apm-python-testbed/pull/48)):

```[ solarwinds_apm.exporter WARNING  p#1.140549948016384] Version lookup of asgi failed, so skipping: No module named 'asgi'```

This is a bit of an odd approach but all of `SolarWindsSpanExporter._add_info_instrumented_framework` is a little odd. The exceptions were being raised (and caught to log) because we can't `import asgi` to get its version. Instead, ASGI design is implemented by several frameworks listed [here](https://asgi.readthedocs.io/en/latest/implementations.html) and added to new `_ASGI_APP_IMPLEMENTATIONS` and `_ASGI_SERVER_IMPLEMENTATIONS`. There are two new loops depending on if `SpanKind.SERVER` or any other kind (e.g. `INTERNAL`, `CLIENT`). Each loop goes through one implementations list and stops when it can set e.g.  `Python.Fastapi.Version` as `0.89.1` or `Python.Uvicorn.Version` as `0.20.0`. It won't try to set `Python.Asgi.Version` anymore.

Caveat: The new loops stop at the first framework they're able to import. We're making these "estimates" right now as a placeholder until there is more demand for this feature. Then we'd address the `TODO` and find how to be more precise than relying only on `span.instrumentation_scope.name` (`opentelemetry.instrumentation.asgi`) and SpanKind for setting `Python.*.Version`.

Example trace from simple ASGI app, with two `Python.Fastapi.Version` spans and one `Python.Uvicorn.Version` span: https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/42280A9C6F489D8603D60B14FE80A322/54CD29BC456800EF/details

Compared trace from `main`, which is missing `Python.*.Version` KVs on all spans: https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/B5A4F6F225065B391F7896B9EFD5810C/D6D2B18C2CABF10C/details. This is the actual bug. 🙂 