### PR TITLE
NH-34752 Parse txn filters and calculate tracing mode

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -569,15 +569,16 @@ class SolarWindsApmConfig:
                     )
                     continue
 
+                txn_filter_re = None
                 try:
-                    re.compile(filter["regex"])
+                    txn_filter_re = re.compile(filter["regex"])
                 except re.error:
                     logger.warning(
                         "Transaction filter regex invalid. Ignoring: %s",
                         filter,
                     )
                     continue
-                txn_filter["regex"] = filter["regex"]
+                txn_filter["regex"] = txn_filter_re
                 self.__config["transaction_filters"].append(txn_filter)
 
         logger.debug(

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -576,6 +576,7 @@ class SolarWindsApmConfig:
                         "Transaction filter regex invalid. Ignoring: %s",
                         filter,
                     )
+                    continue
                 txn_filter["regex"] = filter["regex"]
                 self.__config["transaction_filters"].append(txn_filter)
 

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -561,6 +561,14 @@ class SolarWindsApmConfig:
                         filter,
                     )
                     continue
+
+                if not len(filter["regex"]) > 0:
+                    logger.warning(
+                        "Transaction filter regex must not be empty. Ignoring: %s",
+                        filter,
+                    )
+                    continue
+
                 try:
                     re.compile(filter["regex"])
                 except re.error:

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -579,10 +579,6 @@ class SolarWindsApmConfig:
                 txn_filter["regex"] = filter["regex"]
                 self.__config["transaction_filters"].append(txn_filter)
 
