### PR TITLE
NH-29380 Remove unused clean_hack config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add log warning when `set_transaction_name` with empty name ([#162](https://github.com/solarwindscloud/solarwinds-apm-python/pull/162))
 
+
+- Removed unused is_grpc_clean_hack_enabled config storage ([#165](https://github.com/solarwindscloud/solarwinds-apm-python/pull/165))
+
 ## [0.12.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.12.0) - 2023-06-01
 ### Changed
 - Bugfix: APM tracing disabled when platform not supported ([#153](https://github.com/solarwindscloud/solarwinds-apm-python/pull/153))

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -109,7 +109,6 @@ class SolarWindsApmConfig:
             "enable_sanitize_sql": True,
             "log_trace_id": "never",
             "proxy": "",
-            "is_grpc_clean_hack_enabled": False,
             "transaction_filters": [],
         }
         self.agent_enabled = True
@@ -722,8 +721,6 @@ class SolarWindsApmConfig:
                 ]:
                     raise ValueError
                 self.__config[key] = val.lower()
-            elif keys == ["is_grpc_clean_hack_enabled"]:
-                self.__config[key] = _convert_to_bool(val)
             elif isinstance(sub_dict, dict) and keys[-1] in sub_dict:
                 if isinstance(sub_dict[keys[-1]], bool):
                     val = _convert_to_bool(val)

--- a/tests/unit/test_apm_config/fixtures/cnf_dict.py
+++ b/tests/unit/test_apm_config/fixtures/cnf_dict.py
@@ -27,7 +27,6 @@ def fixture_cnf_dict():
         "enableSanitizeSql": True,
         "logTraceId": "always",
         "proxy": "http://foo-bar",
-        "isGrpcCleanHackEnabled": True,
     }
 
 @pytest.fixture
@@ -57,5 +56,4 @@ def fixture_cnf_dict_enabled_false():
         "enableSanitizeSql": True,
         "logTraceId": "always",
         "proxy": "http://foo-bar",
-        "isGrpcCleanHackEnabled": True,
     }

--- a/tests/unit/test_apm_config/test_apm_config_cnf_file.py
+++ b/tests/unit/test_apm_config/test_apm_config_cnf_file.py
@@ -133,7 +133,6 @@ class TestSolarWindsApmConfigCnfFile:
         assert resulting_config.get("enable_sanitize_sql") == True
         assert resulting_config.get("log_trace_id") == "always"
         assert resulting_config.get("proxy") == "http://foo-bar"
-        assert resulting_config.get("is_grpc_clean_hack_enabled") == True
 
         # update_transaction_filters was called
         mock_update_txn_filters.assert_called_once_with(fixture_cnf_dict)
@@ -181,7 +180,6 @@ class TestSolarWindsApmConfigCnfFile:
             "enableSanitizeSql": "foo",
             "log_trace_id": "not-never-always-etc",
             "proxy": "foo",
-            "isGrpcCleanHackEnabled": "foo",
         }
         mock_get_cnf_dict = mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict"
@@ -214,7 +212,6 @@ class TestSolarWindsApmConfigCnfFile:
         assert resulting_config.get("enable_sanitize_sql") == True
         assert resulting_config.get("log_trace_id") == "never"
         assert resulting_config.get("proxy") == ""
-        assert resulting_config.get("is_grpc_clean_hack_enabled") == False
         # Meanwhile these are pretty open
         assert resulting_config.get("collector") == "False"
         assert resulting_config.get("hostname_alias") == "False"
@@ -263,7 +260,6 @@ class TestSolarWindsApmConfigCnfFile:
             "SW_APM_ENABLE_SANITIZE_SQL": "false",
             "SW_APM_LOG_TRACE_ID": "never",
             "SW_APM_PROXY": "http://other-foo-bar",
-            "SW_APM_IS_GRPC_CLEAN_HACK_ENABLED": "false",
         })
         mock_update_txn_filters = mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.update_transaction_filters"
@@ -305,7 +301,6 @@ class TestSolarWindsApmConfigCnfFile:
         assert resulting_config.get("enable_sanitize_sql") == False
         assert resulting_config.get("log_trace_id") == "never"
         assert resulting_config.get("proxy") == "http://other-foo-bar"
-        assert resulting_config.get("is_grpc_clean_hack_enabled") == False
 
         # Restore old collector
         if old_collector:
@@ -347,7 +342,6 @@ class TestSolarWindsApmConfigCnfFile:
             "SW_APM_ENABLE_SANITIZE_SQL": "other-foo-bar",
             "SW_APM_LOG_TRACE_ID": "other-foo-bar",
             "SW_APM_PROXY": "other-foo-bar",
-            "SW_APM_IS_GRPC_CLEAN_HACK_ENABLED": "other-foo-bar",
         })
         mock_update_txn_filters = mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.update_transaction_filters"
@@ -386,7 +380,6 @@ class TestSolarWindsApmConfigCnfFile:
         assert resulting_config.get("enable_sanitize_sql") == True
         assert resulting_config.get("log_trace_id") == "always"
         assert resulting_config.get("proxy") == "http://foo-bar"
-        assert resulting_config.get("is_grpc_clean_hack_enabled") == True
 
         # These are still valid, so env_var > cnf_file
         assert resulting_config.get("collector") == "False"


### PR DESCRIPTION
Similar to https://github.com/solarwindscloud/solarwinds-apm-python/pull/163 and https://github.com/solarwindscloud/solarwinds-apm-python/pull/164

This removes `is_grpc_clean_hack_enabled` from APM Python config. It is not currently used and I don't think it's needed since liboboe 12.0.0 (https://swicloud.atlassian.net/browse/NH-28555) but please let me know if I'm wrong! The value is not used to config Reporter nor anything else. This value was copied from AO which I think used it as a hidden option to re-activate a hack (https://github.com/librato/python-appoptics/pull/254).
