### PR TITLE
NH-34752 Update span layer, little refactor

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -485,6 +485,13 @@ class SolarWindsApmConfig:
 
     def update_with_cnf_file(self) -> None:
         """Update the settings with the config file (json), if any."""
+
+        def _snake_to_camel_case(key):
+            key_parts = key.split("_")
+            camel_head = key_parts[0]
+            camel_body = ''.join(part.title() for part in key_parts[1:])
+            return f"{camel_head}{camel_body}"
+
         cnf_filepath = os.environ.get(
             "SW_APM_CONFIG_FILE", "./solarwinds-apm-config.json"
         )
@@ -514,9 +521,8 @@ class SolarWindsApmConfig:
         available_cnf = set(self.__config.keys())
         # TODO after alpha: is_lambda
         for key in available_cnf:
-            cnf_key_parts = key.split("_")
-            cnf = f"{cnf_key_parts[0]}{''.join(part.title() for part in cnf_key_parts[1:])}"
-            val = cnf_dict.get(cnf)
+            # Use internal snake_case config keys to check JSON config file camelCase keys
+            val = cnf_dict.get(_snake_to_camel_case(key))
             if val is not None:
                 self._set_config_value(key, val)
 

--- a/solarwinds_apm/exporter.py
+++ b/solarwinds_apm/exporter.py
@@ -101,7 +101,8 @@ class SolarWindsSpanExporter(SpanExporter):
                 evt = self.context.createEntry(md, int(span.start_time / 1000))
                 self._add_info_transaction_name(span, evt)
 
-            evt.addInfo("Layer", span.name)
+            layer = f"{span.kind.name}:{span.name}"
+            evt.addInfo("Layer", layer)
             evt.addInfo(self._SW_SPAN_KIND, span.kind.name)
             evt.addInfo("Language", "Python")
             self._add_info_instrumentation_scope(span, evt)
@@ -117,7 +118,7 @@ class SolarWindsSpanExporter(SpanExporter):
                     self._report_info_event(event)
 
             evt = self.context.createExit(int(span.end_time / 1000))
-            evt.addInfo("Layer", span.name)
+            evt.addInfo("Layer", layer)
             self.reporter.sendReport(evt, False)
 
     def _add_info_transaction_name(self, span, evt) -> None:


### PR DESCRIPTION
Updates Python APM-produced span layers to be `<KIND>:<NAME>` and match what Java APM does. This is a prerequisite for implementing transaction filtering.

[Example trace](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/C04D893DA4CE836EB8D19C2E7BB29AB4/44B8C218C7D288B3/details/breakdown) before this update uses these span layers:

1. `home_a/`
2. `home_b/`
3. `HTTP GET`
4. `manual_instrumentation_django_a`
5. `manual_instrumentation_django_b`
6. `postgresql`
7. `sqlite`

[Example trace](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/F281979E8D386F5956D45E42001EAB9F/083D925736C37861/details/breakdown) after this update uses:

1. `SERVER:home_a/`
2. `SERVER:home_b/`
3. `CLIENT:HTTP GET`
4. `INTERNAL:manual_instrumentation_django_a`
5. `INTERNAL:manual_instrumentation_django_b`
6. `postgresql`
7. `sqlite`

6 and 7 are expected as per improvements based on mrQ's requests (see also [Slack thread](https://swicloud.slack.com/archives/C2J43PE4R/p1681857025522799)).

This PR also does a little refactor of config file reading based on [this PR comment](https://github.com/solarwindscloud/solarwinds-apm-python/pull/133#discussion_r1169296592).

Please let me know if any questions/suggestions!