### PR TITLE
NH-41991 Add stub for verify_install_arm64.yaml

### DIFF
--- a/.github/workflows/verify_install_arm64.yaml
+++ b/.github/workflows/verify_install_arm64.yaml
@@ -71,6 +71,7 @@ jobs:
       - run: echo "Hello from EC2 ${{ matrix.job }} !"
 
   terminate-arm64:
+    if: ${{ always() }}
     needs:
       - launch-arm64
       - install-tests

--- a/.github/workflows/verify_install_arm64.yaml
+++ b/.github/workflows/verify_install_arm64.yaml
@@ -62,9 +62,10 @@ jobs:
     needs:
       - launch-arm64
     strategy:
-      matrix: |
-        py3.7-ubuntu18.04
-        py3.11-ubuntu20.04
+      matrix:
+        job:
+          - py3.7-ubuntu18.04
+          - py3.11-ubuntu20.04
     runs-on: ${{ fromJSON(needs.launch-runners.outputs.matrix)[matrix.job].label }}
     steps:
       - run: echo "Hello from EC2 ${{ matrix.job }} !"

--- a/.github/workflows/verify_install_arm64.yaml
+++ b/.github/workflows/verify_install_arm64.yaml
@@ -37,7 +37,7 @@ jobs:
     outputs:
       matrix: ${{ steps.launch.outputs.matrix }}
     steps:
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.CI_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.CI_SECRET_ACCESS_KEY }}
@@ -76,7 +76,7 @@ jobs:
       - install-tests
     runs-on: ubuntu-latest
     steps:
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.CI_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.CI_SECRET_ACCESS_KEY }}

--- a/.github/workflows/verify_install_arm64.yaml
+++ b/.github/workflows/verify_install_arm64.yaml
@@ -1,0 +1,87 @@
+# © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+name: Verify Installation ARM64
+
+on:
+  workflow_dispatch:
+    inputs:
+      install-registry:
+        required: true
+        description: 'Registry used for install tests, e.g. pypi, testpypi, packagecloud'
+        type: choice
+        default: 'pypi'
+        options:
+        - pypi
+        - packagecloud
+        - testpypi
+      solarwinds-version:
+        required: false
+        description: 'Optional solarwinds-apm version, e.g. 0.0.3.2'
+
+env:
+  SOLARWINDS_APM_VERSION: ${{ github.event.inputs.solarwinds-version }}
+  SW_APM_COLLECTOR_AO_PROD: ${{ secrets.SW_APM_COLLECTOR_AO_PROD }}
+  SW_APM_COLLECTOR_PROD: ${{ secrets.SW_APM_COLLECTOR_PROD }}
+  SW_APM_COLLECTOR_STAGING: ${{ secrets.SW_APM_COLLECTOR_STAGING }}
+  SW_APM_SERVICE_KEY_AO_PROD: ${{ secrets.SW_APM_SERVICE_KEY_AO_PROD }}
+  SW_APM_SERVICE_KEY_PROD: ${{ secrets.SW_APM_SERVICE_KEY_PROD }}
+  SW_APM_SERVICE_KEY_STAGING: ${{ secrets.SW_APM_SERVICE_KEY_STAGING }}
+
+jobs:
+  launch-arm64:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.launch.outputs.matrix }}
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.CI_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CI_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - id: launch
+        uses: solarwindscloud/ec2-runner-action@main
+        with:
+          action: launch
+          matrix: |
+            py3.7-ubuntu18.04
+            py3.11-ubuntu20.04
+          github-token: ${{ secrets.CI_GITHUB_TOKEN }}
+          runner-user: github
+          runner-directory: /github/actions
+          instance-type: t4g.medium
+          ami-name: gha-arm64-ubuntu22-.*
+          ami-owner: "858939916050"
+          subnet-id: subnet-0fd499f8a50e41807
+          security-group-ids: sg-0fd8d8cd6effda4a5
+
+  install-tests:
+    needs:
+      - launch-arm64
+    strategy:
+      matrix: |
+        py3.7-ubuntu18.04
+        py3.11-ubuntu20.04
+    runs-on: ${{ fromJSON(needs.launch-runners.outputs.matrix)[matrix.job].label }}
+    steps:
+      - run: echo "Hello from EC2 ${{ matrix.job }} !"
+
+  terminate-arm64:
+    needs:
+      - launch-arm64
+      - install-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.CI_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CI_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - uses: solarwindscloud/ec2-runner-action@main
+        with:
+          action: terminate
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          matrix: ${{ needs.launch-arm64.outputs.matrix }}


### PR DESCRIPTION
Adds stub for verify_install_arm64.yaml that uses https://github.com/solarwindscloud/ec2-runner-action. Adds two jobs in matrix that will `echo` to make sure new secrets work. After this PR to `main` I can run the action with dispatch and update it.