### PR TITLE
NH-36371 Bump Otel Python 1.17.0/0.38b0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
-opentelemetry-test-utils==0.37b0
-opentelemetry-instrumentation-flask==0.37b0
-opentelemetry-instrumentation-requests==0.37b0
+opentelemetry-test-utils==0.38b0
+opentelemetry-instrumentation-flask==0.38b0
+opentelemetry-instrumentation-requests==0.38b0
 pytest
 pytest-cov
 pytest-mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,9 +23,9 @@ classifiers =
 [options]
 python_requires = >=3.7
 install_requires =
-    opentelemetry-api == 1.16.0
-    opentelemetry-sdk == 1.16.0
-    opentelemetry-instrumentation == 0.37b0
+    opentelemetry-api == 1.17.0
+    opentelemetry-sdk == 1.17.0
+    opentelemetry-instrumentation == 0.38b0
 packages = solarwinds_apm, solarwinds_apm.api, solarwinds_apm.certs, solarwinds_apm.extension
 
 [options.package_data]

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.8.3"
+__version__ = "0.8.4.2"


### PR DESCRIPTION
Bump Python APM to Otel 1.17.0/0.38b0. Goes with this [testbed PR](https://github.com/appoptics/solarwinds-apm-python-testbed/pull/57).

tox tests on this PR pass.

Test traces:
* [Django NH prod](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/3D3A5439D2FD9990863E5E6DDFC9C5D1/7E7C7DF82894A2DE/details/breakdown)
* [FastAPI NH prod](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/BCE5FF0F19D2E3ADF54E8DEF29AFD068/8F1DB0064F27CC7A/details/breakdown)
* [Django AO prod](https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/EE3F61FF60587AA5881BB57A5DBBAAB300000000/details)
* [FastAPI NH prod](https://my.appoptics.com/apm/123092/services/asgi_app_ot/traces/B8AAC59F1337E377DF5F3A7B5246377400000000/details)

Testreleased as [TestPyPI 0.8.4.2](https://test.pypi.org/project/solarwinds-apm/0.8.4.2/). [Install tests from registry pass.](https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/4672207848)