### PR TITLE
NH-41991 Fix install test Python version coverage

### DIFF
--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -87,32 +87,38 @@ jobs:
     runs-on: ${{ matrix.arch == 'arm64' && fromJSON(needs.launch-arm64.outputs.matrix)[matrix.image].label || 'ubuntu-latest' }}
     strategy:
       matrix:
-        image:
-          - amazonlinux:2023
-          - centos:8
-          - registry.fedoraproject.org/f33/python3
-          - ubuntu:18.04
-          - ubuntu:20.04
-          - ubuntu:22.04
-          - python:3.7-alpine3.12
-          - python:3.7-alpine3.13
-          - python:3.7-alpine3.17
-          - python:3.7-buster
-          - python:3.8-alpine3.12
-          - python:3.8-alpine3.13
-          - python:3.8-buster
-          - python:3.9-alpine3.12
-          - python:3.9-alpine3.13
-          - python:3.9-alpine3.16
-          - python:3.9-alpine3.17
-          - python:3.9-buster
-          - python:3.10-alpine3.13
-          - python:3.10-alpine3.16
-          - python:3.10-alpine3.17
-          - python:3.10-buster
-          - python:3.11-alpine3.16
-          - python:3.11-alpine3.17
-          - python:3.11-buster
+        hostname:
+          - py3.10-amazon2023
+          - py3.9-centos8
+          - py3.9-rhel8
+          - py3.7-ubuntu18.04
+          - py3.8-ubuntu18.04
+          - py3.8-ubuntu20.04
+          - py3.9-ubuntu20.04
+          - py3.10-ubuntu20.04
+          - py3.10-ubuntu22.04
+          - py3.11-ubuntu20.04
+          - py3.11-ubuntu20.04
+          - py3.11-ubuntu22.04
+          - py3.7-alpine3.12
+          - py3.7-alpine3.13
+          - py3.7-alpine3.17
+          - py3.7-debian10
+          - py3.8-alpine3.12
+          - py3.8-alpine3.13
+          - py3.8-debian10
+          - py3.9-alpine3.12
+          - py3.9-alpine3.13
+          - py3.9-alpine3.16
+          - py3.9-alpine3.17
+          - py3.9-debian10
+          - py3.10-alpine3.13
+          - py3.10-alpine3.16
+          - py3.10-alpine3.17
+          - py3.10-debian10
+          - py3.11-alpine3.16
+          - py3.11-alpine3.17
+          - py3.11-debian10
         arch:
           - x64
           - arm64
@@ -180,33 +186,33 @@ jobs:
           - image: python:3.11-buster
             hostname: py3.11-debian10
         exclude:
-          - image: python:3.7-alpine3.12
+          - hostname: py3.7-alpine3.12
             arch: arm64
-          - image: python:3.7-alpine3.13
+          - hostname: py3.7-alpine3.13
             arch: arm64
-          - image: python:3.7-alpine3.17
+          - hostname: py3.7-alpine3.17
             arch: arm64
-          - image: python:3.8-alpine3.12
+          - hostname: py3.8-alpine3.12
             arch: arm64
-          - image: python:3.8-alpine3.13
+          - hostname: py3.8-alpine3.13
             arch: arm64           
-          - image: python:3.9-alpine3.12
+          - hostname: py3.9-alpine3.12
             arch: arm64
-          - image: python:3.9-alpine3.13
+          - hostname: py3.9-alpine3.13
             arch: arm64
-          - image: python:3.9-alpine3.16
+          - hostname: py3.9-alpine3.16
             arch: arm64
-          - image: python:3.9-alpine3.17
+          - hostname: py3.9-alpine3.17
             arch: arm64
-          - image: python:3.10-alpine3.13
+          - hostname: py3.10-alpine3.13
             arch: arm64
-          - image: python:3.10-alpine3.16
+          - hostname: py3.10-alpine3.16
             arch: arm64
-          - image: python:3.10-alpine3.17
+          - hostname: py3.10-alpine3.17
             arch: arm64
-          - image: python:3.11-alpine3.16
+          - hostname: py3.11-alpine3.16
             arch: arm64
-          - image: python:3.11-alpine3.17
+          - hostname: py3.11-alpine3.17
             arch: arm64
     container:
       image: "${{ matrix.image }}"

--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -49,10 +49,6 @@ jobs:
           matrix: |
             amazonlinux:2023
             centos:8
-            registry.fedoraproject.org/f33/python3
-            ubuntu:18.04
-            ubuntu:20.04
-            ubuntu:22.04
             python:3.7-alpine3.12
             python:3.7-alpine3.13
             python:3.7-alpine3.17
@@ -72,6 +68,10 @@ jobs:
             python:3.11-alpine3.16
             python:3.11-alpine3.17
             python:3.11-buster
+            registry.fedoraproject.org/f33/python3
+            ubuntu:18.04
+            ubuntu:20.04
+            ubuntu:22.04
           github-token: ${{ secrets.CI_GITHUB_TOKEN }}
           runner-user: github
           runner-directory: /gh
