### PR TITLE
NH-34752 Add txn filter unit tests and bugfix

### DIFF
--- a/tests/unit/test_apm_config/test_apm_config_cnf_file.py
+++ b/tests/unit/test_apm_config/test_apm_config_cnf_file.py
@@ -263,7 +263,6 @@ class TestSolarWindsApmConfigCnfFile:
             "SW_APM_ENABLE_SANITIZE_SQL": "false",
             "SW_APM_LOG_TRACE_ID": "never",
             "SW_APM_PROXY": "http://other-foo-bar",
-            "SW_APM_TRANSACTION": "wont-be-used",
             "SW_APM_IS_GRPC_CLEAN_HACK_ENABLED": "false",
         })
         mock_update_txn_filters = mocker.patch(
@@ -348,7 +347,6 @@ class TestSolarWindsApmConfigCnfFile:
             "SW_APM_ENABLE_SANITIZE_SQL": "other-foo-bar",
             "SW_APM_LOG_TRACE_ID": "other-foo-bar",
             "SW_APM_PROXY": "other-foo-bar",
-            "SW_APM_TRANSACTION": "wont-be-used",
             "SW_APM_IS_GRPC_CLEAN_HACK_ENABLED": "other-foo-bar",
         })
         mock_update_txn_filters = mocker.patch(

--- a/tests/unit/test_apm_config/test_apm_config_transaction_filters.py
+++ b/tests/unit/test_apm_config/test_apm_config_transaction_filters.py
@@ -1,0 +1,35 @@
+# © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+from solarwinds_apm import apm_config
+
+class TestSolarWindsApmConfigTxnFilters:
+    def test_update_transaction_filters_none(self):
+        pass
+
+    def test_update_transaction_filters_not_list(self):
+        pass
+
+    def test_update_transaction_filters_missing_tracing(self):
+        pass
+
+    def test_update_transaction_filters_invalid_tracing(self):
+        pass
+
+    def test_update_transaction_filters_missing_regex(self):
+        pass
+
+    def test_update_transaction_filters_invalid_type_regex(self):
+        pass
+
+    def test_update_transaction_filters_empty_regex(self):
+        pass
+
+    def test_update_transaction_filters_invalid_compile_regex(self):
+        pass
+
+    def test_update_transaction_filters_multiple_regex_use_first(self):
+        pass

--- a/tests/unit/test_apm_config/test_apm_config_transaction_filters.py
+++ b/tests/unit/test_apm_config/test_apm_config_transaction_filters.py
@@ -4,32 +4,165 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
+import re
+
 from solarwinds_apm import apm_config
 
 class TestSolarWindsApmConfigTxnFilters:
     def test_update_transaction_filters_none(self):
-        pass
+        cfg = apm_config.SolarWindsApmConfig()
+        cfg.update_transaction_filters({})
+        assert cfg.get("transaction_filters") == []
 
     def test_update_transaction_filters_not_list(self):
-        pass
+        cfg = apm_config.SolarWindsApmConfig()
+        cfg.update_transaction_filters(
+            {
+                "transactionSettings": "foo"
+            }
+        )
+        assert cfg.get("transaction_filters") == []
 
     def test_update_transaction_filters_missing_tracing(self):
-        pass
+        cfg = apm_config.SolarWindsApmConfig()
+        cfg.update_transaction_filters(
+            {
+                "transactionSettings": [
+                    {
+                        "regex": "foo"
+                    }
+                ]
+            }
+        )
+        assert cfg.get("transaction_filters") == []
 
     def test_update_transaction_filters_invalid_tracing(self):
-        pass
+        cfg = apm_config.SolarWindsApmConfig()
+        cfg.update_transaction_filters(
+            {
+                "transactionSettings": [
+                    {
+                        "regex": "foo",
+                        "tracing": "not-valid"
+                    }
+                ]
+            }
+        )
+        assert cfg.get("transaction_filters") == []
 
     def test_update_transaction_filters_missing_regex(self):
-        pass
+        cfg = apm_config.SolarWindsApmConfig()
+        cfg.update_transaction_filters(
+            {
+                "transactionSettings": [
+                    {
+                        "tracing": "enabled"
+                    }
+                ]
+            }
+        )
+        assert cfg.get("transaction_filters") == []
 
     def test_update_transaction_filters_invalid_type_regex(self):
-        pass
+        cfg = apm_config.SolarWindsApmConfig()
+        cfg.update_transaction_filters(
+            {
+                "transactionSettings": [
+                    {
+                        "regex": 123,
+                        "tracing": "enabled"
+                    }
+                ]
+            }
+        )
+        assert cfg.get("transaction_filters") == []
 
     def test_update_transaction_filters_empty_regex(self):
-        pass
+        cfg = apm_config.SolarWindsApmConfig()
+        cfg.update_transaction_filters(
+            {
+                "transactionSettings": [
+                    {
+                        "regex": "",
+                        "tracing": "enabled"
+                    }
+                ]
+            }
+        )
+        assert cfg.get("transaction_filters") == []
 
     def test_update_transaction_filters_invalid_compile_regex(self):
-        pass
+        cfg = apm_config.SolarWindsApmConfig()
+        cfg.update_transaction_filters(
+            {
+                "transactionSettings": [
+                    {
+                        "regex": "[",
+                        "tracing": "enabled"
+                    }
+                ]
+            }
+        )
+        assert cfg.get("transaction_filters") == []
+
+    def test_update_transaction_filters(self):
+        cfg = apm_config.SolarWindsApmConfig()
+        cfg.update_transaction_filters(
+            {
+                "transactionSettings": [
+                    {
+                        "regex": "foo",
+                        "tracing": "enabled"
+                    },
+                    {
+                        "regex": "bar",
+                        "tracing": "disabled"
+                    }
+                ]
+            }
+        )
+        assert cfg.get("transaction_filters") == [
+            {
+                "regex": re.compile("foo"),
+                "tracing_mode": 1
+            },
+            {
+                "regex": re.compile("bar"),
+                "tracing_mode": 0
+            }
+        ]
 
     def test_update_transaction_filters_multiple_regex_use_first(self):
-        pass
+        cfg = apm_config.SolarWindsApmConfig()
+        cfg.update_transaction_filters(
+            {
+                "transactionSettings": [
+                    {
+                        "regex": "foo",
+                        "tracing": "enabled"
+                    },
+                    {
+                        "regex": "bar",
+                        "tracing": "disabled"
+                    },
+                    {
+                        "regex": "foo",
+                        "tracing": "disabled"
+                    },
+                    {
+                        "regex": "bar",
+                        "tracing": "enabled"
+                    }
+                ]
+            }
+        )
+        assert cfg.get("transaction_filters") == [
+            {
+                "regex": re.compile("foo"),
+                "tracing_mode": 1
+            },
+            {
+                "regex": re.compile("bar"),
+                "tracing_mode": 0
+            }
+        ]


### PR DESCRIPTION
Adds unit tests for `update_transaction_filters`, which revealed a bug with how multiple customer filters are handled. Bugfix included in b616f96 so `test_update_transaction_filters_multiple_regex_use_first` passes.

[Test trace](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/69C88A691A90F1F650751BE660E53989/28B84DBFEE997D6A/details/breakdown?perspective=requests&serviceId=e-1540126275982954496) since source code changed. This was for a request that was not filtered out, whereas those filtered out did not trace with flag `00`. 

EDIT: I missed a test case update for #140 so added here in [9a7fb98](https://github.com/solarwindscloud/solarwinds-apm-python/pull/141/commits/9a7fb9848946df8de794284f8095ea7805821fd7).