### PR TITLE
NH-33743 Bump Otel Python 1.16.0-0.370b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.7.0...HEAD)
 
+### Changed
+- OpenTelemetry API/SDK 1.16.0 ([#116](https://github.com/solarwindscloud/solarwinds-apm-python/pull/116))
+- OpenTelemetry Instrumentation 0.37b0 ([#116](https://github.com/solarwindscloud/solarwinds-apm-python/pull/116))
+
 ## [0.7.0.5](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.7.0) - 2023-02-22
 ### Added
 - Add ARM support ([#111](https://github.com/solarwindscloud/solarwinds-apm-python/pull/111))

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
-opentelemetry-test-utils==0.36b0
-opentelemetry-instrumentation-flask==0.36b0
-opentelemetry-instrumentation-requests==0.36b0
+opentelemetry-test-utils==0.37b0
+opentelemetry-instrumentation-flask==0.37b0
+opentelemetry-instrumentation-requests==0.37b0
 pytest
 pytest-cov
 pytest-mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,9 +23,9 @@ classifiers =
 [options]
 python_requires = >=3.7
 install_requires =
-    opentelemetry-api == 1.15.0
-    opentelemetry-sdk == 1.15.0
-    opentelemetry-instrumentation == 0.36b0
+    opentelemetry-api == 1.16.0
+    opentelemetry-sdk == 1.16.0
+    opentelemetry-instrumentation == 0.37b0
 packages = solarwinds_apm, solarwinds_apm.certs, solarwinds_apm.extension
 
 [options.package_data]


### PR DESCRIPTION
Bump Otel Python 1.16.0-0.370b.

NH test trace: https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/229240F1497484FE0309209D459ED26D/FC8FB4720A6096C0/details/breakdown

AO test trace: https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/270BE597ECE91DD1D1BF843ADFDAD32100000000/graph

tox tests passing.