### PR TITLE
NH-31430 Add Ubuntu 22, use current setuptools in install tests

### DIFF
--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -52,6 +52,7 @@ jobs:
             registry.fedoraproject.org/f33/python3
             ubuntu:18.04
             ubuntu:20.04
+            ubuntu:22.04
             python:3.7-alpine3.12
             python:3.7-alpine3.13
             python:3.7-alpine3.17
@@ -92,6 +93,7 @@ jobs:
           - registry.fedoraproject.org/f33/python3
           - ubuntu:18.04
           - ubuntu:20.04
+          - ubuntu:22.04
           - python:3.7-alpine3.12
           - python:3.7-alpine3.13
           - python:3.7-alpine3.17
@@ -131,10 +133,14 @@ jobs:
             hostname: py3.9-ubuntu20.04
           - image: ubuntu:20.04
             hostname: py3.10-ubuntu20.04
+          - image: ubuntu:22.04
+            hostname: py3.10-ubuntu22.04
           - image: ubuntu:20.04
             hostname: py3.11-ubuntu20.04
           - image: ubuntu:20.04
             hostname: py3.11-ubuntu20.04
+          - image: ubuntu:22.04
+            hostname: py3.11-ubuntu22.04
           - image: python:3.7-alpine3.12
             hostname: py3.7-alpine3.12
           - image: python:3.7-alpine3.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Verify Installation tests run on EC2 ([#156](https://github.com/solarwindscloud/solarwinds-apm-python/pull/156))
+- Installation tests include Ubuntu 22 ([#158](https://github.com/solarwindscloud/solarwinds-apm-python/pull/158))
 
 ## [0.11.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.11.0) - 2023-05-25
 ### Added

--- a/tests/docker/install/_helper_run_install_tests.sh
+++ b/tests/docker/install/_helper_run_install_tests.sh
@@ -63,7 +63,7 @@ echo "Installing test dependencies for Python $python_version on $pretty_name"
             TZ=America
             ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
             if [ "$python_version" = "3.10" ] || [ "$python_version" = "3.11" ]; then
-                # py3.10,3.11 not currently on main apt repo so use deadsnakes
+                # py3.10,3.11 not currently on main apt repo for ubuntu 18/20 so use deadsnakes
                 apt-get install -y software-properties-common
                 add-apt-repository ppa:deadsnakes/ppa -y
                 apt-get install -y \
@@ -89,17 +89,33 @@ echo "Installing test dependencies for Python $python_version on $pretty_name"
                 update-alternatives --install /usr/bin/python python "/usr/bin/python$python_version" 1
             fi
             
-            # Make sure we don't install py3.6's pip
-            # Official get-pip documentation:
-            # https://pip.pypa.io/en/stable/installation/#get-pip-py
-            wget https://bootstrap.pypa.io/get-pip.py
-            python get-pip.py
+        elif [ "$ubuntu_version" = "22.04" ]; then
+            apt-get update -y
+            TZ=America
+            ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-            pip install --upgrade pip >/dev/null
+            apt-get install -y \
+                "python$python_version" \
+                "python$python_version-distutils" \
+                "python$python_version-dev" \
+                python3-setuptools \
+                build-essential \
+                unzip \
+                wget \
+                curl
+            update-alternatives --install /usr/bin/python python "/usr/bin/python$python_version" 1
+
         else
             echo "ERROR: Testing on Ubuntu <18.04 not supported."
             exit 1
         fi
+
+        # Make sure we don't install py3.6's pip on ubuntu
+        # Official get-pip documentation:
+        # https://pip.pypa.io/en/stable/installation/#get-pip-py
+        wget https://bootstrap.pypa.io/get-pip.py
+        python get-pip.py
+        pip install --upgrade pip >/dev/null
 
     elif grep "Amazon Linux" /etc/os-release; then
         yum update -y

--- a/tests/docker/install/client.py
+++ b/tests/docker/install/client.py
@@ -41,8 +41,6 @@ def request_server(attempts=10):
 
 
 if __name__ == "__main__":
-    logger.debug("Waiting a moment for instrumented app to start...")
-    time.sleep(20)
     request_server()
     logger.debug("Waiting a moment in case reporter needs extra time...")
     time.sleep(10)

--- a/tests/docker/install/docker-compose.yml
+++ b/tests/docker/install/docker-compose.yml
@@ -204,6 +204,13 @@ services:
     environment:
       << : *envvars-install-test
 
+  py3.10-install-ubuntu22.04:
+    hostname: "py3.10-ubuntu22.04"
+    image: "ubuntu:22.04"
+    << : [*command-install-test, *workdir, *volumes-codebase]
+    environment:
+      << : *envvars-install-test
+
   py3.10-install-alpine3.13:
     hostname: "py3.10-alpine3.13"
     image: "python:3.10-alpine3.13"
@@ -239,6 +246,13 @@ services:
   py3.11-install-ubuntu20.04:
     hostname: "py3.11-ubuntu20.04"
     image: "ubuntu:20.04"
+    << : [*command-install-test, *workdir, *volumes-codebase]
+    environment:
+      << : *envvars-install-test
+
+  py3.11-install-ubuntu22.04:
+    hostname: "py3.11-ubuntu22.04"
+    image: "ubuntu:22.04"
     << : [*command-install-test, *workdir, *volumes-codebase]
     environment:
       << : *envvars-install-test

--- a/tests/docker/install/install_tests.sh
+++ b/tests/docker/install/install_tests.sh
@@ -147,20 +147,6 @@ function check_agent_startup(){
 
 function install_test_app_dependencies(){
     pip install flask requests
-    # setuptools 66.0.0 breaks opentelemetry-bootstrap on Ubuntu 18.04+, Python 3.10+ from deadsnakes
-    if grep Ubuntu /etc/os-release; then
-        ubuntu_version=$(grep VERSION_ID /etc/os-release | sed 's/VERSION_ID="//' | sed 's/"//')
-        if [ "$ubuntu_version" = "18.04" ] || [ "$ubuntu_version" = "20.04" ]; then
-            echo "Installing test app deps on ubuntu_version $ubuntu_version"
-            # get Python version from container hostname, e.g. "3.7", "3.10"
-            python_version=$(grep -Eo 'py3.[0-9]+[0-9]*' /etc/hostname | grep -Eo '3.[0-9]+[0-9]*')
-            if [ "$python_version" = "3.10" ] || [ "$python_version" = "3.11" ]; then
-                echo "Re-installing setuptools for Python $python_version"
-                apt-get remove -y python3-setuptools
-                pip install --ignore-installed setuptools==65.7.0
-            fi
-        fi
-    fi
     opentelemetry-bootstrap --action=install
 }
 


### PR DESCRIPTION
Removes the part of the install_tests script that uninstalls the latest `setuptools` and installs an older version, because this is no longer needed. `opentelemetry-bootstrap` now works ok with current `setuptools`.

Also adds local and GH install test containers for Ubuntu 22 and py3.10/3.11. Ubuntu 22 does not need to use `deadsnakes` to install Python but Ubuntu 20 still needs it.

GH test run: https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/5138153171