### PR TITLE
NH-34752 Add calculate_tracing_mode tests and fixture

### DIFF
--- a/tests/unit/test_sampler/fixtures/sampler.py
+++ b/tests/unit/test_sampler/fixtures/sampler.py
@@ -1,8 +1,12 @@
 import pytest
+import re
 
 from solarwinds_apm.sampler import _SwSampler
 
-def side_effect_fn(param):
+
+# Basic Sampler fixture =====================================
+
+def config_get(param):
     if param == "tracing_mode":
         return -1
     elif param == "transaction_filters":
@@ -12,7 +16,63 @@ def side_effect_fn(param):
 def fixture_swsampler(mocker):
     mock_apm_config = mocker.Mock()
     mock_get = mocker.Mock(
-        side_effect=side_effect_fn
+        side_effect=config_get
+    )
+    mock_apm_config.configure_mock(
+        **{
+            "agent_enabled": True,
+            "get": mock_get,
+        }
+    )
+    return _SwSampler(mock_apm_config)
+
+
+# Sampler fixtures with Transaction Filters =================
+
+def config_get_txn_filters(param):
+    if param == "tracing_mode":
+        return -1
+    elif param == "transaction_filters":
+        return [
+            {
+                "regex": re.compile("http://foo/bar"),
+                "tracing_mode": 1,
+            },
+            {
+                "regex": re.compile(r"http://foo/[a-z]*/bar"),
+                "tracing_mode": 1,
+            },
+            {
+                "regex": re.compile("http://foo/bar-baz"),
+                "tracing_mode": 1,
+            },
+            {
+                "regex": re.compile("http://foo/bar-baz"),
+                "tracing_mode": 0,
+            },
+            {
+                "regex": re.compile("CLIENT:foo"),
+                "tracing_mode": 1,
+            },
+            {
+                "regex": re.compile(r"CLIENT:f[a-z]*o"),
+                "tracing_mode": 1,
+            },
+            {
+                "regex": re.compile("CLIENT:foo_bar"),
+                "tracing_mode": 1,
+            },
+            {
+                "regex": re.compile("CLIENT:foo_bar"),
+                "tracing_mode": 0,
+            }
+        ]
+
+@pytest.fixture(name="sw_sampler_txnfilters")
+def fixture_swsampler_txnfilters(mocker):
+    mock_apm_config = mocker.Mock()
+    mock_get = mocker.Mock(
+        side_effect=config_get_txn_filters
     )
     mock_apm_config.configure_mock(
         **{

--- a/tests/unit/test_sampler/fixtures/sampler.py
+++ b/tests/unit/test_sampler/fixtures/sampler.py
@@ -1,17 +1,19 @@
 import pytest
 import re
+from typing import Any
 
 from solarwinds_apm.sampler import _SwSampler
 
 
 # Basic Sampler fixture =====================================
 
-def config_get(param):
+def config_get(param) -> Any:
     if param == "tracing_mode":
         return -1
     elif param == "transaction_filters":
         return []
-    return None
+    else:
+        return None
 
 @pytest.fixture(name="fixture_swsampler")
 def fixture_swsampler(mocker):
@@ -30,7 +32,7 @@ def fixture_swsampler(mocker):
 
 # Sampler fixtures with Transaction Filters =================
 
-def config_get_txn_filters(param):
+def config_get_txn_filters(param)  -> Any:
     if param == "tracing_mode":
         return -1
     elif param == "transaction_filters":
@@ -68,7 +70,8 @@ def config_get_txn_filters(param):
                 "tracing_mode": 0,
             }
         ]
-    return None
+    else:
+        return None
 
 @pytest.fixture(name="fixture_swsampler_txnfilters")
 def fixture_swsampler_txnfilters(mocker):

--- a/tests/unit/test_sampler/fixtures/sampler.py
+++ b/tests/unit/test_sampler/fixtures/sampler.py
@@ -11,8 +11,9 @@ def config_get(param):
         return -1
     elif param == "transaction_filters":
         return []
+    return None
 
-@pytest.fixture(name="sw_sampler")
+@pytest.fixture(name="fixture_swsampler")
 def fixture_swsampler(mocker):
     mock_apm_config = mocker.Mock()
     mock_get = mocker.Mock(
@@ -67,8 +68,9 @@ def config_get_txn_filters(param):
                 "tracing_mode": 0,
             }
         ]
+    return None
 
