### PR TITLE
Testrelease 0.8.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.7.0...HEAD)
+## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.8.0...HEAD)
+
+## [0.8.0.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.8.0) - 2023-02-28
 
 ### Added
 - Add `set_transaction_name` API method ([#115](https://github.com/solarwindscloud/solarwinds-apm-python/pull/115))

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     opentelemetry-api == 1.16.0
     opentelemetry-sdk == 1.16.0
     opentelemetry-instrumentation == 0.37b0
-packages = solarwinds_apm, solarwinds_apm.certs, solarwinds_apm.extension
+packages = solarwinds_apm, solarwinds_apm.api, solarwinds_apm.certs, solarwinds_apm.extension
 
 [options.package_data]
 solarwinds_apm = extension/liboboe.so, extension/VERSION, extension/bson/bson.h, extension/bson/platform_hacks.h

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.8.0.1"
+__version__ = "0.8.0.2"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.8.0.0"
+__version__ = "0.8.0.1"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.7.0"
+__version__ = "0.8.0.0"

--- a/tests/docker/install/install_tests.sh
+++ b/tests/docker/install/install_tests.sh
@@ -106,7 +106,7 @@ function check_agent_startup(){
     export SW_APM_DEBUG_LEVEL=6
     export SW_APM_SERVICE_KEY=invalid-token-for-testing-1234567890:servicename
     
-    # return value we expect form solarwinds_apm.solarwinds_ready().
+    # return value we expect form solarwinds_apm.api.solarwinds_ready().
     # This should normally be 1 (ready), because the collector does not send
     # "invalid api token" response; it sends "ok" with soft disable settings.
     expected_agent_return=1
@@ -119,7 +119,7 @@ function check_agent_startup(){
     # unset stop on error so we can catch debug messages in case of failures
     set +e
 
-    result=$(opentelemetry-instrument python -c 'from solarwinds_apm.apm_ready import solarwinds_ready; r=solarwinds_ready(wait_milliseconds=10000, integer_response=True); print(r)' 2>startup.log)
+    result=$(opentelemetry-instrument python -c 'from solarwinds_apm.api import solarwinds_ready; r=solarwinds_ready(wait_milliseconds=10000, integer_response=True); print(r)' 2>startup.log)
 
     if [ "$result" != "$expected_agent_return" ]; then
         echo "FAILED! Expected solarwinds_ready to return $expected_agent_return, but got: $result"


### PR DESCRIPTION
Updates since 0.7.0 (this PR also includes an install test and packaging fix):

```
## Added
- Add `set_transaction_name` API method ([#115](https://github.com/solarwindscloud/solarwinds-apm-python/pull/115))

### Changed
- Deprecated `solarwinds_apm.apm_ready.solarwinds_ready`. Instead, use `solarwinds_apm.api.solarwinds_ready`. ([#115](https://github.com/solarwindscloud/solarwinds-apm-python/pull/115))
- OpenTelemetry API/SDK 1.16.0 ([#116](https://github.com/solarwindscloud/solarwinds-apm-python/pull/116))
- OpenTelemetry Instrumentation 0.37b0 ([#116](https://github.com/solarwindscloud/solarwinds-apm-python/pull/116))
```

Published to TestPyPI as 0.8.0.2: https://test.pypi.org/project/solarwinds-apm/0.8.0.2/#files

- NH Django test trace: https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/B3435F0A8F004E72BD6E95AD57C3EE83/0FF90D152DEB17C0/details/breakdown
- NH ASGI test trace: https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/447F35FABC4C6EEC3BFBC9ED5CF40AC7/266671B993DA1FAC/details/breakdown
- AO Django test trace: https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/FB37638604AB31E1E04C564980C716E600000000/graph
- AO ASGI test trace https://my.appoptics.com/apm/123092/services/asgi_app_ot/traces/801DB606D42B03B61F48A4FC2239659D00000000/graph
- tox tests on this PR pass
- Install tests: https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/4299097362