### PR TITLE
NH-40333 Adjust config-related logging

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -531,9 +531,14 @@ class SolarWindsApmConfig:
     def update_transaction_filters(self, cnf_dict: dict) -> None:
         """Update configured transaction_filters using config dict"""
         txn_settings = cnf_dict.get("transactionSettings")
-        if not txn_settings or not isinstance(txn_settings, list):
+        if not txn_settings:
+            logger.debug(
+                "No transaction filters provided by config."
+            )
+            return
+        if not isinstance(txn_settings, list):
             logger.warning(
-                "Transaction filters must be a non-empty list of filters. Ignoring."
+                "Transaction filters must be a list of filters. Ignoring."
             )
             return
         for filter in txn_settings:

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -532,9 +532,7 @@ class SolarWindsApmConfig:
         """Update configured transaction_filters using config dict"""
         txn_settings = cnf_dict.get("transactionSettings")
         if not txn_settings:
-            logger.debug(
-                "No transaction filters provided by config."
-            )
+            logger.debug("No transaction filters provided by config.")
             return
         if not isinstance(txn_settings, list):
             logger.warning(

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -75,6 +75,7 @@ class SolarWindsApmConfig:
     done only once during the initialization and the properties cannot be refreshed.
     """
 
+    _CONFIG_FILE_DEFAULT = "./solarwinds-apm-config.json"
     _DELIMITER = "."
     _KEY_MASK = "{}...{}:{}"
     _KEY_MASK_BAD_FORMAT = "{}...<invalid_format>"
@@ -481,10 +482,15 @@ class SolarWindsApmConfig:
 
     def get_cnf_dict(self) -> Any:
         """Load Python dict from confg file (json), if any"""
-        cnf_filepath = os.environ.get(
-            "SW_APM_CONFIG_FILE", "./solarwinds-apm-config.json"
-        )
+        cnf_filepath = os.environ.get("SW_APM_CONFIG_FILE")
         cnf_dict = None
+
+        if not cnf_filepath:
+            cnf_filepath = self._CONFIG_FILE_DEFAULT
+            if not os.path.isfile(cnf_filepath):
+                logger.debug("No config file at %s; skipping", cnf_filepath)
+                return cnf_dict
+
         try:
             with open(cnf_filepath, encoding="utf-8") as cnf_file:
                 try:


### PR DESCRIPTION
Adjusts some config-related logging that was a little misleading.

### Before:

If `SW_APM_CONFIG_FILE` is not set, the default is used (`./solarwinds-apm-config.json`). A config file actually being there should be optional, but instead error logs every time: `[ solarwinds_apm.apm_config ERROR    p#1.139799927957312] Invalid config file path. Ignoring: [Errno 2] No such file or directory: './solarwinds-apm-config.json'`

If no transaction filters are provided, including when if no config file is provided, then this is ok. But this message isn't great when that's the case: `[ solarwinds_apm.apm_config WARNING  p#1.140511341504320] Transaction filters must be a non-empty list of filters. Ignoring.`

### After:

If `SW_APM_CONFIG_FILE` is not set and there is no file at the default `./solarwinds-apm-config.json`, there is a debug message: `[ solarwinds_apm.apm_config DEBUG    p#1.140144370591552] No config file at ./solarwinds-apm-config.json; skipping`

If no transaction filters are provided (no config file, or config file without KV for `transactionSettings`), there is a debug message: `[ solarwinds_apm.apm_config DEBUG    p#1.140327568500544] No transaction filters provided by config.`

If a config file has `transactionSettings: []`, `update_transaction_filters` does not log. At highest debug level, the ApmConfig init will [log what the entire config is](https://github.com/solarwindscloud/solarwinds-apm-python/blob/3813946035c71538323278fcb665af69a5c2764d/solarwinds_apm/apm_config.py#L145) when complete.

Please let me know if any questions/suggestions!