### PR TITLE
NH-39702 Remove unused prepend_domain_name from config

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -9,7 +9,6 @@ import logging
 import os
 import re
 import sys
-from collections import defaultdict
 from functools import reduce
 from pathlib import Path
 from typing import Any
@@ -114,11 +113,9 @@ class SolarWindsApmConfig:
             "enable_sanitize_sql": True,
             "log_trace_id": "never",
             "proxy": "",
-            "transaction": defaultdict(lambda: True),
             "is_grpc_clean_hack_enabled": False,
             "transaction_filters": [],
         }
-        self.__config["transaction"]["prepend_domain_name"] = False
         self.agent_enabled = self._calculate_agent_enabled()
         self.service_name = self._calculate_service_name(
             self.agent_enabled,
@@ -515,12 +512,6 @@ class SolarWindsApmConfig:
         if not cnf_dict:
             return
 
-        try:
-            val = cnf_dict.get("transaction").get("prependDomain")
-            if val is not None:
-                self._set_config_value("transaction.prepend_domain_name", val)
-        except AttributeError:
-            pass
         available_cnf = set(self.__config.keys())
         # TODO after alpha: is_lambda
         for key in available_cnf:
@@ -590,9 +581,6 @@ class SolarWindsApmConfig:
 
     def update_with_env_var(self) -> None:
         """Update the settings with environment variables."""
-        val = os.environ.get("SW_APM_PREPEND_DOMAIN_NAME", None)
-        if val is not None:
-            self._set_config_value("transaction.prepend_domain_name", val)
         available_envvs = set(self.__config.keys())
         # TODO after alpha: is_lambda
         for key in available_envvs:

--- a/tests/unit/test_apm_config/fixtures/cnf_dict.py
+++ b/tests/unit/test_apm_config/fixtures/cnf_dict.py
@@ -27,8 +27,5 @@ def fixture_cnf_dict():
         "enableSanitizeSql": True,
         "logTraceId": "always",
         "proxy": "http://foo-bar",
-        "transaction": {
-            "prependDomain": True
-        },
         "isGrpcCleanHackEnabled": True,
     }

--- a/tests/unit/test_apm_config/test_apm_config_cnf_file.py
+++ b/tests/unit/test_apm_config/test_apm_config_cnf_file.py
@@ -80,66 +80,6 @@ class TestSolarWindsApmConfigCnfFile:
         # cnf_dict is dict with kv from fixture
         assert resulting_config.get_cnf_dict() == {"foo": "bar"}
 
