### PR TITLE
NH-39019 PoC: Use default OTel OTLPMetricExporter

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
 python_requires = >=3.7
 install_requires =
     opentelemetry-api == 1.17.0
+    opentelemetry-exporter-otlp == 1.17.0
     opentelemetry-sdk == 1.17.0
     opentelemetry-instrumentation == 0.38b0
 packages = solarwinds_apm, solarwinds_apm.api, solarwinds_apm.certs, solarwinds_apm.extension

--- a/solarwinds_apm/apm_constants.py
+++ b/solarwinds_apm/apm_constants.py
@@ -6,6 +6,7 @@
 
 INTL_SWO_AO_COLLECTOR = "collector.appoptics.com"
 INTL_SWO_AO_STG_COLLECTOR = "collector-stg.appoptics.com"
+INTL_SWO_CHAINSAW_COLLECTOR_NA = "otel.collector.na-01.cloud.solarwinds.com:443"
 INTL_SWO_CURRENT_SPAN_ID = "sw-current-entry-span-id"
 INTL_SWO_CURRENT_TRACE_ID = "sw-current-trace-id"
 INTL_SWO_COMMA = ","

--- a/solarwinds_apm/apm_constants.py
+++ b/solarwinds_apm/apm_constants.py
@@ -6,7 +6,9 @@
 
 INTL_SWO_AO_COLLECTOR = "collector.appoptics.com"
 INTL_SWO_AO_STG_COLLECTOR = "collector-stg.appoptics.com"
