### PR TITLE
NH-36210 Bugfix set_transaction_name when agent_enabled False + linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.8.2...HEAD)
 
+- Bugfix: fixed errors at API `set_transaction_name` calls when APM library tracing disabled ([#126](https://github.com/solarwindscloud/solarwinds-apm-python/pull/126))
+
 ## [0.8.2](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.8.2) - 2023-03-13
 ### Changed
 - Bugfix: fixed noisy trace state KV deletion attempts when key not present ([#121](https://github.com/solarwindscloud/solarwinds-apm-python/pull/121))

--- a/solarwinds_apm/api/__init__.py
+++ b/solarwinds_apm/api/__init__.py
@@ -8,7 +8,7 @@ import logging
 from typing import Any
 
 from opentelemetry import baggage
-from opentelemetry.trace import get_tracer_provider
+from opentelemetry.trace import get_tracer_provider, NoOpTracerProvider
 
 from solarwinds_apm.apm_constants import (
     INTL_SWO_CURRENT_SPAN_ID,
@@ -41,6 +41,13 @@ def set_transaction_name(custom_name: str) -> bool:
      from solarwinds_apm.api import set_transaction_name
      result = set_transaction_name("my-foo-name")
     """
+    if isinstance(get_tracer_provider(), NoOpTracerProvider):
+        logger.debug(
+            "Cannot cache custom transaction name %s because agent not enabled; ignoring",
+            custom_name,
+        )
+        return False
+
     # Assumes TracerProvider's active span processor is SynchronousMultiSpanProcessor
     # or ConcurrentMultiSpanProcessor
     span_processors = (

--- a/solarwinds_apm/api/__init__.py
+++ b/solarwinds_apm/api/__init__.py
@@ -8,13 +8,15 @@ import logging
 from typing import Any
 
 from opentelemetry import baggage
-from opentelemetry.trace import get_tracer_provider, NoOpTracerProvider
+from opentelemetry.trace import NoOpTracerProvider, get_tracer_provider
 
 from solarwinds_apm.apm_constants import (
     INTL_SWO_CURRENT_SPAN_ID,
     INTL_SWO_CURRENT_TRACE_ID,
 )
 from solarwinds_apm.apm_oboe_codes import OboeReadyCode
+
+# pylint: disable=import-error,no-name-in-module
 from solarwinds_apm.extension.oboe import Context
 from solarwinds_apm.inbound_metrics_processor import (
     SolarWindsInboundMetricsSpanProcessor,

--- a/solarwinds_apm/api/__init__.py
+++ b/solarwinds_apm/api/__init__.py
@@ -37,7 +37,7 @@ def set_transaction_name(custom_name: str) -> bool:
     :custom_name:str, custom transaction name to apply
 
     :return:
-    bool True for successful name assignment, False for not
+    bool True
 
     :Example:
      from solarwinds_apm.api import set_transaction_name
@@ -48,7 +48,7 @@ def set_transaction_name(custom_name: str) -> bool:
             "Cannot cache custom transaction name %s because agent not enabled; ignoring",
             custom_name,
         )
-        return False
+        return True
 
     # Assumes TracerProvider's active span processor is SynchronousMultiSpanProcessor
     # or ConcurrentMultiSpanProcessor
@@ -63,7 +63,7 @@ def set_transaction_name(custom_name: str) -> bool:
 
     if not inbound_processor:
         logger.error("Could not find configured InboundMetricsSpanProcessor.")
-        return False
+        return True
 
     entry_trace_id = baggage.get_baggage(INTL_SWO_CURRENT_TRACE_ID)
     entry_span_id = baggage.get_baggage(INTL_SWO_CURRENT_SPAN_ID)
@@ -72,7 +72,7 @@ def set_transaction_name(custom_name: str) -> bool:
             "Cannot cache custom transaction name %s because OTel service entry span not started; ignoring",
             custom_name,
         )
-        return False
+        return True
     trace_span_id = f"{entry_trace_id}-{entry_span_id}"
     inbound_processor.apm_txname_manager[trace_span_id] = custom_name
     logger.debug(

--- a/solarwinds_apm/api/__init__.py
+++ b/solarwinds_apm/api/__init__.py
@@ -37,7 +37,7 @@ def set_transaction_name(custom_name: str) -> bool:
     :custom_name:str, custom transaction name to apply
 
     :return:
-    bool True
+    bool True for successful name assignment, False for not
 
     :Example:
      from solarwinds_apm.api import set_transaction_name
@@ -48,7 +48,7 @@ def set_transaction_name(custom_name: str) -> bool:
             "Cannot cache custom transaction name %s because agent not enabled; ignoring",
             custom_name,
         )
-        return True
+        return False
 
     # Assumes TracerProvider's active span processor is SynchronousMultiSpanProcessor
     # or ConcurrentMultiSpanProcessor
@@ -63,7 +63,7 @@ def set_transaction_name(custom_name: str) -> bool:
 
     if not inbound_processor:
         logger.error("Could not find configured InboundMetricsSpanProcessor.")
-        return True
+        return False
 
     entry_trace_id = baggage.get_baggage(INTL_SWO_CURRENT_TRACE_ID)
     entry_span_id = baggage.get_baggage(INTL_SWO_CURRENT_SPAN_ID)
@@ -72,7 +72,7 @@ def set_transaction_name(custom_name: str) -> bool:
             "Cannot cache custom transaction name %s because OTel service entry span not started; ignoring",
             custom_name,
         )
-        return True
+        return False
     trace_span_id = f"{entry_trace_id}-{entry_span_id}"
     inbound_processor.apm_txname_manager[trace_span_id] = custom_name
     logger.debug(

--- a/solarwinds_apm/api/__init__.py
+++ b/solarwinds_apm/api/__init__.py
@@ -48,7 +48,7 @@ def set_transaction_name(custom_name: str) -> bool:
             "Cannot cache custom transaction name %s because agent not enabled; ignoring",
             custom_name,
         )
-        return False
+        return True
 
     # Assumes TracerProvider's active span processor is SynchronousMultiSpanProcessor
     # or ConcurrentMultiSpanProcessor

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -33,6 +33,8 @@ from solarwinds_apm.apm_constants import (
 )
 from solarwinds_apm.apm_noop import Context as NoopContext
 from solarwinds_apm.certs.ao_issuer_ca import get_public_cert
+
+# pylint: disable=import-error,no-name-in-module
 from solarwinds_apm.extension.oboe import Context
 
 logger = logging.getLogger(__name__)

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -45,6 +45,8 @@ from solarwinds_apm.apm_fwkv_manager import SolarWindsFrameworkKvManager
 from solarwinds_apm.apm_noop import Reporter as NoopReporter
 from solarwinds_apm.apm_oboe_codes import OboeReporterCode
 from solarwinds_apm.apm_txname_manager import SolarWindsTxnNameManager
+
+# pylint: disable=import-error,no-name-in-module
 from solarwinds_apm.extension.oboe import Config, Context, Metadata, Reporter
 from solarwinds_apm.inbound_metrics_processor import (
     SolarWindsInboundMetricsSpanProcessor,

--- a/solarwinds_apm/exporter.py
+++ b/solarwinds_apm/exporter.py
@@ -26,6 +26,8 @@ from solarwinds_apm.apm_constants import (
 )
 from solarwinds_apm.apm_noop import Context as NoopContext
 from solarwinds_apm.apm_noop import Metadata as NoopMetadata
+
+# pylint: disable=import-error,no-name-in-module
 from solarwinds_apm.extension.oboe import Context, Metadata
 from solarwinds_apm.w3c_transformer import W3CTransformer
 

--- a/solarwinds_apm/inbound_metrics_processor.py
+++ b/solarwinds_apm/inbound_metrics_processor.py
@@ -17,6 +17,8 @@ from solarwinds_apm.apm_constants import (
     INTL_SWO_CURRENT_TRACE_ID,
 )
 from solarwinds_apm.apm_noop import Span as NoopSpan
+
+# pylint: disable=import-error,no-name-in-module
 from solarwinds_apm.extension.oboe import Span
 
 if TYPE_CHECKING:

--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -33,6 +33,8 @@ from solarwinds_apm.apm_constants import (
     INTL_SWO_X_OPTIONS_RESPONSE_KEY,
 )
 from solarwinds_apm.apm_noop import Context as NoopContext
+
+# pylint: disable=import-error,no-name-in-module
 from solarwinds_apm.extension.oboe import Context
 from solarwinds_apm.traceoptions import XTraceOptions
 from solarwinds_apm.w3c_transformer import W3CTransformer

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.8.3.0"
+__version__ = "0.8.3.1"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.8.2"
+__version__ = "0.8.3.0"


### PR DESCRIPTION
Fixes errors at customer code calls to API `set_transaction_name` when `agent_enabled` False!:

```
  File "/app/main.py", line 79, in reentry_async
    set_transaction_name("custom-name-that-shouldnt-be-used")
  File "/solarwinds-apm-python/solarwinds_apm/api/__init__.py", line 48, in set_transaction_name
    get_tracer_provider()._active_span_processor._span_processors
AttributeError: 'NoOpTracerProvider' object has no attribute '_active_span_processor'
```

No longer errors when e.g. `Incorrect service key format.`, testbed ASGI app is run, and `curl -v http://0.0.0.0:8005/reentry_async` which includes calls to `set_transaction_name`.

Trace still exports when agent enabled and `set_transaction_name` calls work on entry spans: https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/0E45BB4C6DD24EB273C1323B6C28D9EF/33278EA380018F84/details/breakdown/33278EA380018F84/rawData

Also fixes several linting errors that started happening with the liboboe imports (updated to latest tox dependency virtualenv `'20.20.0'->'20.21.0'`) by ignoring them.

Please let me know what you think!