### PR TITLE
NH-42458 set_transaction_name empty name case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.12.0...HEAD)
+### Added
+- Add log warning when `set_transaction_name` with empty name ([#162](https://github.com/solarwindscloud/solarwinds-apm-python/pull/162))
 
 ## [0.12.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.12.0) - 2023-06-01
 ### Changed

--- a/solarwinds_apm/api/__init__.py
+++ b/solarwinds_apm/api/__init__.py
@@ -50,7 +50,7 @@ def set_transaction_name(custom_name: str) -> bool:
         return False
 
     if isinstance(get_tracer_provider(), NoOpTracerProvider):
-        logger.debug(
+        logger.warning(
             "Cannot cache custom transaction name %s because agent not enabled; ignoring",
             custom_name,
         )
@@ -74,7 +74,7 @@ def set_transaction_name(custom_name: str) -> bool:
     entry_trace_id = baggage.get_baggage(INTL_SWO_CURRENT_TRACE_ID)
     entry_span_id = baggage.get_baggage(INTL_SWO_CURRENT_SPAN_ID)
     if not entry_trace_id or not entry_span_id:
-        logger.debug(
+        logger.error(
             "Cannot cache custom transaction name %s because OTel service entry span not started; ignoring",
             custom_name,
         )

--- a/solarwinds_apm/api/__init__.py
+++ b/solarwinds_apm/api/__init__.py
@@ -43,6 +43,12 @@ def set_transaction_name(custom_name: str) -> bool:
      from solarwinds_apm.api import set_transaction_name
      result = set_transaction_name("my-foo-name")
     """
+    if not custom_name:
+        logger.warning(
+            "Cannot set custom transaction name as empty string; ignoring"
+        )
+        return False
+
     if isinstance(get_tracer_provider(), NoOpTracerProvider):
         logger.debug(
             "Cannot cache custom transaction name %s because agent not enabled; ignoring",

--- a/solarwinds_apm/api/__init__.py
+++ b/solarwinds_apm/api/__init__.py
@@ -37,7 +37,8 @@ def set_transaction_name(custom_name: str) -> bool:
     :custom_name:str, custom transaction name to apply
 
     :return:
-    bool True for successful name assignment, False for not
+    bool True if successful name assignment or if tracing disabled,
+         False if unsuccessful due to invalid name, nonexistent span, or distro error.
 
     :Example:
      from solarwinds_apm.api import set_transaction_name

--- a/solarwinds_apm/api/__init__.py
+++ b/solarwinds_apm/api/__init__.py
@@ -51,7 +51,7 @@ def set_transaction_name(custom_name: str) -> bool:
         return False
 
     if isinstance(get_tracer_provider(), NoOpTracerProvider):
-        logger.warning(
+        logger.debug(
             "Cannot cache custom transaction name %s because agent not enabled; ignoring",
             custom_name,
         )
@@ -75,7 +75,7 @@ def set_transaction_name(custom_name: str) -> bool:
     entry_trace_id = baggage.get_baggage(INTL_SWO_CURRENT_TRACE_ID)
     entry_span_id = baggage.get_baggage(INTL_SWO_CURRENT_SPAN_ID)
     if not entry_trace_id or not entry_span_id:
-        logger.error(
+        logger.warning(
             "Cannot cache custom transaction name %s because OTel service entry span not started; ignoring",
             custom_name,
         )


### PR DESCRIPTION
If customers call `set_transaction_name("")` with an empty string, there will now be a warning log and the method will return `False`. I've commented on the [hijacked spec doc](https://swicloud.atlassian.net/wiki/spaces/NIT/pages/3601400601/Swo-SDK+Application+Programming+Interface?focusedCommentId=3620274549) to confirm, and Java library is doing this too: https://github.com/appoptics/solarwinds-apm-java/pull/105/files

Before this change, Python relies on falsiness to not use empty string nor None as transaction name: https://github.com/solarwindscloud/solarwinds-apm-python/blob/main/solarwinds_apm/inbound_metrics_processor.py#L171 So what's exported to SWO doesn't change with this PR.

I've also adjusted log severity of other parts of the method, though I'm not sure what's best with the return of `True` vs `False` and if it's a simple "ignore" or pretty-bad-can't-find-InboundMetricsSpanProcessor.

Any suggestions welcome 😺 