### PR TITLE
NH-36223 Testrelease 0.8.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.8.2...HEAD)
+## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.8.3...HEAD)
 
+## [0.8.3.2](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.8.3) - 2023-03-20
 ### Changed
 - Bugfix: fixed errors at API `set_transaction_name` calls when APM library tracing disabled ([#126](https://github.com/solarwindscloud/solarwinds-apm-python/pull/126))
 - SolarWinds c-lib 12.1.0, for enhanced metadata retrieval, skipping metrics HTTP status if unavailable, fixed threading locking issue ([#127](https://github.com/solarwindscloud/solarwinds-apm-python/pull/127))

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.8.3.3"
+__version__ = "0.8.3.4"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.8.3.1"
+__version__ = "0.8.3.2"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.8.3.2"
+__version__ = "0.8.3.3"

--- a/tests/docker/install/install_tests.sh
+++ b/tests/docker/install/install_tests.sh
@@ -113,7 +113,6 @@ function check_agent_startup(){
 
     TEST_EXP_LOG_MESSAGES=(
     ">> SSL Reporter using host='apm.collector.cloud.solarwinds.com' port='443' log='' clientid='inva...7890:servicename' buf=1000 maxTransactions='200' flushMaxWaitTime='5000' eventsFlushInterval='2' maxRequestSizeBytes='3000000' proxy=''"
-    "Warning: There is an problem getting the API token authorized. Metrics and tracing for this agent are currently disabled. If you'd like to learn more about resolving this issue, please contact technicalsupport@solarwinds.com."
     )
 
     # unset stop on error so we can catch debug messages in case of failures

--- a/tests/docker/install/install_tests.sh
+++ b/tests/docker/install/install_tests.sh
@@ -113,6 +113,7 @@ function check_agent_startup(){
 
     TEST_EXP_LOG_MESSAGES=(
     ">> SSL Reporter using host='apm.collector.cloud.solarwinds.com' port='443' log='' clientid='inva...7890:servicename' buf=1000 maxTransactions='200' flushMaxWaitTime='5000' eventsFlushInterval='2' maxRequestSizeBytes='3000000' proxy=''"
+    "Warning: There is an problem getting the API token authorized. Metrics and tracing for this agent are currently disabled. If you'd like to learn more about resolving this issue, please contact technicalsupport@solarwinds.com."
     )
 
     # unset stop on error so we can catch debug messages in case of failures

--- a/tests/docker/install/install_tests.sh
+++ b/tests/docker/install/install_tests.sh
@@ -113,7 +113,7 @@ function check_agent_startup(){
 
     TEST_EXP_LOG_MESSAGES=(
     ">> SSL Reporter using host='apm.collector.cloud.solarwinds.com' port='443' log='' clientid='inva...7890:servicename' buf=1000 maxTransactions='200' flushMaxWaitTime='5000' eventsFlushInterval='2' maxRequestSizeBytes='3000000' proxy=''"
-    "Warning: There is an problem getting the API token authorized. Metrics and tracing for this agent are currently disabled. If you'd like to learn more about resolving this issue, please contact technicalsupport@solarwinds.com."
+    "Warning: There is an problem getting the API token authorized. Metrics and tracing for this agent are currently disabled. If you'd like to learn more about resolving this issue, please contact support (see https://support.solarwinds.com/working-with-support)."
     )
 
     # unset stop on error so we can catch debug messages in case of failures


### PR DESCRIPTION
Testrelease 0.8.3.4 of Python APM library. Took a few tries with the install tests' checked warning message contact info update.

tox tests on this PR pass. Test traces:

* [NH Django](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/3B6508581B9C9E91ACB3E50912F3D3F9/988B3E723C40636A/details/breakdown)
* [NH FastAPI](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/3579DF13724B7542C05431217FA72495/819616850F00443F/details/breakdown)
* [AO Django](https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/C32A3D92F9BAD2658C354566C76F8D2000000000/details)
* [AO FastAPI](https://my.appoptics.com/apm/123092/services/asgi_app_ot/traces/6F905F9575E38677D75200B426B63FAD00000000/details)

Test published as [TestPyPI 0.8.3.4](https://test.pypi.org/project/solarwinds-apm/0.8.3.4/). [Install tests pass](https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/4482886406).