-                # TODO (NH-34752) Confirm handling web request filtering after instrumentation
-                #      libraries updated so http attributes available at should_sample
-                #      https://github.com/open-telemetry/opentelemetry-python-contrib/issues/936               
-
         logger.debug(
             "Set up transaction filters: %s",
             self.__config["transaction_filters"],

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -662,9 +662,7 @@ class SolarWindsApmConfig:
                     raise ValueError
                 oboe_trace_mode = OboeTracingMode.get_oboe_trace_mode(val)
                 self.__config[key] = oboe_trace_mode
-                self.context.setTracingMode(
-                    oboe_trace_mode
-                )
+                self.context.setTracingMode(oboe_trace_mode)
             elif keys == ["trigger_trace"]:
                 if not isinstance(val, str):
                     raise ValueError

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -532,7 +532,7 @@ class SolarWindsApmConfig:
         """Update configured transaction_filters using config dict"""
         txn_settings = cnf_dict.get("transactionSettings")
         if not txn_settings or not isinstance(txn_settings, list):
-            logger.error(
+            logger.warning(
                 "Transaction filters must be a non-empty list of filters. Ignoring."
             )
             return
@@ -540,7 +540,7 @@ class SolarWindsApmConfig:
             if set(filter) != set(["regex", "tracing"]) or filter[
                 "tracing"
             ] not in ["enabled", "disabled"]:
-                logger.error(
+                logger.warning(
                     "Invalid transaction filter rule. Ignoring: %s", filter
                 )
                 continue

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -658,9 +658,10 @@ class SolarWindsApmConfig:
                     val = "enabled" if val == "always" else "disabled"
                 if val not in ["enabled", "disabled"]:
                     raise ValueError
-                self.__config[key] = val
+                oboe_trace_mode = OboeTracingMode.get_oboe_trace_mode(val)
+                self.__config[key] = oboe_trace_mode
                 self.context.setTracingMode(
-                    OboeTracingMode.get_oboe_trace_mode(val)
+                    oboe_trace_mode
                 )
             elif keys == ["trigger_trace"]:
                 if not isinstance(val, str):

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -89,8 +89,8 @@ class SolarWindsApmConfig:
         self.__config = {}
         # Update the config with default values
         self.__config = {
-            # 'tracing_mode' is unset by default and not supported in NH Python
-            "tracing_mode": None,
+            # 'tracing_mode' is unset by default
+            "tracing_mode": OboeTracingMode.get_oboe_trace_mode("unset"),
             # 'trigger_trace' is enabled by default
             "trigger_trace": "enabled",
             "collector": "",  # the collector address in host:port format.

--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -75,10 +75,23 @@ class _SwSampler(Sampler):
     def get_description(self) -> str:
         return "SolarWinds custom opentelemetry sampler"
 
+    def calculate_tracing_mode(
+        self,
+        name: str,
+        kind: SpanKind = None,
+        attributes: Attributes = None,
+    ) -> int:
+        """Calculates tracing mode per-request or global mode, if set"""
+        # TODO implement this
+        return self._UNSET
+
     # pylint: disable=too-many-locals
     def calculate_liboboe_decision(
         self,
         parent_span_context: SpanContext,
+        name: str,
+        kind: SpanKind = None,
+        attributes: Attributes = None,
         xtraceoptions: Optional[XTraceOptions] = None,
     ) -> dict:
         """Calculates oboe trace decision based on parent span context and APM config."""
@@ -91,8 +104,11 @@ class _SwSampler(Sampler):
             INTL_SWO_TRACESTATE_KEY
         )
 
-        # 'tracing_mode' is not supported in NH Python, so give as unset
-        tracing_mode = self._UNSET
+        tracing_mode = self.calculate_tracing_mode(
+            name,
+            kind,
+            attributes,
+        )
 
         trigger_trace_mode = OboeTracingMode.get_oboe_trigger_trace_mode(
             self.apm_config.get("trigger_trace")
@@ -486,7 +502,7 @@ class _SwSampler(Sampler):
         xtraceoptions = XTraceOptions(parent_context)
 
         liboboe_decision = self.calculate_liboboe_decision(
-            parent_span_context, xtraceoptions
+            parent_span_context, name, kind, attributes, xtraceoptions
         )
 
         # Always calculate trace_state for propagation

--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -99,7 +99,7 @@ class _SwSampler(Sampler):
 
                 # Only matches span kind and name at this time
                 identifier = f"{kind.name}:{name}"
-                if re.search(txn_filter.get("regex"), identifier):
+                if txn_filter.get("regex").search(identifier):
                     logger.debug("Got a match for identifier %s", identifier)
                     logger.debug(
                         "Setting tracing_mode as %s",

--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -11,7 +11,6 @@ The custom sampler will fetch sampling configurations for the SolarWinds backend
 
 import enum
 import logging
-import re
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Optional, Sequence
 

--- a/tests/unit/test_apm_config.py
+++ b/tests/unit/test_apm_config.py
@@ -650,7 +650,7 @@ class TestSolarWindsApmConfig:
     def test_set_config_value_default_tracing_mode(self, caplog, mock_env_vars):
         test_config = apm_config.SolarWindsApmConfig()
         test_config._set_config_value("tracing_mode", "not-valid-mode")
-        assert test_config.get("tracing_mode") == None
+        assert test_config.get("tracing_mode") == -1
         assert "Ignore config option" in caplog.text
 
     # pylint:disable=unused-argument

--- a/tests/unit/test_sampler/fixtures/sampler.py
+++ b/tests/unit/test_sampler/fixtures/sampler.py
@@ -2,17 +2,22 @@ import pytest
 
 from solarwinds_apm.sampler import _SwSampler
 
+def side_effect_fn(param):
+    if param == "tracing_mode":
+        return -1
+    elif param == "transaction_filters":
+        return []
+
 @pytest.fixture(name="sw_sampler")
 def fixture_swsampler(mocker):
     mock_apm_config = mocker.Mock()
     mock_get = mocker.Mock(
-        return_value=1  # enabled
+        side_effect=side_effect_fn
     )
     mock_apm_config.configure_mock(
         **{
             "agent_enabled": True,
             "get": mock_get,
-            "tracing_mode": None,  # mapped to -1
         }
     )
     return _SwSampler(mock_apm_config)

--- a/tests/unit/test_sampler/test_sampler.py
+++ b/tests/unit/test_sampler/test_sampler.py
@@ -196,6 +196,9 @@ class Test_SwSampler():
     ):
         sw_sampler.calculate_liboboe_decision(
             parent_span_context_invalid,
+            'foo',
+            None,
+            {'foo': 'bar'},
             mock_xtraceoptions_signed_tt,
         )
         solarwinds_apm.extension.oboe.Context.getDecisions.assert_called_once_with(
@@ -219,6 +222,9 @@ class Test_SwSampler():
     ):
         sw_sampler.calculate_liboboe_decision(
             parent_span_context_valid_remote,
+            'foo',
+            None,
+            {'foo': 'bar'},
         )
         solarwinds_apm.extension.oboe.Context.getDecisions.assert_called_once_with(
             "foo-bar",
@@ -574,6 +580,9 @@ class Test_SwSampler():
 
         _SwSampler.calculate_liboboe_decision.assert_called_once_with(
             "my_span_context",
+            'foo',
+            None,
+            {'foo': 'bar'},
             mock_xtraceoptions
         )
         _SwSampler.calculate_trace_state.assert_called_once_with(


### PR DESCRIPTION
This is more steps towards implementing transaction filtering:

1. Update `update_transaction_filters` in the Configurator to use existing helper `OboeTracingMode.get_oboe_trace_mode` to map filter's `tracing` to int for liboboe
2. Also more checks for valid filter's `regex` values
3. Adds `calculate_tracing_mode` used by sampler to apply per-request filter or "global" `tracing_mode` that can also be configured.

This only filters for span `<kind>:<name>` right now because `http.*` attributes generated by instrumentation libraries are not yet available to the sampler, but this is gradually being implemented in [OTel #936](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/936).

Example basic config file JSON I'm using with Django A:
```
{
    "tracingMode": "enabled",
    "transactionSettings": [
        {
            "regex": "SERVER:another/",
            "tracing": "disabled"
        },
    ]
}
```

Next PRs:
* Add two-signal check ~~OR support for third filter component, signal (see Slack thread)~~ See https://github.com/solarwindscloud/solarwinds-apm-python/pull/137
* Add more unit tests
* Add web request filtering -- best tested when some [OTel #936](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/936) updates are merged and released
* infodev/customer docs update

Please let me know if any questions/suggestions!