### PR TITLE
NH-29380 Remove unused log_trace_id config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add log warning when `set_transaction_name` with empty name ([#162](https://github.com/solarwindscloud/solarwinds-apm-python/pull/162))
 
+### Removed
+- Removed unused log_trace_id config storage ([#163](https://github.com/solarwindscloud/solarwinds-apm-python/pull/163))
+
 ## [0.12.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.12.0) - 2023-06-01
 ### Changed
 - Bugfix: APM tracing disabled when platform not supported ([#153](https://github.com/solarwindscloud/solarwinds-apm-python/pull/153))

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -107,7 +107,6 @@ class SolarWindsApmConfig:
             "histogram_precision": -1,
             "reporter_file_single": 0,
             "enable_sanitize_sql": True,
-            "log_trace_id": "never",
             "proxy": "",
             "is_grpc_clean_hack_enabled": False,
             "transaction_filters": [],
@@ -447,10 +446,6 @@ class SolarWindsApmConfig:
         if key == "tracing_mode":
             self._set_config_value(key, value)
 
-        # TODO set up using OTel logging instrumentation
-        elif key == "log_trace_id":
-            self._set_config_value(key, value)
-
         elif key in {"enable_sanitize_sql", "warn_deprecated"}:
             self._set_config_value(key, value)
         else:
@@ -713,15 +708,6 @@ class SolarWindsApmConfig:
                 self.__config[key] = val
                 # update logging level of agent logger
                 apm_logging.set_sw_log_level(val)
-            elif keys == ["log_trace_id"]:
-                if not isinstance(val, str) or val.lower() not in [
-                    "never",
-                    "sampled",
-                    "traced",
-                    "always",
-                ]:
-                    raise ValueError
-                self.__config[key] = val.lower()
             elif keys == ["is_grpc_clean_hack_enabled"]:
                 self.__config[key] = _convert_to_bool(val)
             elif isinstance(sub_dict, dict) and keys[-1] in sub_dict:

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -504,13 +504,6 @@ class TestSolarWindsApmConfig:
         if old_debug_level:
             os.environ["SW_APM_DEBUG_LEVEL"] = old_debug_level
 
-    # pylint:disable=unused-argument
-    def test_set_config_value_default_log_trace_id(self, caplog, mock_env_vars):
-        test_config = apm_config.SolarWindsApmConfig()
-        test_config._set_config_value("log_trace_id", "not-valid-mode")
-        assert test_config.get("log_trace_id") == "never"
-        assert "Ignore config option" in caplog.text
-
     def test__calculate_service_name_agent_disabled(self):
         test_config = apm_config.SolarWindsApmConfig()
         result = test_config._calculate_service_name(

--- a/tests/unit/test_apm_config/test_apm_config_cnf_file.py
+++ b/tests/unit/test_apm_config/test_apm_config_cnf_file.py
@@ -131,7 +131,6 @@ class TestSolarWindsApmConfigCnfFile:
         assert resulting_config.get("histogram_precision") == 2
         assert resulting_config.get("reporter_file_single") == 2
         assert resulting_config.get("enable_sanitize_sql") == True
-        assert resulting_config.get("log_trace_id") == "always"
         assert resulting_config.get("proxy") == "http://foo-bar"
         assert resulting_config.get("is_grpc_clean_hack_enabled") == True
 
@@ -179,7 +178,6 @@ class TestSolarWindsApmConfigCnfFile:
             "histogramPrecision": "foo",
             "reporterFileSingle": "foo",
             "enableSanitizeSql": "foo",
-            "log_trace_id": "not-never-always-etc",
             "proxy": "foo",
             "isGrpcCleanHackEnabled": "foo",
         }
@@ -212,7 +210,6 @@ class TestSolarWindsApmConfigCnfFile:
         assert resulting_config.get("histogram_precision") == -1
         assert resulting_config.get("reporter_file_single") == 0
         assert resulting_config.get("enable_sanitize_sql") == True
-        assert resulting_config.get("log_trace_id") == "never"
         assert resulting_config.get("proxy") == ""
         assert resulting_config.get("is_grpc_clean_hack_enabled") == False
         # Meanwhile these are pretty open
@@ -261,7 +258,6 @@ class TestSolarWindsApmConfigCnfFile:
             "SW_APM_HISTOGRAM_PRECISION": "3",
             "SW_APM_REPORTER_FILE_SINGLE": "3",
             "SW_APM_ENABLE_SANITIZE_SQL": "false",
-            "SW_APM_LOG_TRACE_ID": "never",
             "SW_APM_PROXY": "http://other-foo-bar",
             "SW_APM_IS_GRPC_CLEAN_HACK_ENABLED": "false",
         })
@@ -303,7 +299,6 @@ class TestSolarWindsApmConfigCnfFile:
         assert resulting_config.get("histogram_precision") == 3
         assert resulting_config.get("reporter_file_single") == 3
         assert resulting_config.get("enable_sanitize_sql") == False
-        assert resulting_config.get("log_trace_id") == "never"
         assert resulting_config.get("proxy") == "http://other-foo-bar"
         assert resulting_config.get("is_grpc_clean_hack_enabled") == False
 
@@ -345,7 +340,6 @@ class TestSolarWindsApmConfigCnfFile:
             "SW_APM_HISTOGRAM_PRECISION": "other-foo-bar",
             "SW_APM_REPORTER_FILE_SINGLE": "other-foo-bar",
             "SW_APM_ENABLE_SANITIZE_SQL": "other-foo-bar",
-            "SW_APM_LOG_TRACE_ID": "other-foo-bar",
             "SW_APM_PROXY": "other-foo-bar",
             "SW_APM_IS_GRPC_CLEAN_HACK_ENABLED": "other-foo-bar",
         })
@@ -384,7 +378,6 @@ class TestSolarWindsApmConfigCnfFile:
         assert resulting_config.get("histogram_precision") == 2
         assert resulting_config.get("reporter_file_single") == 2
         assert resulting_config.get("enable_sanitize_sql") == True
-        assert resulting_config.get("log_trace_id") == "always"
         assert resulting_config.get("proxy") == "http://foo-bar"
         assert resulting_config.get("is_grpc_clean_hack_enabled") == True
 


### PR DESCRIPTION
I'm working on documentation updates and found `log_trace_id` in APM Python config. This is not used and will not be needed because the distro leverages existing Otel Python instrumentation library completely for the trace context in logs feature and it makes no sense to me to have an extra layer: https://documentation.solarwinds.com/en/success_center/observability/content/configure/services/python/configure.htm#link17. So I'm removing all mentions and storage of this value.