### PR TITLE
NH-29380 Add distro default OTEL_PYTHON_LOG_FORMAT

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     opentelemetry-api == 1.17.0
     opentelemetry-sdk == 1.17.0
     opentelemetry-instrumentation == 0.38b0
+    opentelemetry-instrumentation-logging == 0.38b0
 packages = solarwinds_apm, solarwinds_apm.api, solarwinds_apm.certs, solarwinds_apm.extension
 
 [options.package_data]

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -13,7 +13,9 @@ from opentelemetry.environment_variables import (
     OTEL_TRACES_EXPORTER,
 )
 from opentelemetry.instrumentation.distro import BaseDistro
-from opentelemetry.instrumentation.logging.environment_variables import OTEL_PYTHON_LOG_FORMAT
+from opentelemetry.instrumentation.logging.environment_variables import (
+    OTEL_PYTHON_LOG_FORMAT,
+)
 
 from solarwinds_apm.apm_constants import (
     INTL_SWO_DEFAULT_PROPAGATORS,
@@ -33,5 +35,6 @@ class SolarWindsDistro(BaseDistro):
             OTEL_PROPAGATORS, ",".join(INTL_SWO_DEFAULT_PROPAGATORS)
         )
         environ.setdefault(
-            OTEL_PYTHON_LOG_FORMAT, "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] [trace_id=%(otelTraceID)s span_id=%(otelSpanID)s trace_flags=%(otelTraceSampled)02d resource.service.name=%(otelServiceName)s] - %(message)s"
+            OTEL_PYTHON_LOG_FORMAT,
+            "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] [trace_id=%(otelTraceID)s span_id=%(otelSpanID)s trace_flags=%(otelTraceSampled)02d resource.service.name=%(otelServiceName)s] - %(message)s",
         )

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -13,6 +13,7 @@ from opentelemetry.environment_variables import (
     OTEL_TRACES_EXPORTER,
 )
 from opentelemetry.instrumentation.distro import BaseDistro
+from opentelemetry.instrumentation.logging.environment_variables import OTEL_PYTHON_LOG_FORMAT
 
 from solarwinds_apm.apm_constants import (
     INTL_SWO_DEFAULT_PROPAGATORS,
@@ -30,4 +31,7 @@ class SolarWindsDistro(BaseDistro):
         )
         environ.setdefault(
             OTEL_PROPAGATORS, ",".join(INTL_SWO_DEFAULT_PROPAGATORS)
+        )
+        environ.setdefault(
+            OTEL_PYTHON_LOG_FORMAT, "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] [trace_id=%(otelTraceID)s span_id=%(otelSpanID)s trace_flags=%(otelTraceSampled)02d resource.service.name=%(otelServiceName)s] - %(message)s"
         )

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ deps =
   opentelemetry-api
   opentelemetry-sdk
   opentelemetry-instrumentation
+  opentelemetry-instrumentation-logging
   pylint
   flake8
   isort


### PR DESCRIPTION
~~Do not merge until after this is on main: https://swicloud.atlassian.net/browse/NH-39995~~ EDIT: Done ✅ 

Adds a custom distro-side default for `OTEL_PYTHON_LOG_FORMAT` which is used by [opentelemetry-logging-instrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-logging) to set format of all logs from Python `logging` module and include trace context information. It's a default, so customer can still specify their own `OTEL_PYTHON_LOG_FORMAT` by environment variable.

Default format is:
`%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] [trace_id=%(otelTraceID)s span_id=%(otelSpanID)s trace_flags=%(otelTraceSampled)02d resource.service.name=%(otelServiceName)s] - %(message)s`

Example log with that format:
`2:08:10,279 WARNING [root] [app.py:26] [trace_id=4442bce141ca9101bddcbec545d8e826 span_id=53033a49320fe226 trace_flags=01 resource.service.name=my-otel-envvar-service-name] - Made autoinstrumented request to sw.com`

Manual testing description and results here: https://swicloud.atlassian.net/wiki/spaces/NIT/pages/3567091735/2022-05-02+Trace+context+in+logs EDIT: I tested again on May 23 and results were the same.