@@ -88,103 +88,100 @@ jobs:
     strategy:
       matrix:
         hostname:
-          - py3.10-amazon2023
-          - py3.9-centos8
-          - py3.9-rhel8
-          - py3.7-ubuntu18.04
-          - py3.8-ubuntu18.04
-          - py3.8-ubuntu20.04
-          - py3.9-ubuntu20.04
-          - py3.10-ubuntu20.04
-          - py3.10-ubuntu22.04
-          - py3.11-ubuntu20.04
-          - py3.11-ubuntu20.04
-          - py3.11-ubuntu22.04
           - py3.7-alpine3.12
           - py3.7-alpine3.13
           - py3.7-alpine3.17
           - py3.7-debian10
+          - py3.7-ubuntu18.04
           - py3.8-alpine3.12
           - py3.8-alpine3.13
           - py3.8-debian10
+          - py3.8-ubuntu18.04
+          - py3.8-ubuntu20.04
           - py3.9-alpine3.12
           - py3.9-alpine3.13
           - py3.9-alpine3.16
           - py3.9-alpine3.17
+          - py3.9-centos8
           - py3.9-debian10
+          - py3.9-rhel8
+          - py3.9-ubuntu20.04
           - py3.10-alpine3.13
           - py3.10-alpine3.16
           - py3.10-alpine3.17
+          - py3.10-amazon2023
           - py3.10-debian10
+          - py3.10-ubuntu20.04
+          - py3.10-ubuntu22.04
           - py3.11-alpine3.16
           - py3.11-alpine3.17
           - py3.11-debian10
+          - py3.11-ubuntu20.04
+          - py3.11-ubuntu22.04
         arch:
           - x64
           - arm64
         include:
-          - image: amazonlinux:2023
-            hostname: py3.10-amazon2023
-          - image: centos:8
-            hostname: py3.9-centos8
-          - image: registry.fedoraproject.org/f33/python3
-            hostname: py3.9-rhel8
-          - image: ubuntu:18.04
-            hostname: py3.7-ubuntu18.04
-          - image: ubuntu:18.04
-            hostname: py3.8-ubuntu18.04
-          - image: ubuntu:20.04
-            hostname: py3.8-ubuntu20.04
-          - image: ubuntu:20.04
-            hostname: py3.9-ubuntu20.04
-          - image: ubuntu:20.04
-            hostname: py3.10-ubuntu20.04
-          - image: ubuntu:22.04
-            hostname: py3.10-ubuntu22.04
-          - image: ubuntu:20.04
-            hostname: py3.11-ubuntu20.04
-          - image: ubuntu:20.04
-            hostname: py3.11-ubuntu20.04
-          - image: ubuntu:22.04
-            hostname: py3.11-ubuntu22.04
-          - image: python:3.7-alpine3.12
-            hostname: py3.7-alpine3.12
-          - image: python:3.7-alpine3.13
-            hostname: py3.7-alpine3.13
-          - image: python:3.7-alpine3.17
-            hostname: py3.7-alpine3.17
-          - image: python:3.7-buster
-            hostname: py3.7-debian10
-          - image: python:3.8-alpine3.12
-            hostname: py3.8-alpine3.12
-          - image: python:3.8-alpine3.13
-            hostname: py3.8-alpine3.13
-          - image: python:3.8-buster
-            hostname: py3.8-debian10
-          - image: python:3.9-alpine3.12
-            hostname: py3.9-alpine3.12
-          - image: python:3.9-alpine3.13
-            hostname: py3.9-alpine3.13
-          - image: python:3.9-alpine3.16
-            hostname: py3.9-alpine3.16
-          - image: python:3.9-alpine3.17
-            hostname: py3.9-alpine3.17
-          - image: python:3.9-buster
-            hostname: py3.9-debian10
-          - image: python:3.10-alpine3.13
-            hostname: py3.10-alpine3.13
-          - image: python:3.10-alpine3.16
-            hostname: py3.10-alpine3.16
-          - image: python:3.10-alpine3.17
-            hostname: py3.10-alpine3.17
-          - image: python:3.10-buster
-            hostname: py3.10-debian10
-          - image: python:3.11-alpine3.16
-            hostname: py3.11-alpine3.16
-          - image: python:3.11-alpine3.17
-            hostname: py3.11-alpine3.17
-          - image: python:3.11-buster
-            hostname: py3.11-debian10
+          - hostname: py3.7-alpine3.12
+            image: python:3.7-alpine3.12
+          - hostname: py3.7-alpine3.13
+            image: python:3.7-alpine3.13
+          - hostname: py3.7-alpine3.17
+            image: python:3.7-alpine3.17
+          - hostname: py3.7-debian10
+            image: python:3.7-buster
+          - hostname: py3.7-ubuntu18.04
+            image: ubuntu:18.04
+          - hostname: py3.8-alpine3.12
+            image: python:3.8-alpine3.12
+          - hostname: py3.8-alpine3.13
+            image: python:3.8-alpine3.13
+          - hostname: py3.8-debian10
+            image: python:3.8-buster
+          - hostname: py3.8-ubuntu18.04
+            image: ubuntu:18.04
+          - hostname: py3.8-ubuntu20.04
+            image: ubuntu:20.04
+          - hostname: py3.9-alpine3.12
+            image: python:3.9-alpine3.12
+          - hostname: py3.9-alpine3.13
+            image: python:3.9-alpine3.13
+          - hostname: py3.9-alpine3.16
+            image: python:3.9-alpine3.16
+          - hostname: py3.9-alpine3.17
+            image: python:3.9-alpine3.17
+          - hostname: py3.9-centos8
+            image: centos:8
+          - hostname: py3.9-debian10
+            image: python:3.9-buster
+          - hostname: py3.9-rhel8
+            image: registry.fedoraproject.org/f33/python3
+          - hostname: py3.9-ubuntu20.04
+            image: ubuntu:20.04
+          - hostname: py3.10-alpine3.13
+            image: python:3.10-alpine3.13
+          - hostname: py3.10-alpine3.16
+            image: python:3.10-alpine3.16
+          - hostname: py3.10-alpine3.17
+            image: python:3.10-alpine3.17
+          - hostname: py3.10-amazon2023
+            image: amazonlinux:2023
+          - hostname: py3.10-debian10
+            image: python:3.10-buster
+          - hostname: py3.10-ubuntu20.04
+            image: ubuntu:20.04
+          - hostname: py3.10-ubuntu22.04
+            image: ubuntu:22.04
+          - hostname: py3.11-alpine3.16
+            image: python:3.11-alpine3.16
+          - hostname: py3.11-alpine3.17
+            image: python:3.11-alpine3.17
+          - hostname: py3.11-debian10
+            image: python:3.11-buster
+          - hostname: py3.11-ubuntu20.04
+            image: ubuntu:20.04
+          - hostname: py3.11-ubuntu22.04
+            image: ubuntu:22.04
         exclude:
           - hostname: py3.7-alpine3.12
             arch: arm64

