### PR TITLE
NH-42174 Testrelease 0.12.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.11.0...HEAD)
+## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.12.0...HEAD)
 
+## [0.12.0.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.12.0) - 2023-06-01
 ### Changed
 - Bugfix: APM tracing disabled when platform not supported ([#153](https://github.com/solarwindscloud/solarwinds-apm-python/pull/153))
 - Updated to liboboe version 12.3.1 ([#155](https://github.com/solarwindscloud/solarwinds-apm-python/pull/155))

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.11.0"
+__version__ = "0.12.0.0"


### PR DESCRIPTION
Testrelease 0.12.0.0

Published to TestPyPI: https://test.pypi.org/project/solarwinds-apm/0.12.0.0/

Install tests pass, now on EC2 runners 🌟 : https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/5149464209

tox tests on this PR pass.

e2e test traces:
* [SWO Django](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/C7EB3037E209D4B5A73D8DA4D703A93E/F860E61FDD992E94/details/breakdown?perspective=requests&serviceId=e-1540126275982954496&sort_by_breakdown=SpanLayer&sort_order_breakdown=ascending)
* [SWO FastAPI](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/B3A87695E654C458B4C76DB174BF1FB6/3674B8BC9DCE4C81/details/breakdown?perspective=requests&serviceId=e-1563388155741380608)
* [AO Django](https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/AB941FD1B41CB94DA9ED9BC647943E7F00000000?duration=3600)
* [AO FastAPI](https://my.appoptics.com/apm/123092/services/asgi_app_ot/traces/EF04B56B9E2DC7E4D741531874C79F1100000000?duration=3600)