-@pytest.fixture(name="sw_sampler_txnfilters")
+@pytest.fixture(name="fixture_swsampler_txnfilters")
 def fixture_swsampler_txnfilters(mocker):
     mock_apm_config = mocker.Mock()
     mock_get = mocker.Mock(

--- a/tests/unit/test_sampler/test_sampler.py
+++ b/tests/unit/test_sampler/test_sampler.py
@@ -190,11 +190,11 @@ class Test_SwSampler():
 
     def test_calculate_liboboe_decision_root_span(
         self,
-        sw_sampler,
+        fixture_swsampler,
         parent_span_context_invalid,
         mock_xtraceoptions_signed_tt,
     ):
-        sw_sampler.calculate_liboboe_decision(
+        fixture_swsampler.calculate_liboboe_decision(
             parent_span_context_invalid,
             'foo',
             None,
@@ -216,11 +216,11 @@ class Test_SwSampler():
     # pylint:disable=unused-argument
     def test_calculate_liboboe_decision_parent_valid_remote(
         self,
-        sw_sampler,
+        fixture_swsampler,
         mock_traceparent_from_context,
         parent_span_context_valid_remote,
     ):
-        sw_sampler.calculate_liboboe_decision(
+        fixture_swsampler.calculate_liboboe_decision(
             parent_span_context_valid_remote,
             'foo',
             None,
@@ -238,67 +238,67 @@ class Test_SwSampler():
             None,
         )
 
-    def test_is_decision_continued_false(self, sw_sampler):
-        assert not sw_sampler.is_decision_continued({
+    def test_is_decision_continued_false(self, fixture_swsampler):
+        assert not fixture_swsampler.is_decision_continued({
             "rate": 0,
             "source": -1,
             "bucket_rate": -1,
             "bucket_cap": -1,
         })
-        assert not sw_sampler.is_decision_continued({
+        assert not fixture_swsampler.is_decision_continued({
             "rate": -1,
             "source": 0,
             "bucket_rate": -1,
             "bucket_cap": -1,
         })
-        assert not sw_sampler.is_decision_continued({
+        assert not fixture_swsampler.is_decision_continued({
             "rate": -1,
             "source": -1,
             "bucket_rate": 0,
             "bucket_cap": -1,
         })
-        assert not sw_sampler.is_decision_continued({
+        assert not fixture_swsampler.is_decision_continued({
             "rate": -1,
             "source": -1,
             "bucket_rate": -1,
             "bucket_cap": 0,
         })
 
-    def test_is_decision_continued_true(self, sw_sampler):
-        assert sw_sampler.is_decision_continued({
+    def test_is_decision_continued_true(self, fixture_swsampler):
+        assert fixture_swsampler.is_decision_continued({
             "rate": -1,
             "source": -1,
             "bucket_rate": -1,
             "bucket_cap": -1,
         })
 
-    def test_otel_decision_from_liboboe(self, sw_sampler):
-        assert sw_sampler.otel_decision_from_liboboe({
+    def test_otel_decision_from_liboboe(self, fixture_swsampler):
+        assert fixture_swsampler.otel_decision_from_liboboe({
             "do_metrics": 0,
             "do_sample": 0,
         }) == Decision.DROP
-        assert sw_sampler.otel_decision_from_liboboe({
+        assert fixture_swsampler.otel_decision_from_liboboe({
             "do_metrics": 1,
             "do_sample": 0,
         }) == Decision.RECORD_ONLY
-        assert sw_sampler.otel_decision_from_liboboe({
+        assert fixture_swsampler.otel_decision_from_liboboe({
             "do_metrics": 1,
             "do_sample": 1,
         }) == Decision.RECORD_AND_SAMPLE
         # Technically possible but we don't handle this
-        assert sw_sampler.otel_decision_from_liboboe({
+        assert fixture_swsampler.otel_decision_from_liboboe({
             "do_metrics": 0,
             "do_sample": 1,
         }) == Decision.RECORD_AND_SAMPLE
 
     def test_create_xtraceoptions_response_value_auth_valid_sig(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_auth_valid_sig,
         parent_span_context_valid_remote,
         mock_xtraceoptions_signed_tt,
     ):
-        response_val = sw_sampler.create_xtraceoptions_response_value(
+        response_val = fixture_swsampler.create_xtraceoptions_response_value(
             decision_auth_valid_sig,
             parent_span_context_valid_remote,
             mock_xtraceoptions_signed_tt,
@@ -307,12 +307,12 @@ class Test_SwSampler():
 
     def test_create_xtraceoptions_response_value_auth_invalid_sig(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_auth_invalid_sig,
         parent_span_context_valid_remote,
         mock_xtraceoptions_signed_tt,
     ):
-        response_val = sw_sampler.create_xtraceoptions_response_value(
+        response_val = fixture_swsampler.create_xtraceoptions_response_value(
             decision_auth_invalid_sig,
             parent_span_context_valid_remote,
             mock_xtraceoptions_signed_tt,
@@ -321,12 +321,12 @@ class Test_SwSampler():
 
     def test_create_xtraceoptions_response_value_tt_unauth_type_nonzero_root_span(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_not_auth_type_nonzero,
         parent_span_context_invalid,
         mock_xtraceoptions_signed_tt,
     ):
-        response_val = sw_sampler.create_xtraceoptions_response_value(
+        response_val = fixture_swsampler.create_xtraceoptions_response_value(
             decision_not_auth_type_nonzero,
             parent_span_context_invalid,
             mock_xtraceoptions_signed_tt,
@@ -335,12 +335,12 @@ class Test_SwSampler():
 
     def test_create_xtraceoptions_response_value_tt_unauth_type_nonzero_parent_span_remote(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_not_auth_type_nonzero,
         parent_span_context_valid_remote,
         mock_xtraceoptions_signed_tt,
     ):
-        response_val = sw_sampler.create_xtraceoptions_response_value(
+        response_val = fixture_swsampler.create_xtraceoptions_response_value(
             decision_not_auth_type_nonzero,
             parent_span_context_valid_remote,
             mock_xtraceoptions_signed_tt, 
@@ -349,12 +349,12 @@ class Test_SwSampler():
 
     def test_create_xtraceoptions_response_value_tt_unauth_type_zero_root_span(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_not_auth_type_zero,
         parent_span_context_invalid,
         mock_xtraceoptions_signed_tt,
     ):
-        response_val = sw_sampler.create_xtraceoptions_response_value(
+        response_val = fixture_swsampler.create_xtraceoptions_response_value(
             decision_not_auth_type_zero,
             parent_span_context_invalid,
             mock_xtraceoptions_signed_tt,
@@ -363,12 +363,12 @@ class Test_SwSampler():
 
     def test_create_xtraceoptions_response_value_tt_unauth_type_zero_parent_span_remote(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_not_auth_type_zero,
         parent_span_context_valid_remote,
         mock_xtraceoptions_signed_tt,
     ):
-        response_val = sw_sampler.create_xtraceoptions_response_value(
+        response_val = fixture_swsampler.create_xtraceoptions_response_value(
             decision_not_auth_type_zero,
             parent_span_context_valid_remote,
             mock_xtraceoptions_signed_tt,    
@@ -377,12 +377,12 @@ class Test_SwSampler():
 
     def test_create_xtraceoptions_response_value_not_tt_unauth(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_not_auth_type_nonzero,
         parent_span_context_invalid,
         mock_xtraceoptions_signed_not_tt,
     ):
-        response_val = sw_sampler.create_xtraceoptions_response_value(
+        response_val = fixture_swsampler.create_xtraceoptions_response_value(
             decision_not_auth_type_nonzero,
             parent_span_context_invalid,
             mock_xtraceoptions_signed_not_tt,     
@@ -391,12 +391,12 @@ class Test_SwSampler():
 
     def test_create_xtraceoptions_response_value_case_8(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_signed_tt_traced,
         parent_span_context_invalid,
         mock_xtraceoptions_signed_tt,
     ):
-        response_val = sw_sampler.create_xtraceoptions_response_value(
+        response_val = fixture_swsampler.create_xtraceoptions_response_value(
             decision_signed_tt_traced,
             parent_span_context_invalid,
             mock_xtraceoptions_signed_tt,   
@@ -405,12 +405,12 @@ class Test_SwSampler():
 
     def test_create_xtraceoptions_response_value_case_14(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_non_tt_traced,
         parent_span_context_invalid,
         mock_xtraceoptions_signed_not_tt,
     ):
-        response_val = sw_sampler.create_xtraceoptions_response_value(
+        response_val = fixture_swsampler.create_xtraceoptions_response_value(
             decision_non_tt_traced,
             parent_span_context_invalid,
             mock_xtraceoptions_signed_not_tt,   
@@ -419,12 +419,12 @@ class Test_SwSampler():
 
     def test_create_xtraceoptions_response_value_case_11(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_unsigned_tt_not_traced,
         parent_span_context_invalid,
         mock_xtraceoptions_unsigned_tt,
     ):
-        response_val = sw_sampler.create_xtraceoptions_response_value(
+        response_val = fixture_swsampler.create_xtraceoptions_response_value(
             decision_unsigned_tt_not_traced,
             parent_span_context_invalid,
             mock_xtraceoptions_unsigned_tt, 
@@ -434,7 +434,7 @@ class Test_SwSampler():
     def test_create_new_trace_state(
         self,
         mocker,
-        sw_sampler,
+        fixture_swsampler,
         decision_auth_valid_sig,
         parent_span_context_valid_remote,
         mock_xtraceoptions_signed_tt
@@ -443,7 +443,7 @@ class Test_SwSampler():
             "solarwinds_apm.sampler._SwSampler.create_xtraceoptions_response_value",
             return_value="bar"
         )
-        trace_state = sw_sampler.create_new_trace_state(
+        trace_state = fixture_swsampler.create_new_trace_state(
             decision_auth_valid_sig,
             parent_span_context_valid_remote,
             mock_xtraceoptions_signed_tt
@@ -456,7 +456,7 @@ class Test_SwSampler():
     def test_create_new_trace_state_without_tt(
         self,
         mocker,
-        sw_sampler,
+        fixture_swsampler,
         decision_auth_valid_sig,
         parent_span_context_valid_remote,
         mock_xtraceoptions_signed_without_tt
@@ -465,7 +465,7 @@ class Test_SwSampler():
             "solarwinds_apm.sampler._SwSampler.create_xtraceoptions_response_value",
             return_value="bar"
         )
-        trace_state = sw_sampler.create_new_trace_state(
+        trace_state = fixture_swsampler.create_new_trace_state(
             decision_auth_valid_sig,
             parent_span_context_valid_remote,
             mock_xtraceoptions_signed_without_tt
@@ -478,7 +478,7 @@ class Test_SwSampler():
     def test_calculate_trace_state_root_span(
         self,
         mocker,
-        sw_sampler,
+        fixture_swsampler,
         decision_auth_valid_sig,
         parent_span_context_invalid
     ):
@@ -486,7 +486,7 @@ class Test_SwSampler():
             "solarwinds_apm.sampler._SwSampler.create_new_trace_state",
             return_value="bar"
         )
-        trace_state = sw_sampler.calculate_trace_state(
+        trace_state = fixture_swsampler.calculate_trace_state(
             decision_auth_valid_sig,
             parent_span_context_invalid
         )
@@ -495,7 +495,7 @@ class Test_SwSampler():
     def test_calculate_trace_state_is_remote_create(
         self,
         mocker,
-        sw_sampler,
+        fixture_swsampler,
         decision_auth_valid_sig,
         parent_span_context_valid_remote_no_tracestate
     ):
@@ -503,7 +503,7 @@ class Test_SwSampler():
             "solarwinds_apm.sampler._SwSampler.create_new_trace_state",
             return_value="bar"
         )
-        trace_state = sw_sampler.calculate_trace_state(
+        trace_state = fixture_swsampler.calculate_trace_state(
             decision_auth_valid_sig,
             parent_span_context_valid_remote_no_tracestate
         )
@@ -512,7 +512,7 @@ class Test_SwSampler():
     def test_calculate_trace_state_is_remote_update(
         self,
         mocker,
-        sw_sampler,
+        fixture_swsampler,
         decision_auth_valid_sig,
         parent_span_context_valid_remote,
         mock_xtraceoptions_signed_tt,
@@ -524,7 +524,7 @@ class Test_SwSampler():
         assert parent_span_context_valid_remote.trace_state == TraceState([
             ["sw", "123"]
         ])
-        trace_state = sw_sampler.calculate_trace_state(
+        trace_state = fixture_swsampler.calculate_trace_state(
             decision_auth_valid_sig,
             parent_span_context_valid_remote,
             mock_xtraceoptions_signed_tt,
@@ -537,7 +537,7 @@ class Test_SwSampler():
     def test_should_sample(
         self,
         mocker,
-        sw_sampler,
+        fixture_swsampler,
     ):
         mock_get_current_span = mocker.patch("solarwinds_apm.sampler.get_current_span")
         mock_get_current_span.configure_mock(
@@ -571,7 +571,7 @@ class Test_SwSampler():
             return_value=Decision.RECORD_AND_SAMPLE
         )
 
-        sampling_result = sw_sampler.should_sample(
+        sampling_result = fixture_swsampler.should_sample(
             parent_context=mocker.MagicMock(),
             trace_id=123,
             name="foo",

--- a/tests/unit/test_sampler/test_sampler_calculate_attributes.py
+++ b/tests/unit/test_sampler/test_sampler_calculate_attributes.py
@@ -248,11 +248,11 @@ class Test_SwSampler_calculate_attributes():
     def test_decision_drop_with_no_sw_keys_nor_custom_keys_nor_tt_unsigned(
         self,
         mocker,
-        sw_sampler,
+        fixture_swsampler,
         decision_drop,
         mock_xtraceoptions_no_sw_keys_nor_custom_keys_nor_tt_unsigned,
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=mocker.Mock(),
             decision=decision_drop,
@@ -264,11 +264,11 @@ class Test_SwSampler_calculate_attributes():
     def test_decision_drop_with_sw_keys_and_custom_keys_no_tt_unsigned(
         self,
         mocker,
-        sw_sampler,
+        fixture_swsampler,
         decision_drop,
         mock_xtraceoptions_sw_keys_and_custom_keys_no_tt_unsigned,
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=mocker.Mock(),
             decision=decision_drop,
@@ -280,11 +280,11 @@ class Test_SwSampler_calculate_attributes():
     def test_decision_drop_with_no_sw_keys_nor_custom_keys_nor_tt_signed(
         self,
         mocker,
-        sw_sampler,
+        fixture_swsampler,
         decision_drop,
         mock_xtraceoptions_no_sw_keys_nor_custom_keys_nor_tt_signed,
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=mocker.Mock(),
             decision=decision_drop,
@@ -296,11 +296,11 @@ class Test_SwSampler_calculate_attributes():
     def test_decision_drop_with_sw_keys_and_custom_keys_no_tt_signed(
         self,
         mocker,
-        sw_sampler,
+        fixture_swsampler,
         decision_drop,
         mock_xtraceoptions_sw_keys_and_custom_keys_no_tt_signed,
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=mocker.Mock(),
             decision=decision_drop,
@@ -312,11 +312,11 @@ class Test_SwSampler_calculate_attributes():
     def test_decision_record_only_with_custom_and_sw_keys_no_tt_unsigned(
         self,
         mocker,
-        sw_sampler,
+        fixture_swsampler,
         decision_record_only_regular,
         mock_xtraceoptions_sw_keys_and_custom_keys_no_tt_unsigned,
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=mocker.Mock(),
             decision=decision_record_only_regular,
@@ -328,11 +328,11 @@ class Test_SwSampler_calculate_attributes():
     def test_decision_record_only_with_custom_and_sw_keys_no_tt_signed(
         self,
         mocker,
-        sw_sampler,
+        fixture_swsampler,
         decision_record_only_regular,
         mock_xtraceoptions_sw_keys_and_custom_keys_no_tt_signed,
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=mocker.Mock(),
             decision=decision_record_only_regular,
@@ -343,12 +343,12 @@ class Test_SwSampler_calculate_attributes():
 
     def test_decision_record_and_sample_with_sw_keys_and_custom_keys_no_tt_unsigned(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_record_and_sample_unsigned_tt,
         parent_span_context_invalid,
         mock_xtraceoptions_sw_keys_and_custom_keys_no_tt_unsigned,
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_record_and_sample_unsigned_tt,
@@ -366,12 +366,12 @@ class Test_SwSampler_calculate_attributes():
 
     def test_decision_auth_ok_with_sw_keys_and_custom_keys_no_tt_signed(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_record_and_sample_signed_tt_auth_ok,
         parent_span_context_invalid,
         mock_xtraceoptions_sw_keys_and_custom_keys_no_tt_signed,
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_record_and_sample_signed_tt_auth_ok,
@@ -389,12 +389,12 @@ class Test_SwSampler_calculate_attributes():
 
     def test_decision_auth_failed_with_sw_keys_and_custom_keys_no_tt_signed(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_record_only_signed_tt_auth_failed,
         parent_span_context_invalid,
         mock_xtraceoptions_sw_keys_and_custom_keys_no_tt_signed,
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_record_only_signed_tt_auth_failed,
@@ -405,12 +405,12 @@ class Test_SwSampler_calculate_attributes():
 
     def test_decision_auth_ok_with_sw_keys_and_custom_keys_and_signed_tt(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_record_and_sample_signed_tt_auth_ok,
         parent_span_context_invalid,
         mock_xtraceoptions_sw_keys_and_custom_keys_and_signed_tt,
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_record_and_sample_signed_tt_auth_ok,
@@ -429,12 +429,12 @@ class Test_SwSampler_calculate_attributes():
 
     def test_decision_auth_failed_with_sw_keys_and_custom_keys_and_signed_tt(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_record_only_signed_tt_auth_failed,
         parent_span_context_invalid,
         mock_xtraceoptions_sw_keys_and_custom_keys_and_signed_tt,
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_record_only_signed_tt_auth_failed,
@@ -445,12 +445,12 @@ class Test_SwSampler_calculate_attributes():
 
     def test_contd_decision_sw_keys_and_custom_keys_and_unsigned_tt(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_continued,
         parent_span_context_invalid,
         mock_xtraceoptions_sw_keys_and_custom_keys_and_unsigned_tt
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_continued,
@@ -469,12 +469,12 @@ class Test_SwSampler_calculate_attributes():
 
     def test_contd_decision_sw_keys_and_custom_keys_and_signed_tt(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_continued,
         parent_span_context_invalid,
         mock_xtraceoptions_sw_keys_and_custom_keys_and_signed_tt
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_continued,
@@ -493,12 +493,12 @@ class Test_SwSampler_calculate_attributes():
 
     def test_contd_decision_with_no_sw_keys_nor_custom_keys_nor_tt_unsigned(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_continued,
         parent_span_context_invalid,
         mock_xtraceoptions_no_sw_keys_nor_custom_keys_nor_tt_unsigned
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_continued,
@@ -514,12 +514,12 @@ class Test_SwSampler_calculate_attributes():
 
     def test_contd_decision_with_no_sw_keys_nor_custom_keys_nor_tt_signed(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_continued,
         parent_span_context_invalid,
         mock_xtraceoptions_no_sw_keys_nor_custom_keys_nor_tt_unsigned
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_continued,
@@ -535,12 +535,12 @@ class Test_SwSampler_calculate_attributes():
 
     def test_contd_decision_with_no_sw_keys_nor_custom_keys_with_unsigned_tt(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_continued,
         parent_span_context_invalid,
         mock_xtraceoptions_no_sw_keys_nor_custom_keys_with_unsigned_tt
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_continued,
@@ -557,12 +557,12 @@ class Test_SwSampler_calculate_attributes():
 
     def test_contd_decision_with_no_sw_keys_nor_custom_keys_with_signed_tt(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_continued,
         parent_span_context_invalid,
         mock_xtraceoptions_no_sw_keys_nor_custom_keys_with_signed_tt
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_continued,
@@ -579,12 +579,12 @@ class Test_SwSampler_calculate_attributes():
 
     def test_not_contd_decision_with_sw_keys_and_custom_keys_and_unsigned_tt(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_not_continued,
         parent_span_context_invalid,
         mock_xtraceoptions_sw_keys_and_custom_keys_and_unsigned_tt
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_not_continued,
@@ -603,12 +603,12 @@ class Test_SwSampler_calculate_attributes():
 
     def test_not_contd_decision_with_sw_keys_and_custom_keys_and_signed_tt(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_not_continued,
         parent_span_context_invalid,
         mock_xtraceoptions_sw_keys_and_custom_keys_and_signed_tt
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_not_continued,
@@ -627,12 +627,12 @@ class Test_SwSampler_calculate_attributes():
 
     def test_not_contd_decision_with_no_sw_keys_nor_custom_keys_with_unsigned_tt(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_not_continued,
         parent_span_context_invalid,
         mock_xtraceoptions_no_sw_keys_nor_custom_keys_with_unsigned_tt
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_not_continued,
@@ -649,12 +649,12 @@ class Test_SwSampler_calculate_attributes():
 
     def test_not_contd_decision_with_no_sw_keys_nor_custom_keys_with_signed_tt(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_not_continued,
         parent_span_context_invalid,
         mock_xtraceoptions_no_sw_keys_nor_custom_keys_with_signed_tt
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_not_continued,
@@ -671,12 +671,12 @@ class Test_SwSampler_calculate_attributes():
 
     def test_not_contd_decision_with_no_sw_keys_nor_custom_keys_nor_tt_unsigned(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_not_continued,
         parent_span_context_invalid,
         mock_xtraceoptions_no_sw_keys_nor_custom_keys_nor_tt_unsigned
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_not_continued,
@@ -692,12 +692,12 @@ class Test_SwSampler_calculate_attributes():
 
     def test_not_contd_decision_with_no_sw_keys_nor_custom_keys_nor_tt_signed(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_not_continued,
         parent_span_context_invalid,
         mock_xtraceoptions_no_sw_keys_nor_custom_keys_nor_tt_signed
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_not_continued,
@@ -713,13 +713,13 @@ class Test_SwSampler_calculate_attributes():
 
     def test_valid_parent_create_new_attrs_with_sw_keys_and_custom_keys_and_unsigned_tt(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_continued,
         tracestate_with_sw_and_others,
         parent_span_context_valid_remote,
         mock_xtraceoptions_sw_keys_and_custom_keys_and_unsigned_tt
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_continued,
@@ -740,13 +740,13 @@ class Test_SwSampler_calculate_attributes():
 
     def test_valid_parent_create_new_attrs_with_sw_keys_and_custom_keys_and_signed_tt(
         self,
-        sw_sampler,
+        fixture_swsampler,
         decision_continued,
         tracestate_with_sw_and_others,
         parent_span_context_valid_remote,
         mock_xtraceoptions_sw_keys_and_custom_keys_and_signed_tt
     ):
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=None,
             decision=decision_continued,
@@ -767,14 +767,14 @@ class Test_SwSampler_calculate_attributes():
 
     def test_valid_parent_update_attrs_no_tracestate_capture_with_sw_keys_and_custom_keys_and_unsigned_tt(
         self,
-        sw_sampler,
+        fixture_swsampler,
         attributes_no_tracestate,
         decision_continued,
         tracestate_with_sw_and_others,
         parent_span_context_valid_remote,
         mock_xtraceoptions_sw_keys_and_custom_keys_and_unsigned_tt
     ):
-        result = sw_sampler.calculate_attributes(
+        result = fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=attributes_no_tracestate,
             decision=decision_continued,
@@ -800,14 +800,14 @@ class Test_SwSampler_calculate_attributes():
 
     def test_valid_parent_update_attrs_no_tracestate_capture_with_sw_keys_and_custom_keys_and_signed_tt(
         self,
-        sw_sampler,
+        fixture_swsampler,
         attributes_no_tracestate,
         decision_continued,
         tracestate_with_sw_and_others,
         parent_span_context_valid_remote,
         mock_xtraceoptions_sw_keys_and_custom_keys_and_signed_tt
     ):
-        result = sw_sampler.calculate_attributes(
+        result = fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=attributes_no_tracestate,
             decision=decision_continued,
@@ -833,14 +833,14 @@ class Test_SwSampler_calculate_attributes():
 
     def test_valid_parent_update_attrs_tracestate_capture_with_sw_keys_and_custom_keys_and_unsigned_tt(
         self,
-        sw_sampler,
+        fixture_swsampler,
         attributes_with_tracestate,
         decision_continued,
         tracestate_with_sw_and_others,
         parent_span_context_valid_remote,
         mock_xtraceoptions_sw_keys_and_custom_keys_and_unsigned_tt
     ):
-        result = sw_sampler.calculate_attributes(
+        result = fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=attributes_with_tracestate,
             decision=decision_continued,
@@ -866,14 +866,14 @@ class Test_SwSampler_calculate_attributes():
 
     def test_valid_parent_update_attrs_tracestate_capture_with_sw_keys_and_custom_keys_and_signed_tt(
         self,
-        sw_sampler,
+        fixture_swsampler,
         attributes_with_tracestate,
         decision_continued,
         tracestate_with_sw_and_others,
         parent_span_context_valid_remote,
         mock_xtraceoptions_sw_keys_and_custom_keys_and_signed_tt
     ):
-        result = sw_sampler.calculate_attributes(
+        result = fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=attributes_with_tracestate,
             decision=decision_continued,
@@ -899,13 +899,13 @@ class Test_SwSampler_calculate_attributes():
 
     def test_no_parent_update_attrs_no_tracestate(
         self,
-        sw_sampler,
+        fixture_swsampler,
         attributes_no_tracestate,
         decision_record_and_sample_regular,
         mock_xtraceoptions_empty,
     ):
         """Represents manual SDK start_as_current_span with attributes at root"""
-        assert sw_sampler.calculate_attributes(
+        assert fixture_swsampler.calculate_attributes(
             span_name="foo",
             attributes=attributes_no_tracestate,
             decision=decision_record_and_sample_regular,

--- a/tests/unit/test_sampler/test_sampler_calculate_attributes.py
+++ b/tests/unit/test_sampler/test_sampler_calculate_attributes.py
@@ -259,7 +259,7 @@ class Test_SwSampler_calculate_attributes():
             trace_state=mocker.Mock(),
             parent_span_context=mocker.Mock(),
             xtraceoptions=mock_xtraceoptions_no_sw_keys_nor_custom_keys_nor_tt_unsigned,
-        ) == None
+        ) is None
 
     def test_decision_drop_with_sw_keys_and_custom_keys_no_tt_unsigned(
         self,
@@ -275,7 +275,7 @@ class Test_SwSampler_calculate_attributes():
             trace_state=mocker.Mock(),
             parent_span_context=mocker.Mock(),
             xtraceoptions=mock_xtraceoptions_sw_keys_and_custom_keys_no_tt_unsigned,
-        ) == None
+        ) is None
 
     def test_decision_drop_with_no_sw_keys_nor_custom_keys_nor_tt_signed(
         self,
@@ -291,7 +291,7 @@ class Test_SwSampler_calculate_attributes():
             trace_state=mocker.Mock(),
             parent_span_context=mocker.Mock(),
             xtraceoptions=mock_xtraceoptions_no_sw_keys_nor_custom_keys_nor_tt_signed,
-        ) == None
+        ) is None
 
     def test_decision_drop_with_sw_keys_and_custom_keys_no_tt_signed(
         self,
@@ -307,7 +307,7 @@ class Test_SwSampler_calculate_attributes():
             trace_state=mocker.Mock(),
             parent_span_context=mocker.Mock(),
             xtraceoptions=mock_xtraceoptions_sw_keys_and_custom_keys_no_tt_signed,
-        ) == None
+        ) is None
 
     def test_decision_record_only_with_custom_and_sw_keys_no_tt_unsigned(
         self,
@@ -323,7 +323,7 @@ class Test_SwSampler_calculate_attributes():
             trace_state=mocker.Mock(),
             parent_span_context=mocker.Mock(),
             xtraceoptions=mock_xtraceoptions_sw_keys_and_custom_keys_no_tt_unsigned,
-        ) == None
+        ) is None
 
     def test_decision_record_only_with_custom_and_sw_keys_no_tt_signed(
         self,
@@ -339,7 +339,7 @@ class Test_SwSampler_calculate_attributes():
             trace_state=mocker.Mock(),
             parent_span_context=mocker.Mock(),
             xtraceoptions=mock_xtraceoptions_sw_keys_and_custom_keys_no_tt_signed,
-        ) == None
+        ) is None
 
     def test_decision_record_and_sample_with_sw_keys_and_custom_keys_no_tt_unsigned(
         self,
@@ -401,7 +401,7 @@ class Test_SwSampler_calculate_attributes():
             trace_state=None,
             parent_span_context=parent_span_context_invalid,
             xtraceoptions=mock_xtraceoptions_sw_keys_and_custom_keys_no_tt_signed,
-        ) == None
+        ) is None
 
     def test_decision_auth_ok_with_sw_keys_and_custom_keys_and_signed_tt(
         self,
@@ -441,7 +441,7 @@ class Test_SwSampler_calculate_attributes():
             trace_state=None,
             parent_span_context=parent_span_context_invalid,
             xtraceoptions=mock_xtraceoptions_sw_keys_and_custom_keys_and_signed_tt,
-        ) == None
+        ) is None
 
     def test_contd_decision_sw_keys_and_custom_keys_and_unsigned_tt(
         self,

--- a/tests/unit/test_sampler/test_sampler_calculate_tracing_mode.py
+++ b/tests/unit/test_sampler/test_sampler_calculate_tracing_mode.py
@@ -4,8 +4,6 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-import pytest
-
 from opentelemetry.trace import SpanKind
 
 # pylint: disable=unused-import

--- a/tests/unit/test_sampler/test_sampler_calculate_tracing_mode.py
+++ b/tests/unit/test_sampler/test_sampler_calculate_tracing_mode.py
@@ -1,0 +1,168 @@
+# © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+import pytest
+
+from opentelemetry.trace import SpanKind
+
+# pylint: disable=unused-import
+from .fixtures.sampler import (
+    fixture_swsampler,
+    fixture_swsampler_txnfilters,
+)
+
+# The Tests =========================================================
+
+class Test_SwSampler_construct_url():
+    def test_construct_url_attrs_none(
+        self,
+        sw_sampler,
+    ):
+        assert sw_sampler.construct_url() == ""
+
+    def test_construct_url_no_http(
+        self,
+        sw_sampler,
+    ):
+        assert sw_sampler.construct_url({"foo": "bar"}) == ""
+
+    def test_construct_url_one_only(
+        self,
+        sw_sampler,
+    ):
+        assert sw_sampler.construct_url({"http.scheme": "bar"}) == ""
+        assert sw_sampler.construct_url({"net.host.name": "bar"}) == ""
+        assert sw_sampler.construct_url({"net.host.port": "bar"}) == ""
+        assert sw_sampler.construct_url({"http.target": "bar"}) == ""
+
+    def test_construct_url_all_attrs(
+        self,
+        sw_sampler,
+    ):
+        assert sw_sampler.construct_url(
+            {
+                "http.scheme": "foo",
+                "net.host.name": "bar",
+                "net.host.port": "baz",
+                "http.target": "/qux"
+            }
+        ) == "foo://bar:baz/qux"
+
+    def test_construct_url_all_attrs_except_port(
+        self,
+        sw_sampler,
+    ):
+        assert sw_sampler.construct_url(
+            {
+                "http.scheme": "foo",
+                "net.host.name": "bar",
+                "http.target": "/qux"
+            }
+        ) == "foo://bar/qux"
+
+
+class Test_SwSampler_calculate_tracing_mode():
+    def test_calculate_tracing_mode_no_filters(
+        self,
+        sw_sampler,
+    ):
+        # this fixture has global tracing_mode -1 (unset)
+        assert sw_sampler.calculate_tracing_mode("foo", None) == -1
+
+    def test_calculate_tracing_mode_filters_url_no_match(
+        self,
+        sw_sampler_txnfilters,
+    ):
+        # this fixture has global tracing_mode -1 (unset)
+        assert sw_sampler_txnfilters.calculate_tracing_mode(
+            "foo",
+            None,
+            {
+                "http.scheme": "foo",
+                "net.host.name": "bar",
+                "net.host.port": "baz",
+                "http.target": "/qux"   
+            }
+        ) == -1
+
+    def test_calculate_tracing_mode_filters_url_one_match_exact(
+        self,
+        sw_sampler_txnfilters,
+    ):
+        assert sw_sampler_txnfilters.calculate_tracing_mode(
+            "foo",
+            None,
+            {
+                "http.scheme": "http",
+                "net.host.name": "foo",
+                "http.target": "/bar"   
+            }
+        ) == 1
+
+    def test_calculate_tracing_mode_filters_url_one_match(
+        self,
+        sw_sampler_txnfilters,
+    ):
+        assert sw_sampler_txnfilters.calculate_tracing_mode(
+            "foo",
+            None,
+            {
+                "http.scheme": "http",
+                "net.host.name": "foo",
+                "http.target": "/abcdef/bar"   
+            }
+        ) == 1
+
+    def test_calculate_tracing_mode_filters_url_multiple_match(
+        self,
+        sw_sampler_txnfilters,
+    ):
+        assert sw_sampler_txnfilters.calculate_tracing_mode(
+            "foo",
+            None,
+            {
+                "http.scheme": "http",
+                "net.host.name": "foo",
+                "http.target": "/bar-baz"   
+            }
+        ) == 1
+
+    def test_calculate_tracing_mode_filters_no_url_no_match(
+        self,
+        sw_sampler_txnfilters,
+    ):
+        # the sampler fixture has global tracing_mode -1 (unset)
+        assert sw_sampler_txnfilters.calculate_tracing_mode(
+            "no-foo",
+            SpanKind.CLIENT,
+        ) == -1
+
+    def test_calculate_tracing_mode_filters_no_url_one_match_exact(
+        self,
+        sw_sampler_txnfilters,
+    ):
+        assert sw_sampler_txnfilters.calculate_tracing_mode(
+            "foo",
+            SpanKind.CLIENT,
+        ) == 1
+
+    def test_calculate_tracing_mode_filters_no_url_one_match(
+        self,
+        sw_sampler_txnfilters,
+    ):
+        assert sw_sampler_txnfilters.calculate_tracing_mode(
+            "fooooooo",
+            SpanKind.CLIENT,
+        ) == 1
+
+    def test_calculate_tracing_mode_filters_no_url_multiple_match(
+        self,
+        sw_sampler_txnfilters,
+    ):
+        assert sw_sampler_txnfilters.calculate_tracing_mode(
+            "foo_bar",
+            SpanKind.CLIENT,
+        ) == 1

--- a/tests/unit/test_sampler/test_sampler_calculate_tracing_mode.py
+++ b/tests/unit/test_sampler/test_sampler_calculate_tracing_mode.py
@@ -17,30 +17,30 @@ from .fixtures.sampler import (
 class Test_SwSampler_construct_url():
     def test_construct_url_attrs_none(
         self,
-        sw_sampler,
+        fixture_swsampler,
     ):
-        assert sw_sampler.construct_url() == ""
+        assert fixture_swsampler.construct_url() == ""
 
     def test_construct_url_no_http(
         self,
-        sw_sampler,
+        fixture_swsampler,
     ):
-        assert sw_sampler.construct_url({"foo": "bar"}) == ""
+        assert fixture_swsampler.construct_url({"foo": "bar"}) == ""
 
     def test_construct_url_one_only(
         self,
-        sw_sampler,
+        fixture_swsampler,
     ):
-        assert sw_sampler.construct_url({"http.scheme": "bar"}) == ""
-        assert sw_sampler.construct_url({"net.host.name": "bar"}) == ""
-        assert sw_sampler.construct_url({"net.host.port": "bar"}) == ""
-        assert sw_sampler.construct_url({"http.target": "bar"}) == ""
+        assert fixture_swsampler.construct_url({"http.scheme": "bar"}) == ""
+        assert fixture_swsampler.construct_url({"net.host.name": "bar"}) == ""
+        assert fixture_swsampler.construct_url({"net.host.port": "bar"}) == ""
+        assert fixture_swsampler.construct_url({"http.target": "bar"}) == ""
 
     def test_construct_url_all_attrs(
         self,
-        sw_sampler,
+        fixture_swsampler,
     ):
-        assert sw_sampler.construct_url(
+        assert fixture_swsampler.construct_url(
             {
                 "http.scheme": "foo",
                 "net.host.name": "bar",
@@ -51,9 +51,9 @@ class Test_SwSampler_construct_url():
 
     def test_construct_url_all_attrs_except_port(
         self,
-        sw_sampler,
+        fixture_swsampler,
     ):
-        assert sw_sampler.construct_url(
+        assert fixture_swsampler.construct_url(
             {
                 "http.scheme": "foo",
                 "net.host.name": "bar",
@@ -65,17 +65,17 @@ class Test_SwSampler_construct_url():
 class Test_SwSampler_calculate_tracing_mode():
     def test_calculate_tracing_mode_no_filters(
         self,
-        sw_sampler,
+        fixture_swsampler,
     ):
         # this fixture has global tracing_mode -1 (unset)
-        assert sw_sampler.calculate_tracing_mode("foo", None) == -1
+        assert fixture_swsampler.calculate_tracing_mode("foo", None) == -1
 
     def test_calculate_tracing_mode_filters_url_no_match(
         self,
-        sw_sampler_txnfilters,
+        fixture_swsampler_txnfilters,
     ):
         # this fixture has global tracing_mode -1 (unset)
-        assert sw_sampler_txnfilters.calculate_tracing_mode(
+        assert fixture_swsampler_txnfilters.calculate_tracing_mode(
             "foo",
             None,
             {
@@ -88,9 +88,9 @@ class Test_SwSampler_calculate_tracing_mode():
 
     def test_calculate_tracing_mode_filters_url_one_match_exact(
         self,
-        sw_sampler_txnfilters,
+        fixture_swsampler_txnfilters,
     ):
-        assert sw_sampler_txnfilters.calculate_tracing_mode(
+        assert fixture_swsampler_txnfilters.calculate_tracing_mode(
             "foo",
             None,
             {
@@ -102,9 +102,9 @@ class Test_SwSampler_calculate_tracing_mode():
 
     def test_calculate_tracing_mode_filters_url_one_match(
         self,
-        sw_sampler_txnfilters,
+        fixture_swsampler_txnfilters,
     ):
-        assert sw_sampler_txnfilters.calculate_tracing_mode(
+        assert fixture_swsampler_txnfilters.calculate_tracing_mode(
             "foo",
             None,
             {
@@ -116,9 +116,9 @@ class Test_SwSampler_calculate_tracing_mode():
 
     def test_calculate_tracing_mode_filters_url_multiple_match(
         self,
-        sw_sampler_txnfilters,
+        fixture_swsampler_txnfilters,
     ):
-        assert sw_sampler_txnfilters.calculate_tracing_mode(
+        assert fixture_swsampler_txnfilters.calculate_tracing_mode(
             "foo",
             None,
             {
@@ -130,37 +130,37 @@ class Test_SwSampler_calculate_tracing_mode():
 
     def test_calculate_tracing_mode_filters_no_url_no_match(
         self,
-        sw_sampler_txnfilters,
+        fixture_swsampler_txnfilters,
     ):
         # the sampler fixture has global tracing_mode -1 (unset)
-        assert sw_sampler_txnfilters.calculate_tracing_mode(
+        assert fixture_swsampler_txnfilters.calculate_tracing_mode(
             "no-foo",
             SpanKind.CLIENT,
         ) == -1
 
     def test_calculate_tracing_mode_filters_no_url_one_match_exact(
         self,
-        sw_sampler_txnfilters,
+        fixture_swsampler_txnfilters,
     ):
-        assert sw_sampler_txnfilters.calculate_tracing_mode(
+        assert fixture_swsampler_txnfilters.calculate_tracing_mode(
             "foo",
             SpanKind.CLIENT,
         ) == 1
 
     def test_calculate_tracing_mode_filters_no_url_one_match(
         self,
-        sw_sampler_txnfilters,
+        fixture_swsampler_txnfilters,
     ):
-        assert sw_sampler_txnfilters.calculate_tracing_mode(
+        assert fixture_swsampler_txnfilters.calculate_tracing_mode(
             "fooooooo",
             SpanKind.CLIENT,
         ) == 1
 
     def test_calculate_tracing_mode_filters_no_url_multiple_match(
         self,
-        sw_sampler_txnfilters,
+        fixture_swsampler_txnfilters,
     ):
-        assert sw_sampler_txnfilters.calculate_tracing_mode(
+        assert fixture_swsampler_txnfilters.calculate_tracing_mode(
             "foo_bar",
             SpanKind.CLIENT,
         ) == 1


### PR DESCRIPTION
Adds unit tests for `calculate_tracing_mode` and `construct_url`, with a new fixture for a sampler with some transaction filters set.

The source code was introduced in https://github.com/solarwindscloud/solarwinds-apm-python/pull/136/files and https://github.com/solarwindscloud/solarwinds-apm-python/pull/137/files.

EDIT: In [b7180d5](https://github.com/solarwindscloud/solarwinds-apm-python/pull/138/commits/b7180d5520f53ccfd3394eba6fcbba5e7ce7f9ab) I've renamed both sampler fixtures for general clarity and to try to make CodeQL happy.