### PR TITLE
Testrelease 0.7.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.6.0...HEAD)
+## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.7.0...HEAD)
+
+## [0.7.0.5](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.7.0) - 2023-02-22
 ### Added
 - Add ARM support ([#111](https://github.com/solarwindscloud/solarwinds-apm-python/pull/111))
+
+### Changed
+- Updated CodeQL scans ([#112](https://github.com/solarwindscloud/solarwinds-apm-python/pull/112))
 
 ## [0.6.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.6.0) - 2023-02-08
 ### Changed

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.7.0.4"
+__version__ = "0.7.0.5"


### PR DESCRIPTION
Testrelease 0.7.0.5 before prod/PyPI release.

x86_64 and AARCH64 artifacts published to: https://test.pypi.org/project/solarwinds-apm/0.7.0.5/#files

Installation tests for both pass: https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/4245798590