### PR TITLE
NH-34752 Add sw.span_name attribute at export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.9.0...HEAD)
 ### Added
 - Add custom transaction filtering support ([#136](https://github.com/solarwindscloud/solarwinds-apm-python/pull/136), [#137](https://github.com/solarwindscloud/solarwinds-apm-python/pull/137), [#138](https://github.com/solarwindscloud/solarwinds-apm-python/pull/138), [#139](https://github.com/solarwindscloud/solarwinds-apm-python/pull/139), [#141](https://github.com/solarwindscloud/solarwinds-apm-python/pull/141))
+- Add span attribute `sw.span_name` at export ([#143](https://github.com/solarwindscloud/solarwinds-apm-python/pull/143))
 
 ### Removed
 - Removed unused prepend_domain_name config storage ([#140](https://github.com/solarwindscloud/solarwinds-apm-python/pull/140))

--- a/solarwinds_apm/exporter.py
+++ b/solarwinds_apm/exporter.py
@@ -55,6 +55,7 @@ class SolarWindsSpanExporter(SpanExporter):
     ]
     _INTERNAL_TRANSACTION_NAME = "TransactionName"
     _SW_SPAN_KIND = "sw.span_kind"
+    _SW_SPAN_NAME = "sw.span_name"
 
     def __init__(
         self,
@@ -103,6 +104,7 @@ class SolarWindsSpanExporter(SpanExporter):
 
             layer = f"{span.kind.name}:{span.name}"
             evt.addInfo("Layer", layer)
+            evt.addInfo(self._SW_SPAN_NAME, span.name)
             evt.addInfo(self._SW_SPAN_KIND, span.kind.name)
             evt.addInfo("Language", "Python")
             self._add_info_instrumentation_scope(span, evt)

--- a/tests/unit/test_exporter.py
+++ b/tests/unit/test_exporter.py
@@ -195,9 +195,12 @@ def fixture_exporter(mocker):
         "solarwinds_apm.apm_txname_manager.SolarWindsTxnNameManager",
         return_value=mocker.Mock()
     )
+    mock_txnman_get = mocker.Mock()
+    mock_txnman_get.configure_mock(return_value="foo")
     mock_apm_txname_manager.configure_mock(
         **{
-            "__delitem__": mocker.Mock()
+            "__delitem__": mocker.Mock(),
+            "get": mock_txnman_get
         }
     )
     mock_apm_fwkv_manager = mocker.patch(
@@ -239,7 +242,7 @@ class Test_SolarWindsSpanExporter():
         mock_report_exception,
         mock_add_info,
         mock_add_info_instr_scope,
-        mock_add_info_instr_fwork,        
+        mock_add_info_instr_fwork,     
         exporter
     ):
         # mock_spans has one info event, one exception event
@@ -252,7 +255,9 @@ class Test_SolarWindsSpanExporter():
 
         # addInfo calls for entry and exit events
         mock_add_info.assert_has_calls([
+            mocker.call("TransactionName", "foo"),
             mocker.call("Layer", "FOO:foo"),
+            mocker.call(solarwinds_apm.exporter.SolarWindsSpanExporter._SW_SPAN_NAME, "foo"),
             mocker.call(solarwinds_apm.exporter.SolarWindsSpanExporter._SW_SPAN_KIND, FooNum.FOO.name),
             mocker.call("Language", "Python"),
             mocker.call("foo", "bar"),


### PR DESCRIPTION
Add `sw.span_name` attribute at export as per [acceptance criteria](https://swicloud.atlassian.net/wiki/spaces/NIT/pages/3538485339/Transaction+Filtering+aka+per-request+tracing+mode#Acceptance-Criteria).

I've added the test case's additional expected call `mocker.call("TransactionName", "foo")` because we've gone from a mock txn name manager with unspecified `get` method (which does magic mocking) to an explicit one.

[Example trace](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/C2B6EB747B271FAE44CF17A17E7F1A6C/5267657C46A48D38/details/breakdown/5267657C46A48D38/raw-data?perspective=requests&serviceId=e-1540126275982954496) with `sw.span_name` included in the exported spans.