--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -125,28 +125,22 @@ jobs:
             hostname: py3.9-rhel8
           - image: ubuntu:18.04
             hostname: py3.7-ubuntu18.04
-            python: 3.7
           - image: ubuntu:18.04
             hostname: py3.8-ubuntu18.04
-            python: 3.8
           - image: ubuntu:20.04
             hostname: py3.8-ubuntu20.04
-            python: 3.8
           - image: ubuntu:20.04
             hostname: py3.9-ubuntu20.04
-            python: 3.9
           - image: ubuntu:20.04
             hostname: py3.10-ubuntu20.04
-            python: 3.10
           - image: ubuntu:22.04
             hostname: py3.10-ubuntu22.04
-            python: 3.10
           - image: ubuntu:20.04
             hostname: py3.11-ubuntu20.04
-            python: 3.11
+          - image: ubuntu:20.04
+            hostname: py3.11-ubuntu20.04
           - image: ubuntu:22.04
             hostname: py3.11-ubuntu22.04
-            python: 3.11
           - image: python:3.7-alpine3.12
             hostname: py3.7-alpine3.12
           - image: python:3.7-alpine3.13

--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -125,22 +125,28 @@ jobs:
             hostname: py3.9-rhel8
           - image: ubuntu:18.04
             hostname: py3.7-ubuntu18.04
+            python: 3.7
           - image: ubuntu:18.04
             hostname: py3.8-ubuntu18.04
+            python: 3.8
           - image: ubuntu:20.04
             hostname: py3.8-ubuntu20.04
+            python: 3.8
           - image: ubuntu:20.04
             hostname: py3.9-ubuntu20.04
+            python: 3.9
           - image: ubuntu:20.04
             hostname: py3.10-ubuntu20.04
+            python: 3.10
           - image: ubuntu:22.04
             hostname: py3.10-ubuntu22.04
+            python: 3.10
           - image: ubuntu:20.04
             hostname: py3.11-ubuntu20.04
-          - image: ubuntu:20.04
-            hostname: py3.11-ubuntu20.04
+            python: 3.11
           - image: ubuntu:22.04
             hostname: py3.11-ubuntu22.04
+            python: 3.11
           - image: python:3.7-alpine3.12
             hostname: py3.7-alpine3.12
           - image: python:3.7-alpine3.13


### PR DESCRIPTION
Fixes install test Python version coverage by 'rotating' the workflow matrix.

Before this change ([test run](https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/5138153171)), as an example problem there should have been 4 `ubuntu:18.04` runs for
1. py3.7 x86
2. py3.7 arm64
3. py3.8 x86
4. py3.8 arm64

but only 2 ran for py3.8 on each x86, arm64. 36 jobs ran (2 setup + 34 test runs).

After this change ([test run](https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/5149013274)), we now get all four `ubuntu:18.04` runs and 46 jobs. This is by changing `strategy > matrix > image` to the full list of `strategy > matrix > hostname`, and changing `strategy > matrix > include` to specify the images used.

Please let me know what you think 🙂 