### PR TITLE
NH-41682 Testrelease 0.11.0.0

### DIFF
--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -544,6 +544,20 @@ jobs:
   # x86_64 Python 3.10
   #--------------------------------------------------------------------
 
+  py310_install_amazon2023:
+    runs-on: ubuntu-latest
+    container:
+      image: amazonlinux:2023
+      options: --hostname py3.10-amazon2023
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup and run install test
+      working-directory: ./tests/docker/install
+      run: ./_helper_run_install_tests.sh
+      shell: sh
+      env:
+        MODE: ${{ github.event.inputs.install-registry }}
+
   py310_install_debian10:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -551,7 +551,7 @@ jobs:
       options: --hostname py3.10-amazon2023
     steps:
     - name: Install checkout deps
-      run: yum update -y && yum install -y tar
+      run: yum update -y && yum install -y tar gzip
     - uses: actions/checkout@v3
     - name: Setup and run install test
       working-directory: ./tests/docker/install

--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -84,30 +84,6 @@ jobs:
         --rm python:3.7-alpine3.12 \
         /bin/sh -c "./_helper_run_install_tests.sh"
 
-  aarch64_py37_install_amazon2:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-    - uses: actions/checkout@v3
-    - name: Run install test container with QEMU
-      run: |
-        sudo docker run \
-        --platform linux/arm64 \
-        -e MODE=${{ github.event.inputs.install-registry }} \
-        -e SOLARWINDS_APM_VERSION=${{ github.event.inputs.solarwinds-version }} \
-        -e SW_APM_COLLECTOR_AO_PROD=${{ secrets.SW_APM_COLLECTOR_AO_PROD }} \
-        -e SW_APM_COLLECTOR_PROD=${{ secrets.SW_APM_COLLECTOR_PROD }} \
-        -e SW_APM_COLLECTOR_STAGING=${{ secrets.SW_APM_COLLECTOR_STAGING }} \
-        -e SW_APM_SERVICE_KEY_AO_PROD=${{ secrets.SW_APM_SERVICE_KEY_AO_PROD }} \
-        -e SW_APM_SERVICE_KEY_PROD=${{ secrets.SW_APM_SERVICE_KEY_PROD }} \
-        -e SW_APM_SERVICE_KEY_STAGING=${{ secrets.SW_APM_SERVICE_KEY_STAGING }} \
-        -h py3.7-install-amazon2 \
-        -v $(pwd):/home \
-        -w /home/tests/docker/install \
-        --rm amazonlinux:2 \
-        /bin/sh -c "./_helper_run_install_tests.sh"
-
   aarch64_py38_install_debian10:
     runs-on: ubuntu-latest
     steps:
@@ -178,6 +154,30 @@ jobs:
         -v $(pwd):/home \
         -w /home/tests/docker/install \
         --rm centos:8 \
+        /bin/sh -c "./_helper_run_install_tests.sh"
+
+  aarch64_py310_install_amazon2023:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - uses: actions/checkout@v3
+    - name: Run install test container with QEMU
+      run: |
+        sudo docker run \
+        --platform linux/arm64 \
+        -e MODE=${{ github.event.inputs.install-registry }} \
+        -e SOLARWINDS_APM_VERSION=${{ github.event.inputs.solarwinds-version }} \
+        -e SW_APM_COLLECTOR_AO_PROD=${{ secrets.SW_APM_COLLECTOR_AO_PROD }} \
+        -e SW_APM_COLLECTOR_PROD=${{ secrets.SW_APM_COLLECTOR_PROD }} \
+        -e SW_APM_COLLECTOR_STAGING=${{ secrets.SW_APM_COLLECTOR_STAGING }} \
+        -e SW_APM_SERVICE_KEY_AO_PROD=${{ secrets.SW_APM_SERVICE_KEY_AO_PROD }} \
+        -e SW_APM_SERVICE_KEY_PROD=${{ secrets.SW_APM_SERVICE_KEY_PROD }} \
+        -e SW_APM_SERVICE_KEY_STAGING=${{ secrets.SW_APM_SERVICE_KEY_STAGING }} \
+        -h py3.10-install-amazon2023 \
+        -v $(pwd):/home \
+        -w /home/tests/docker/install \
+        --rm amazonlinux:2023 \
         /bin/sh -c "./_helper_run_install_tests.sh"
 
   aarch64_py310_install_ubuntu2004:
@@ -300,24 +300,6 @@ jobs:
       image: ubuntu:18.04
       options: --hostname py3.7-ubuntu18.04
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup and run install test
-      working-directory: ./tests/docker/install
-      run: ./_helper_run_install_tests.sh
-      shell: sh
-      env:
-        MODE: ${{ github.event.inputs.install-registry }}
-
-  py37_install_amazon2:
-    runs-on: ubuntu-latest
-    container:
-      image: amazonlinux:2
-      options: --hostname py3.7-install-amazon2
-    steps:
-    - name: Install latest git and tar
-      run: |
-        yum update -y
-        yum install -y git tar
     - uses: actions/checkout@v3
     - name: Setup and run install test
       working-directory: ./tests/docker/install