-    def test_update_with_cnf_file_prependdomain_invalid(
-        self,
-        mocker,
-    ):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_SERVICE_KEY": "valid:key-service-name",
-        })
-        mock_update_txn_filters = mocker.patch(
-            "solarwinds_apm.apm_config.SolarWindsApmConfig.update_transaction_filters"
-        )
-        some_cnf_dict = {
-            "transaction": {
-                "prependDomain": "not-valid-boolean"
-            }
-        }
-        mock_get_cnf_dict = mocker.patch(
-            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict"
-        )
-        mock_get_cnf_dict.configure_mock(
-            return_value=some_cnf_dict
-        )
-        # use key from env var, agent enabled, nothing has errored
-        resulting_config = apm_config.SolarWindsApmConfig()
-        assert resulting_config.agent_enabled == True
-        assert resulting_config.get("service_key") == "valid:key-service-name"
-        # config does not include prepend_domain from mock
-        assert resulting_config.get("transaction.prepend_domain_name") == False
-        # update_transaction_filters was called
-        mock_update_txn_filters.assert_called_once_with(some_cnf_dict)
-
-    def test_update_with_cnf_file_prependdomain_valid(
-        self,
-        mocker,
-    ):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_SERVICE_KEY": "valid:key-service-name",
-        })
-        mock_update_txn_filters = mocker.patch(
-            "solarwinds_apm.apm_config.SolarWindsApmConfig.update_transaction_filters"
-        )
-        some_cnf_dict = {
-            "transaction": {
-                "prependDomain": True
-            }
-        }
-        mock_get_cnf_dict = mocker.patch(
-            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict"
-        )
-        mock_get_cnf_dict.configure_mock(
-            return_value=some_cnf_dict
-        )
-        # use key from env var, agent enabled, nothing has errored
-        resulting_config = apm_config.SolarWindsApmConfig()
-        assert resulting_config.agent_enabled == True
-        assert resulting_config.get("service_key") == "valid:key-service-name"
-        # config includes prepend_domain from mock
-        assert resulting_config.get("transaction.prepend_domain_name") == True
-        # update_transaction_filters was called
-        mock_update_txn_filters.assert_called_once_with(some_cnf_dict)
-
     # pylint:disable=unused-argument
     def test_update_with_cnf_file_all_valid(
         self,
@@ -193,7 +133,6 @@ class TestSolarWindsApmConfigCnfFile:
         assert resulting_config.get("enable_sanitize_sql") == True
         assert resulting_config.get("log_trace_id") == "always"
         assert resulting_config.get("proxy") == "http://foo-bar"
-        assert resulting_config.get("transaction.prepend_domain_name") == True
         assert resulting_config.get("is_grpc_clean_hack_enabled") == True
 
         # update_transaction_filters was called
@@ -242,9 +181,6 @@ class TestSolarWindsApmConfigCnfFile:
             "enableSanitizeSql": "foo",
             "log_trace_id": "not-never-always-etc",
             "proxy": "foo",
-            "transaction": {
-                "prependDomain": "foo"
-            },
             "isGrpcCleanHackEnabled": "foo",
         }
         mock_get_cnf_dict = mocker.patch(
@@ -278,7 +214,6 @@ class TestSolarWindsApmConfigCnfFile:
         assert resulting_config.get("enable_sanitize_sql") == True
         assert resulting_config.get("log_trace_id") == "never"
         assert resulting_config.get("proxy") == ""
-        assert resulting_config.get("transaction.prepend_domain_name") == False
         assert resulting_config.get("is_grpc_clean_hack_enabled") == False
         # Meanwhile these are pretty open
         assert resulting_config.get("collector") == "False"
@@ -345,9 +280,7 @@ class TestSolarWindsApmConfigCnfFile:
         mock_update_txn_filters.assert_called_once_with(fixture_cnf_dict)
 
         # use all keys from env var, none from cnf_file
-        # except for transaction.prependDomain (nested)
         assert resulting_config.get("service_key") == "valid:key-service-name"
-        assert resulting_config.get("transaction.prepend_domain_name") == True
 
         # Rest of config prioritizes env_var > cnf_file
         assert resulting_config.agent_enabled == False
@@ -435,8 +368,6 @@ class TestSolarWindsApmConfigCnfFile:
         # and APM will be disabled
         assert resulting_config.agent_enabled == False
         assert resulting_config.get("service_key") == "not-valid-and-agent-will-be-disabled"  # the full key does not print to std out and appears masked
-        # cnf_file always used for transaction.prependDomain (nested)
-        assert resulting_config.get("transaction.prepend_domain_name") == True
 
         # cnf_file values from fixture_cnf_dict are kept if same env_var invalid
         assert resulting_config.get("tracing_mode") == 1


### PR DESCRIPTION
Remove unused `prepend_domain_name` from Python APM config support. This was copied from AO but is not actually used for SWO transaction naming.

If we support this feature in the future, consider a flat config as mentioned in this [PR comment](https://github.com/solarwindscloud/solarwinds-apm-python/pull/139#discussion_r1179162323) and [NH-39702](https://swicloud.atlassian.net/browse/NH-39702):

```
{
    "transactionPrependDomain": false,
    "transactionSettings": []
}
```

tox tests pass, and here is a manual test trace: https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/CB138A762D313C5093BAAF9ADC2D47BA/67820577B5756263/details/breakdown?perspective=requests&serviceId=e-1540126275982954496

[NH-39702]: https://swicloud.atlassian.net/browse/NH-39702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