### PR TITLE
Testrelease 0.8.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.8.1...HEAD)
-### Changed
-- Fixed noisy trace state KV deletion attempts when key not present ([#121](https://github.com/solarwindscloud/solarwinds-apm-python/pull/121))
+## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.8.2...HEAD)
 
+## [0.8.2.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.8.2) - 2023-03-13
 ### Changed
-- Bugfix: fix version lookup failures for instrumented aiohttp library ([#122](https://github.com/solarwindscloud/solarwinds-apm-python/pull/122))
+- Bugfix: fixed noisy trace state KV deletion attempts when key not present ([#121](https://github.com/solarwindscloud/solarwinds-apm-python/pull/121))
+- Bugfix: fixed version lookup failures for instrumented aiohttp library ([#122](https://github.com/solarwindscloud/solarwinds-apm-python/pull/122))
 
 ## [0.8.1](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.8.1) - 2023-03-08
 ### Changed

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.8.1"
+__version__ = "0.8.2.0"


### PR DESCRIPTION
Testrelease 0.8.2.0. Updates since 0.8.1:

```
### Changed
- Bugfix: fixed noisy trace state KV deletion attempts when key not present ([#121](https://github.com/solarwindscloud/solarwinds-apm-python/pull/121))
- Bugfix: fixed version lookup failures for instrumented aiohttp library ([#122](https://github.com/solarwindscloud/solarwinds-apm-python/pull/122))
```

Published as solarwinds-apm 0.8.2.0 on TestPyPI: https://test.pypi.org/project/solarwinds-apm/0.8.2.0/

tox tests pass on this PR. Install tests: https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/4389822972

Test traces:
* [NH Django](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/CE52D13639C6672A1BA5BA0C61DF3A6B/94EC4A3389FC7FE4/details/breakdown)
* [NH ASGI](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/4EA99911B75B87AEC2AC06C0168316DB/82AA46E52DF9601E/details/breakdown)
* [AO Django](https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/CC71D0C7A561656E90467357A0F2E70E00000000/details)
* [AO ASGI](https://my.appoptics.com/apm/123092/services/asgi_app_ot/traces/55664771FFF711B5F52D94D302495A5900000000/details)