### PR TITLE
NH-32619 Testrelease 0.6.0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.5.0...HEAD)
 
+## [0.6.0.24](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.6.0) - 2023-02-08
 ### Changed
 - SolarWinds c-lib 12.0.0, for gRPC upgrade ([#107](https://github.com/solarwindscloud/solarwinds-apm-python/pull/107))
 - Bugfix: fix version lookup failures for instrumented ASGI libraries ([#108](https://github.com/solarwindscloud/solarwinds-apm-python/pull/108))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.5.0...HEAD)
+## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.6.0...HEAD)
 
 ## [0.6.0.24](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.6.0) - 2023-02-08
 ### Changed

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.6.0.13"
+__version__ = "0.6.0.24"


### PR DESCRIPTION
Test publish of solarwinds-apm 0.6.0.24 to TestPyPI (`x86_64` only):
https://test.pypi.org/project/solarwinds-apm/0.6.0.24/

Test traces:
* NH prod: https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/E3E5353038573EC1804FCBA02866344C/4E8927A23CA41106/details
* AO prod: https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/C5723087D04100E80F96264FFA9BED8100000000/graph

Install tests pass: https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/4127805557

Updates since 0.5.0:
```
### Changed
- SolarWinds c-lib 12.0.0, for gRPC upgrade ([#107](https://github.com/solarwindscloud/solarwinds-apm-python/pull/107))
- Bugfix: fix version lookup failures for instrumented ASGI libraries ([#108](https://github.com/solarwindscloud/solarwinds-apm-python/pull/108))

### Removed
- Drop centos7 support ([#107](https://github.com/solarwindscloud/solarwinds-apm-python/pull/107))
- Drop Debian 9 support ([#107](https://github.com/solarwindscloud/solarwinds-apm-python/pull/107))
- Drop Amazon Linux 2018.03 support ([#107](https://github.com/solarwindscloud/solarwinds-apm-python/pull/107))
```