### PR TITLE
NH-33749 Fix typo in aiohttp_client lib lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.8.1...HEAD)
 
+### Changed
+- Bugfix: fix version lookup failures for instrumented aiohttp library ([#122](https://github.com/solarwindscloud/solarwinds-apm-python/pull/122))
+
 ## [0.8.1](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.8.1) - 2023-03-08
 ### Changed
 - Fixed installation from source distribution ([#119](https://github.com/solarwindscloud/solarwinds-apm-python/pull/119))

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -337,7 +337,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
             # Some OTel instrumentation libraries are named not exactly
             # the same as the instrumented libraries!
             # https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/README.md
-            if entry_point_name == "aiohttp-client":
+            if entry_point_name == "aiohttp_client":
                 entry_point_name = "aiohttp"
             elif "grpc_" in entry_point_name:
                 entry_point_name = "grpc"

--- a/solarwinds_apm/exporter.py
+++ b/solarwinds_apm/exporter.py
@@ -168,7 +168,7 @@ class SolarWindsSpanExporter(SpanExporter):
             # Some OTel instrumentation libraries are named not exactly
             # the same as the instrumented libraries!
             # https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/README.md
-            if framework == "aiohttp-client":
+            if framework == "aiohttp_client":
                 framework = "aiohttp"
             elif framework == "system_metrics":
                 framework = "psutil"

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -799,7 +799,7 @@ class Test_SolarWindsSpanExporter():
             mock_event,
             mock_create_event,
             mock_sys_modules,
-            "opentelemetry.instrumentation.aiohttp-client",
+            "opentelemetry.instrumentation.aiohttp_client",
             "Python.aiohttp.Version",
             "4.5.6",
         )


### PR DESCRIPTION
This is a typo bugfix so that setting span attribute (event info) `Python.aiohttp.version` stops failing. This also stops this message from logging at every export of aiohttp client spans:

```
2023-02-17 23:13:31,732 [ solarwinds_apm.exporter WARNING  p#1.140602549180160] Version lookup of aiohttp_client failed, so skipping: No module named 'aiohttp_client'
```

tox tests pass on this PR. Exported test traces look ok on [SWO](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/97C0BA508EBC35465B30B16288AE291D/E7AD9949E5667C14/details/breakdown/D503276EA2A76ED4/rawData) and [AO](https://my.appoptics.com/apm/123092/services/asgi_app_ot/traces/0187432070FC0EE11138EC9300E224C300000000/span/31D7820D5A06782C), with the `HTTP GET` spans now including `Python.aiohttp.version`.