--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -550,6 +550,8 @@ jobs:
       image: amazonlinux:2023
       options: --hostname py3.10-amazon2023
     steps:
+    - name: Install checkout deps
+      run: yum update -y && yum install -y tar
     - uses: actions/checkout@v3
     - name: Setup and run install test
       working-directory: ./tests/docker/install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.10.0...HEAD)
+## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.11.0...HEAD)
+
+## [0.11.0.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.11.0) - 2023-05-23
+### Added
+- Added trace context to logging ([#146](https://github.com/solarwindscloud/solarwinds-apm-python/pull/146))
+
+### Changed
+- Adjusted config file logging ([#147](https://github.com/solarwindscloud/solarwinds-apm-python/pull/147))
+- OpenTelemetry API/SDK 1.18.0 ([#150](https://github.com/solarwindscloud/solarwinds-apm-python/pull/150))
+
 
 ## [0.10.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.10.0) - 2023-05-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Adjusted config file logging ([#147](https://github.com/solarwindscloud/solarwinds-apm-python/pull/147))
 - OpenTelemetry API/SDK 1.18.0 ([#150](https://github.com/solarwindscloud/solarwinds-apm-python/pull/150))
+- Added Amazon 2023 install tests; removed Amazon 2018 and Amazon 2 install tests ([#151](https://github.com/solarwindscloud/solarwinds-apm-python/pull/151))
 
 
 ## [0.10.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.10.0) - 2023-05-01

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.11.0.3"
+__version__ = "0.11.0.4"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.11.0.0"
+__version__ = "0.11.0.1"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.11.0.2"
+__version__ = "0.11.0.3"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.10.0"
+__version__ = "0.11.0.0"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.11.0.1"
+__version__ = "0.11.0.2"

--- a/tests/docker/install/_helper_run_install_tests.sh
+++ b/tests/docker/install/_helper_run_install_tests.sh
@@ -94,11 +94,10 @@ echo "Installing test dependencies for Python $python_version on $pretty_name"
             echo "ERROR: Testing on Ubuntu <18.04 not supported."
             exit 1
         fi
-    
+
     elif grep "Amazon Linux" /etc/os-release; then
         yum update -y
-        if grep "Amazon Linux 2" /etc/os-release; then
-            # agent and test deps for py3.7
+        if grep "Amazon Linux 2023" /etc/os-release; then
             yum install -y \
                 python3-devel \
                 python3-pip \
@@ -110,24 +109,19 @@ echo "Installing test dependencies for Python $python_version on $pretty_name"
                 tar \
                 gzip
             update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-            update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1              
+            # cannot symlink/update-alternatives nor upgrade pip
         else
-            # agent and test deps
-            yum install -y \
-                "python$python_version_no_dot-devel" \
-                "python$python_version_no_dot-pip" \
-                "python$python_version_no_dot-setuptools" \
-                gcc \
-                gcc-c++ \
-                unzip \
-                findutils
-            alternatives --set python "/usr/bin/python$python_version"
+            echo "ERROR: Testing on Amazon <2023 not supported."
+            exit 1
         fi
     fi
 } >/dev/null
 
-# need at least pip 19.3 to find manylinux wheels
-pip install --upgrade pip >/dev/null
+# need at least pip 19.3 to find manylinux wheels (except Amazon Linux)
+is_amzn=$(find /etc/os-release -not -name "Amazon Linux")
+if [ ! "$is_amzn" = "/etc/os-release" ]; then
+    pip install --upgrade pip >/dev/null
+fi
 
 # run tests using bash so we can use pipefail
 bash -c "set -o pipefail && ./install_tests.sh 2>&1"

--- a/tests/docker/install/_helper_run_install_tests.sh
+++ b/tests/docker/install/_helper_run_install_tests.sh
@@ -33,6 +33,8 @@ echo "Installing test dependencies for Python $python_version on $pretty_name"
         # agent deps
         apk add python3-dev g++ make curl
 
+        pip install --upgrade pip >/dev/null
+
     elif grep "CentOS Linux 8" /etc/os-release; then
         # fix centos8 metadata download failures for repo 'appstream'
         # https://stackoverflow.com/a/71077606
@@ -51,6 +53,8 @@ echo "Installing test dependencies for Python $python_version on $pretty_name"
             ln -s "/usr/bin/python$python_version" /usr/local/bin/python
         command -v pip ||
             ln -s /usr/bin/pip3 /usr/local/bin/pip
+        
+        pip install --upgrade pip >/dev/null
     
     elif grep Ubuntu /etc/os-release; then
         ubuntu_version=$(grep VERSION_ID /etc/os-release | sed 's/VERSION_ID="//' | sed 's/"//')
@@ -90,6 +94,8 @@ echo "Installing test dependencies for Python $python_version on $pretty_name"
             # https://pip.pypa.io/en/stable/installation/#get-pip-py
             wget https://bootstrap.pypa.io/get-pip.py
             python get-pip.py
+
+            pip install --upgrade pip >/dev/null
         else
             echo "ERROR: Testing on Ubuntu <18.04 not supported."
             exit 1

--- a/tests/docker/install/_helper_run_install_tests.sh
+++ b/tests/docker/install/_helper_run_install_tests.sh
@@ -123,11 +123,5 @@ echo "Installing test dependencies for Python $python_version on $pretty_name"
     fi
 } >/dev/null
 
-# need at least pip 19.3 to find manylinux wheels (except Amazon Linux)
-is_amzn=$(find /etc/os-release -not -name "Amazon Linux")
-if [ ! "$is_amzn" = "/etc/os-release" ]; then
-    pip install --upgrade pip >/dev/null
-fi
-
 # run tests using bash so we can use pipefail
 bash -c "set -o pipefail && ./install_tests.sh 2>&1"

--- a/tests/docker/install/client.py
+++ b/tests/docker/install/client.py
@@ -42,7 +42,7 @@ def request_server(attempts=10):
 
 if __name__ == "__main__":
     logger.debug("Waiting a moment for instrumented app to start...")
-    time.sleep(10)
+    time.sleep(20)
     request_server()
     logger.debug("Waiting a moment in case reporter needs extra time...")
     time.sleep(10)

--- a/tests/docker/install/client.py
+++ b/tests/docker/install/client.py
@@ -41,6 +41,8 @@ def request_server(attempts=10):
 
 
 if __name__ == "__main__":
+    logger.debug("Waiting a moment for instrumented app to start...")
+    time.sleep(10)
     request_server()
     logger.debug("Waiting a moment in case reporter needs extra time...")
     time.sleep(10)

--- a/tests/docker/install/docker-compose.yml
+++ b/tests/docker/install/docker-compose.yml
@@ -121,15 +121,6 @@ services:
     environment:
       << : *envvars-install-test
 
-  py3.8-install-amazon2018.03:
-    hostname: "py3.8-amazon2018.03"
-    image: "amazonlinux:2018.03"
-    << : *command-install-test
-    << : *workdir
-    << : *volumes-codebase
-    environment:
-      << : *envvars-install-test
-
   py3.8-install-alpine3.12:
     hostname: "py3.8-alpine3.12"
     image: "python:3.8-alpine3.12"

--- a/tests/docker/install/docker-compose.yml
+++ b/tests/docker/install/docker-compose.yml
@@ -63,15 +63,6 @@ services:
     environment:
       << : *envvars-install-test
 
-  py3.7-install-amazon2:
-    hostname: "py3.7-amazon2"
-    image: "amazonlinux:2"
-    << : *command-install-test
-    << : *workdir
-    << : *volumes-codebase
-    environment:
-      << : *envvars-install-test
-
   py3.7-install-alpine3.12:
     hostname: "py3.7-alpine3.12"
     image: "python:3.7-alpine3.12"
@@ -236,6 +227,15 @@ services:
   #--------------------------------------------------------------------
   # Python 3.10
   #--------------------------------------------------------------------
+
+  py3.10-install-amazon2023:
+    hostname: "py3.10-amazon2023"
+    image: "amazonlinux:2023"
+    << : *command-install-test
+    << : *workdir
+    << : *volumes-codebase
+    environment:
+      << : *envvars-install-test
 
   py3.10-install-debian10:
     hostname: "py3.10-debian10"


### PR DESCRIPTION
Testrelease Python APM 0.11.0.4. This branch also includes some install test updates:
1. Switch from Amazon 2 to Amazon 2023 install testing as per upstream urllib3 v2.0 update [recommendations](https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html#common-upgrading-issues).
2. Remove a stray Amazon 2018 install test because it's [EOL Dec 31 2020](https://endoflife.date/amazon-linux) and we don’t list it on the [customer docs](https://documentation.solarwinds.com/en/success_center/observability/content/system_requirements/apm_requirements.htm#operating-systems)
3. Add a sleep to the install tests before the client makes requests to the test Flask server, to address https://swicloud.atlassian.net/browse/NH-40332.
 
tox tests pass on this PR.

Test traces:
* [SWO Django trace](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/380B6BD7FB3D80C9C4A78D48BE3A8B77/94388BECFD25BEC4/details/breakdown?perspective=requests&serviceId=e-1540126275982954496)
* [SWO FastAPI trace](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/EED92460D41DF8F511D2E7DBDB2F7A10/A56041B77E4B8DEB/details/breakdown?perspective=requests&serviceId=e-1563388155741380608&duration=3600)
* [AO Django trace](https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/4004B8327A7293BCD8188F324DADDAFA00000000?duration=3600)
* [AO FastAPI trace](https://my.appoptics.com/apm/123092/services/asgi_app_ot/traces/2A149574F90073C4FAE3D9998EAFFF2D00000000?duration=3600)

Released to TestPyPI here: https://test.pypi.org/project/solarwinds-apm/0.11.0.4/#files

Install-from-TestPyPI tests: https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/5082866602 _except_ `aarch64_py310_install_amazon2023` which is taking forever 🙃 . `py310_install_amazon2023` and the other `aarch64` tests have passed.
