### PR TITLE
NH-34752 Add construct_url for calculate_tracing_mode

### DIFF
--- a/solarwinds_apm/sampler.py
+++ b/solarwinds_apm/sampler.py
@@ -92,14 +92,19 @@ class _SwSampler(Sampler):
         #   https://github.com/open-telemetry/opentelemetry-python-contrib/issues/936
         if not attributes:
             return ""
+
+        url = ""
         scheme = attributes.get(SpanAttributes.HTTP_SCHEME)
         host = attributes.get(SpanAttributes.NET_HOST_NAME)
+        port = attributes.get(SpanAttributes.NET_HOST_PORT)
         target = attributes.get(SpanAttributes.HTTP_TARGET)
-        if scheme and host and target:
+        if scheme and host and target and port:
+            url = f"{scheme}://{host}:{port}{target}"
+            logger.debug("Constructed url for filtering: %s", url)
+        elif scheme and host and target:
             url = f"{scheme}://{host}{target}"
             logger.debug("Constructed url for filtering: %s", url)
-            return url
-        return ""
+        return url
 
     def calculate_tracing_mode(
         self,


### PR DESCRIPTION
Adds `construct_url` helper for `calculate_tracing_mode`. I've done it this way so that if there is a URL, it gets used as the identifier and the customer has no choice for filtering (see also [Slack thread](https://swicloud.slack.com/archives/C2J43PE4R/p1682363645105209?thread_ts=1682098813.423939&cid=C2J43PE4R)). At the moment it will always return empty string until a new version of `opentelemetry-python-contrib` is released, so more testing will come later. This is set to merge into https://github.com/solarwindscloud/solarwinds-apm-python/pull/136.