### PR TITLE
NH-39995 Bump Otel Python 1.18.0/0.39b0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.9.0) - 2023-04-20
 ### Changed
-- OpenTelemetry API/SDK 1.18.0 ([#131](https://github.com/solarwindscloud/solarwinds-apm-python/pull/131))
+- OpenTelemetry API/SDK 1.17.0 ([#131](https://github.com/solarwindscloud/solarwinds-apm-python/pull/131))
 - SolarWinds c-lib 12.2.0, to fix memory leak in extension ([#132](https://github.com/solarwindscloud/solarwinds-apm-python/pull/132))
 - Adds support for `SW_APM_CONFIG_FILE` ([#133](https://github.com/solarwindscloud/solarwinds-apm-python/pull/133))
 - Updates Span Layer to be `<KIND>:<NAME>` ([#134](https://github.com/solarwindscloud/solarwinds-apm-python/pull/134))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.9.0) - 2023-04-20
 ### Changed
-- OpenTelemetry API/SDK 1.17.0 ([#131](https://github.com/solarwindscloud/solarwinds-apm-python/pull/131))
+- OpenTelemetry API/SDK 1.18.0 ([#131](https://github.com/solarwindscloud/solarwinds-apm-python/pull/131))
 - SolarWinds c-lib 12.2.0, to fix memory leak in extension ([#132](https://github.com/solarwindscloud/solarwinds-apm-python/pull/132))
 - Adds support for `SW_APM_CONFIG_FILE` ([#133](https://github.com/solarwindscloud/solarwinds-apm-python/pull/133))
 - Updates Span Layer to be `<KIND>:<NAME>` ([#134](https://github.com/solarwindscloud/solarwinds-apm-python/pull/134))

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
-opentelemetry-test-utils==0.38b0
-opentelemetry-instrumentation-flask==0.38b0
-opentelemetry-instrumentation-requests==0.38b0
+opentelemetry-test-utils==0.39b0
+opentelemetry-instrumentation-flask==0.39b0
+opentelemetry-instrumentation-requests==0.39b0
 pytest
 pytest-cov
 pytest-mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,9 +23,9 @@ classifiers =
 [options]
 python_requires = >=3.7
 install_requires =
-    opentelemetry-api == 1.17.0
-    opentelemetry-sdk == 1.17.0
-    opentelemetry-instrumentation == 0.38b0
+    opentelemetry-api == 1.18.0
+    opentelemetry-sdk == 1.18.0
+    opentelemetry-instrumentation == 0.39b0
 packages = solarwinds_apm, solarwinds_apm.api, solarwinds_apm.certs, solarwinds_apm.extension
 
 [options.package_data]


### PR DESCRIPTION
Bumps Python APM to latest Otel Python 1.18.0/0.390b.

Test traces:
* [SWO Django trace](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/FA3CB76CA143FB47B48EE20B92659E4D/5D7919D6503DF943/details/breakdown?perspective=requests&serviceId=e-1540126275982954496)
* [SWO FastAPI trace](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/1A50BEA107273B530D29CF1A7CC49E68/2FB153D1E9770FC3/details/breakdown?perspective=requests&serviceId=e-1563388155741380608)
* [AO Django trace](https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/D14D92CF5E8BDB27A4663678ED38B43800000000/details)
* [AO FastAPI trace](https://my.appoptics.com/apm/123092/services/asgi_app_ot/traces/BE59591BEF175540A1B09928E2957CA500000000/details)

tox tests pass on this PR.