### PR TITLE
PoC: Add request_hook to all loaded instr libraries

### DIFF
--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -6,19 +6,25 @@
 
 """Module to configure OpenTelemetry to work with SolarWinds backend"""
 
+import logging
 from os import environ
+from pkg_resources import EntryPoint
+from types import MappingProxyType
 
 from opentelemetry.environment_variables import (
     OTEL_PROPAGATORS,
     OTEL_TRACES_EXPORTER,
 )
 from opentelemetry.instrumentation.distro import BaseDistro
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 
 from solarwinds_apm.apm_constants import (
     INTL_SWO_DEFAULT_PROPAGATORS,
     INTL_SWO_DEFAULT_TRACES_EXPORTER,
 )
 
+
+logger = logging.getLogger(__name__)
 
 class SolarWindsDistro(BaseDistro):
     """OpenTelemetry Distro for SolarWinds reporting environment"""
@@ -31,3 +37,37 @@ class SolarWindsDistro(BaseDistro):
         environ.setdefault(
             OTEL_PROPAGATORS, ",".join(INTL_SWO_DEFAULT_PROPAGATORS)
         )
+
+    def load_instrumentor(  # pylint: disable=no-self-use
+        self, entry_point: EntryPoint, **kwargs
+    ):
+        """
+        Override of BaseDistro method that loads and instrument() of all installed OTel instrumentation libraries.   
+        """
+        def request_hook(span, request):
+            """
+            request_hook for instrumentation libraries that use them.
+            Edits attributes of spans created from receiving requests.
+
+            See also Django usage
+            https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py#L124-L141
+            """
+            logger.debug("request_hook received span:")
+            logger.debug("type %s", type(span))
+            logger.debug("name %s", span.name)
+            logger.debug("kind %s", span.kind)
+            logger.debug("attributes %s", span.attributes)
+            logger.debug("resource %s", span.resource)
+            logger.debug("request_hook received Django request:")
+            logger.debug("path %s", request.path)
+            logger.debug("headers %s", request.headers)
+
+            new_attributes = {"request-hook-foo": "some-bar-value"}
+            for attr_k, attr_v in span.attributes.items():
+                new_attributes[attr_k] = attr_v
+            span.set_attributes(MappingProxyType(new_attributes))
+            logger.debug("Updated span attributes is %s", span.attributes)
+
+        kwargs.update({"request_hook": request_hook})
+        instrumentor: BaseInstrumentor = entry_point.load()
+        instrumentor().instrument(**kwargs)


### PR DESCRIPTION
PoC: Adds `request_hook` kwarg to `instrument(**kwargs)` of all loaded instrumentation libraries at custom distro startup. Not for any ticket in particular and just for visualization. This might mean we have more opportunities for manipulating span creation in addition to what I've written in the doc section [How-do-OTel-Python-spans-get-created](https://swicloud.atlassian.net/wiki/spaces/NIT/pages/2867726621/NH+Python+Troubleshooting#%E2%80%9CHow-do-OTel-Python-spans-get-created?%E2%80%9D)!

Some but not all OTel Python instrumentation libraries call its received `request_hook` method "right after a span is created for a request". For [Django ](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py#L124-L141)at least, the span at time of `request_hook` is mutable `_Span` and we can change its attributes!

Example trace, where the `home_a_reentry/`, `another/`, and `home_b/` server spans include the arbitrary `request-hook-foo` attribute added to them by our `request_hook` method: https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/42FA5A3869B78465B239FAD568A76BCC/04A0226E0217181C/details/breakdown

I don't think this can be used for transaction filtering by way of early `DROP` because (a) the span has already been created, and (b) anything a `request_hook` method returns won't be used (how Django calls it [here](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/middleware/otel_middleware.py#L276-L279)). So returning a `NonRecordingSpan` can't drop the trace (I've tried this and we still get the [same full trace](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/E48035157AF488D5DAC3785D8E407169/020CC45EC71DC6D1/details/breakdown)).