-INTL_SWO_CHAINSAW_COLLECTOR_NA = "otel.collector.na-01.cloud.solarwinds.com:443"
+INTL_SWO_CHAINSAW_COLLECTOR_NA = (
+    "otel.collector.na-01.cloud.solarwinds.com:443"
+)
 INTL_SWO_CURRENT_SPAN_ID = "sw-current-entry-span-id"
 INTL_SWO_CURRENT_TRACE_ID = "sw-current-trace-id"
 INTL_SWO_COMMA = ","

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -45,6 +45,7 @@ from pkg_resources import get_distribution, iter_entry_points, load_entry_point
 from solarwinds_apm import apm_logging
 from solarwinds_apm.apm_config import SolarWindsApmConfig
 from solarwinds_apm.apm_constants import (
+    INTL_SWO_CHAINSAW_COLLECTOR_NA,
     INTL_SWO_DEFAULT_PROPAGATORS,
     INTL_SWO_DEFAULT_TRACES_EXPORTER,
     INTL_SWO_SUPPORT_EMAIL,

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -14,7 +14,6 @@ import time
 
 from opentelemetry import metrics
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 
@@ -97,28 +96,17 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         """Configure OTel sampler, exporter, propagator, response propagator"""
         self._configure_sampler(apm_config)
         if apm_config.agent_enabled:
-            # self._configure_metrics_span_processor(
-            #     apm_txname_manager,
-            #     apm_config,
-            # )
-            # self._configure_exporter(
-            #     reporter,
-            #     apm_txname_manager,
-            #     apm_fwkv_manager,
-            #     apm_config.agent_enabled,
-            # )
-
-            resource=Resource.create(
-                {"service.name": apm_config.service_name}
-            )
-            self._configure_otlp_trace_exporter(
+            self._configure_metrics_span_processor(
+                apm_txname_manager,
                 apm_config,
-                resource,
             )
-            self._configure_otlp_metrics_exporter(
-                apm_config,
-                resource,
+            self._configure_exporter(
+                reporter,
+                apm_txname_manager,
+                apm_fwkv_manager,
+                apm_config.agent_enabled,
             )
+            self._configure_metrics_exporter(apm_config)
             self._configure_propagator()
             self._configure_response_propagator()
         else:
@@ -231,31 +219,19 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
             span_processor = BatchSpanProcessor(exporter)
             trace.get_tracer_provider().add_span_processor(span_processor)
 
-    def _configure_otlp_trace_exporter(
+    def _configure_metrics_exporter(
         self,
         apm_config: SolarWindsApmConfig,
-        resource: Resource,
-    ) -> None:
-        """Configure default OTLP GRPC trace exporter, or none if agent disabled."""
-        if not apm_config.agent_enabled:
-            logger.error("Tracing disabled. Cannot set span_processor.")
-            return
-
-        provider = TracerProvider(resource=resource)
-        processor = BatchSpanProcessor(OTLPSpanExporter(endpoint="apm.collector.cloud.solarwinds.com:443"))
-        provider.add_span_processor(processor)
-        trace.set_tracer_provider(provider)
-
-    def _configure_otlp_metrics_exporter(
-        self,
-        apm_config: SolarWindsApmConfig,
-        resource: Resource,
     ) -> None:
         """Configure default OTLP GRPC metrics exporter, or none if agent disabled."""
         if not apm_config.agent_enabled:
             logger.error("Tracing disabled. Cannot set span_processor.")
             return
 
+        # This is not the only Resource we create in distro; should consolidate later?
+        resource=Resource.create(
+            {"service.name": apm_config.service_name}
+        )
         reader = PeriodicExportingMetricReader(
             OTLPMetricExporter(endpoint="apm.collector.cloud.solarwinds.com:443")
         )

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -33,7 +33,10 @@ from opentelemetry.propagate import set_global_textmap
 from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.sdk._configuration import _OTelSDKConfigurator
 from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.metrics.export import (
+    ConsoleMetricExporter,
+    PeriodicExportingMetricReader,
+)
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -260,7 +263,12 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                 ),
             )
         )
-        provider = MeterProvider(resource=resource, metric_readers=[reader])
+
+        # For debug exploration only
+        local_reader = PeriodicExportingMetricReader(ConsoleMetricExporter())
+        provider = MeterProvider(
+            resource=resource, metric_readers=[reader, local_reader]
+        )
         metrics.set_meter_provider(provider)
 
     def _configure_propagator(self) -> None:

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -15,7 +15,10 @@ import time
 from opentelemetry import metrics
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.metrics.export import (
+    ConsoleMetricExporter,
+    PeriodicExportingMetricReader,
+)
 
 from opentelemetry import trace
 from opentelemetry.environment_variables import (
@@ -232,8 +235,17 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         resource=Resource.create(
             {"service.name": apm_config.service_name}
         )
+        # reader = PeriodicExportingMetricReader(ConsoleMetricExporter())
         reader = PeriodicExportingMetricReader(
-            OTLPMetricExporter(endpoint=os.environ.get("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://otel-collector:4317"))
+            OTLPMetricExporter(
+                # endpoint="http://otel-collector:4317",
+                # endpoint=os.environ.get("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "otel.collector.na-01.cloud.solarwinds.com"),
+                endpoint="otel.collector.na-01.cloud.solarwinds.com:443",
+                headers={
+                    "authorization": f"Bearer {os.environ.get('API_TOKEN')}"
+                },
+                insecure=False,
+            )
         )
         provider = MeterProvider(resource=resource, metric_readers=[reader])
         metrics.set_meter_provider(provider)

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -233,7 +233,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
             {"service.name": apm_config.service_name}
         )
         reader = PeriodicExportingMetricReader(
-            OTLPMetricExporter(endpoint="apm.collector.cloud.solarwinds.com:443")
+            OTLPMetricExporter(endpoint=os.environ.get("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://otel-collector:4317"))
         )
         provider = MeterProvider(resource=resource, metric_readers=[reader])
         metrics.set_meter_provider(provider)

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ setenv =
 basepython: python3.9
 deps =
   opentelemetry-api
+  opentelemetry-exporter-otlp
   opentelemetry-sdk
   opentelemetry-instrumentation
   pylint


### PR DESCRIPTION
This is a proof-of-concept of a potential short-term solution for Python APM supporting Otel-based, OTLP metrics creation and export to SWO. This functionality is added while Python APM continues to use liboboe and support AO-style inbound metrics and AO-style trace export to SWO.

For a full description, please see this Confluence doc: https://swicloud.atlassian.net/wiki/spaces/NIT/pages/3585474922/SWO+APM+Python+and+OTLP+Metrics+PoC