### PR TITLE
NH-34221 delete xtraceoptions response from tracestate only if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.8.1...HEAD)
+### Changed
+- Fixed noisy trace state KV deletion attempts when key not present ([#121](https://github.com/solarwindscloud/solarwinds-apm-python/pull/121))
 
 ## [0.8.1](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.8.1) - 2023-03-08
 ### Changed

--- a/solarwinds_apm/w3c_transformer.py
+++ b/solarwinds_apm/w3c_transformer.py
@@ -85,4 +85,6 @@ class W3CTransformer:
     @classmethod
     def remove_response_from_sw(cls, trace_state: TraceState) -> TraceState:
         """Remove xtraceoptions response from tracestate"""
-        return trace_state.delete(INTL_SWO_X_OPTIONS_RESPONSE_KEY)
+        if trace_state.get(INTL_SWO_X_OPTIONS_RESPONSE_KEY):
+            trace_state = trace_state.delete(INTL_SWO_X_OPTIONS_RESPONSE_KEY)
+        return trace_state

--- a/tests/unit/test_w3c_transformer.py
+++ b/tests/unit/test_w3c_transformer.py
@@ -53,6 +53,10 @@ class TestW3CTransformer():
         assert W3CTransformer.sw_from_span_and_decision(1234, "01") \
             == "{:016x}-{}".format(1234, "01")
 
-    def test_remove_response_from_sw(self):
+    def test_remove_response_from_sw_key_present(self):
         ts = TraceState([["bar", "456"],["xtrace_options_response", "123"]])
+        assert W3CTransformer.remove_response_from_sw(ts) == TraceState([["bar", "456"]])
+
+    def test_remove_response_from_sw_key_absent(self):
+        ts = TraceState([["bar", "456"]])
         assert W3CTransformer.remove_response_from_sw(ts) == TraceState([["bar", "456"]])


### PR DESCRIPTION
Delete xtraceoptions response from tracestate only if present. This is a bugfix to stop seeing this message that was logging at every single `should_sample` and `inject` call!:

```
The provided key xtrace_options_response doesn't exist.
```

tox tests pass on this PR. Exported test traces look ok on [SWO](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/8EFBD612CC33E3AD1449C5FAC5B2EEE8/D85D8DFFA57AB2B2/details/breakdown) and [AO](https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/CE85F367360102707800831E40B7DC5C00000000/details).