### PR TITLE
ENOPS-3865 update codeql workflow

### DIFF
--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -42,7 +42,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
@@ -50,7 +49,6 @@ jobs:
           # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           queries: security-extended,security-and-quality
           setup-python-dependencies: false
-          debug: true
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v2

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -26,8 +26,17 @@ on:
   #  - cron: '30 1 * * *'
 
 jobs:
-  CodeQL-Build:
+  analyze:
+    name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python' ]
 
     steps:
       - name: Checkout repository
@@ -35,12 +44,16 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
-          languages: python
+          languages: ${{ matrix.language }}
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          queries: security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -7,6 +7,11 @@
 name: CodeQL Analysis
 
 on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
   workflow_dispatch:
   #schedule:
     #        ┌───────────── minute (0 - 59)

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -50,6 +50,7 @@ jobs:
           # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           queries: security-extended,security-and-quality
           setup-python-dependencies: false
+          debug: true
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v2

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -49,6 +49,7 @@ jobs:
           languages: ${{ matrix.language }}
           # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           queries: security-extended,security-and-quality
+          setup-python-dependencies: false
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v2


### PR DESCRIPTION
Updates Python APM library repo's existing CodeQL workflow config to use newer actions and advanced queries, and trigger on PR/push to `main`.

Seems to work:
* Last run finished without errors: https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/4198829934/jobs/7282953892
* resulting in CodeQL suggestions in the [Files changed](https://github.com/solarwindscloud/solarwinds-apm-python/pull/112/files) of this PR under "Unchanged files with check annotations"! (I'll address these in a different PR.)
* No scanning alerts, which I'm still a bit skeptical about: https://github.com/solarwindscloud/solarwinds-apm-python/security/code-scanning