### PR TITLE
NH-29380 Fix accepted config bool values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add log warning when `set_transaction_name` with empty name ([#162](https://github.com/solarwindscloud/solarwinds-apm-python/pull/162))
 
+### Changed
+- Fix accepted config boolean values ([#166](https://github.com/solarwindscloud/solarwinds-apm-python/pull/166))
+
 ### Removed
 - Removed unused log_trace_id config storage ([#163](https://github.com/solarwindscloud/solarwinds-apm-python/pull/163))
 - Removed unused enable_sanitize_sql config storage ([#164](https://github.com/solarwindscloud/solarwinds-apm-python/pull/164))

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -516,8 +516,21 @@ class SolarWindsApmConfig:
 
         # agent_enabled is special
         cnf_agent_enabled = cnf_dict.get(_snake_to_camel_case("agent_enabled"))
-        if cnf_agent_enabled in set([True, False]):
+        logger.warning(
+            "cnf_agent_enabled is %s, type %s",
+            cnf_agent_enabled,
+            type(cnf_agent_enabled),
+        )
+        # accepts boolean or string from dict
+        if isinstance(cnf_agent_enabled, bool):
             self.agent_enabled = cnf_agent_enabled
+        elif cnf_agent_enabled and cnf_agent_enabled.lower() in set(
+            [
+                "true",
+                "false",
+            ]
+        ):
+            self.agent_enabled = json.loads(cnf_agent_enabled.lower())
         elif cnf_agent_enabled:
             logger.warning(
                 "Config file agentEnabled must be one of: true, false. Ignoring."
@@ -599,11 +612,9 @@ class SolarWindsApmConfig:
         """Update the settings with environment variables."""
         # agent_enabled is special
         env_agent_enabled = os.environ.get("SW_APM_AGENT_ENABLED")
-        if env_agent_enabled and env_agent_enabled in set(
+        if env_agent_enabled and env_agent_enabled.lower() in set(
             [
-                "True",
                 "true",
-                "False",
                 "false",
             ]
         ):

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -612,15 +612,11 @@ class SolarWindsApmConfig:
         if isinstance(val, bool):
             return val
         if isinstance(val, str):
-            val = val.lower()
-            if val == "true":
+            if val.lower() == "true":
                 return True
-            if val == "false":
+            if val.lower() == "false":
                 return False
-            logger.warning(
-                "Received invalid config %s instead of true/false", val
-            )
-            return None
+        logger.debug("Received config %s instead of true/false", val)
         return None
 
     # pylint: disable=too-many-branches,too-many-statements

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -516,11 +516,6 @@ class SolarWindsApmConfig:
 
         # agent_enabled is special
         cnf_agent_enabled = cnf_dict.get(_snake_to_camel_case("agent_enabled"))
-        logger.warning(
-            "cnf_agent_enabled is %s, type %s",
-            cnf_agent_enabled,
-            type(cnf_agent_enabled),
-        )
         # accepts boolean or string from dict
         if isinstance(cnf_agent_enabled, bool):
             self.agent_enabled = cnf_agent_enabled

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -207,8 +207,8 @@ class SolarWindsApmConfig:
         if not self.agent_enabled:
             logger.info(
                 "SolarWinds APM is disabled and will not report any traces because the environment variable "
-                "SW_APM_AGENT_ENABLED is set to 'false'! If this is not intended either unset the variable or set it to "
-                "a value other than false. Note that the value of SW_APM_AGENT_ENABLED is case-insensitive."
+                "SW_APM_AGENT_ENABLED or the config file agentEnabled field is set to 'false'! If this is not intended either unset the variable or set it to "
+                "a value other than false. Note that SW_APM_AGENT_ENABLED/agentEnabled is case-insensitive."
             )
             return False
 

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -505,21 +505,11 @@ class SolarWindsApmConfig:
             return
 
         # agent_enabled is special
-        cnf_agent_enabled = cnf_dict.get(_snake_to_camel_case("agent_enabled"))
-        # accepts boolean or string from dict
-        if isinstance(cnf_agent_enabled, bool):
+        cnf_agent_enabled = self._convert_to_bool(
+            cnf_dict.get(_snake_to_camel_case("agent_enabled"))
+        )
+        if cnf_agent_enabled is not None:
             self.agent_enabled = cnf_agent_enabled
-        elif cnf_agent_enabled and cnf_agent_enabled.lower() in set(
-            [
-                "true",
-                "false",
-            ]
-        ):
-            self.agent_enabled = json.loads(cnf_agent_enabled.lower())
-        elif cnf_agent_enabled:
-            logger.warning(
-                "Config file agentEnabled must be one of: true, false. Ignoring."
-            )
 
         available_cnf = set(self.__config.keys())
         # TODO after alpha: is_lambda
@@ -596,18 +586,11 @@ class SolarWindsApmConfig:
     def update_with_env_var(self) -> None:
         """Update the settings with environment variables."""
         # agent_enabled is special
-        env_agent_enabled = os.environ.get("SW_APM_AGENT_ENABLED")
-        if env_agent_enabled and env_agent_enabled.lower() in set(
-            [
-                "true",
-                "false",
-            ]
-        ):
-            self.agent_enabled = json.loads(env_agent_enabled.lower())
-        elif env_agent_enabled:
-            logger.warning(
-                "Environment SW_APM_AGENT_ENABLED must be one of: true, false. Ignoring."
-            )
+        env_agent_enabled = self._convert_to_bool(
+            os.environ.get("SW_APM_AGENT_ENABLED")
+        )
+        if env_agent_enabled is not None:
+            self.agent_enabled = env_agent_enabled
 
         available_envvs = set(self.__config.keys())
         # TODO after alpha: is_lambda
@@ -624,26 +607,32 @@ class SolarWindsApmConfig:
         """Update the configuration settings with (in-code) keyword arguments"""
         # TODO Implement in-code config with kwargs after alpha
 
+    def _convert_to_bool(self, val):
+        """Converts given value to boolean value if bool or str representation, else None"""
+        if isinstance(val, bool):
+            return val
+        if isinstance(val, str):
+            val = val.lower()
+            if val == "true":
+                return True
+            if val == "false":
+                return False
+            logger.warning(
+                "Received invalid config %s instead of true/false", val
+            )
+            return None
+        return None
+
     # pylint: disable=too-many-branches,too-many-statements
-    def _set_config_value(self, keys: str, val: Any) -> Any:
+    def _set_config_value(self, keys_str: str, val: Any) -> Any:
         """Sets the value of the config option indexed by 'keys' to 'val', where 'keys' is a nested key (separated by
         self.delimiter, i.e., the position of the element to be changed in the nested dictionary)
         """
-
-        def _convert_to_bool(val):
-            """Converts given value to boolean value"""
-            val = val.lower() if isinstance(val, str) else val
-            return (
-                val == "true"
-                if isinstance(val, str) and val in {"true", "false"}
-                else bool(int(val))
-            )
-
         # _config is a nested dict, thus find most deeply nested sub dict according to the provided keys
         # by defaulting to None in d.get(), we do not allow the creation of any new (key, value) pair, even
         # when we are handling a defaultdict (i.e., with this we do not allow e.g. the creation of new instrumentations
         # through the config)
-        keys = keys.split(self._DELIMITER)
+        keys = keys_str.split(self._DELIMITER)
         sub_dict = reduce(
             lambda d, key: d.get(key, None) if isinstance(d, dict) else None,
             keys[:-1],
@@ -711,7 +700,7 @@ class SolarWindsApmConfig:
                 apm_logging.set_sw_log_level(val)
             elif isinstance(sub_dict, dict) and keys[-1] in sub_dict:
                 if isinstance(sub_dict[keys[-1]], bool):
-                    val = _convert_to_bool(val)
+                    val = self._convert_to_bool(val)
                 else:
                     val = type(sub_dict[keys[-1]])(val)
                 sub_dict[keys[-1]] = val

--- a/tests/unit/test_apm_config/fixtures/cnf_dict.py
+++ b/tests/unit/test_apm_config/fixtures/cnf_dict.py
@@ -59,3 +59,30 @@ def fixture_cnf_dict_enabled_false():
         "proxy": "http://foo-bar",
         "isGrpcCleanHackEnabled": True,
     }
+
+@pytest.fixture
+def fixture_cnf_dict_enabled_false_mixed_case():
+    return {
+        "agentEnabled": "fALsE",
+        "tracingMode": "enabled",
+        "triggerTrace": "enabled",
+        "collector": "foo-bar",
+        "reporter": "udp",
+        "debugLevel": 6,
+        "serviceKey": "not-good-to-put-here:still-could-be-used",
+        "hostnameAlias": "foo-bar",
+        "trustedpath": "foo-bar",
+        "eventsFlushInterval": 2,
+        "maxRequestSizeBytes": 2,
+        "ec2MetadataTimeout": 1234,
+        "maxFlushWaitTime": 2,
+        "maxTransactions": 2,
+        "logname": "foo-bar",
+        "traceMetrics": 2,
+        "tokenBucketCapacity": 2,
+        "tokenBucketRate": 2,
+        "bufsize": 2,
+        "histogramPrecision": 2,
+        "reporterFileSingle": 2,
+        "proxy": "http://foo-bar",
+    }

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -590,3 +590,35 @@ class TestSolarWindsApmConfig:
             "bar-service"
         )
         assert result == "valid_key_with:bar-service"
+
+    def test__convert_to_bool_bool_true(self):
+        test_config = apm_config.SolarWindsApmConfig()
+        assert test_config._convert_to_bool(True)
+
+    def test__convert_to_bool_bool_false(self):
+        test_config = apm_config.SolarWindsApmConfig()
+        assert not test_config._convert_to_bool(False)
+
+    def test__convert_to_bool_int(self):
+        test_config = apm_config.SolarWindsApmConfig()
+        assert test_config._convert_to_bool(0) == None
+
+    def test__convert_to_bool_str_invalid(self):
+        test_config = apm_config.SolarWindsApmConfig()
+        assert test_config._convert_to_bool("not-true-nor-false") == None
+
+    def test__convert_to_bool_str_true(self):
+        test_config = apm_config.SolarWindsApmConfig()
+        assert test_config._convert_to_bool("true")
+
+    def test__convert_to_bool_str_true_mixed_case(self):
+        test_config = apm_config.SolarWindsApmConfig()
+        assert test_config._convert_to_bool("tRuE")
+
+    def test__convert_to_bool_str_false(self):
+        test_config = apm_config.SolarWindsApmConfig()
+        assert not test_config._convert_to_bool("false")
+
+    def test__convert_to_bool_str_false_mixed_case(self):
+        test_config = apm_config.SolarWindsApmConfig()
+        assert not test_config._convert_to_bool("fAlSE")

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -438,7 +438,7 @@ class TestSolarWindsApmConfig:
     def test_set_config_value_invalid_key(self, caplog, mock_env_vars):
         test_config = apm_config.SolarWindsApmConfig()
         test_config._set_config_value("invalid_key", "foo")
-        assert test_config.get("invalid_key", None) == None
+        assert test_config.get("invalid_key", None) is None
         assert "Ignore invalid configuration key" in caplog.text
 
     # pylint:disable=unused-argument
@@ -601,11 +601,11 @@ class TestSolarWindsApmConfig:
 
     def test__convert_to_bool_int(self):
         test_config = apm_config.SolarWindsApmConfig()
-        assert test_config._convert_to_bool(0) == None
+        assert test_config._convert_to_bool(0) is None
 
     def test__convert_to_bool_str_invalid(self):
         test_config = apm_config.SolarWindsApmConfig()
-        assert test_config._convert_to_bool("not-true-nor-false") == None
+        assert test_config._convert_to_bool("not-true-nor-false") is None
 
     def test__convert_to_bool_str_true(self):
         test_config = apm_config.SolarWindsApmConfig()

--- a/tests/unit/test_apm_config/test_apm_config_agent_enabled.py
+++ b/tests/unit/test_apm_config/test_apm_config_agent_enabled.py
@@ -12,6 +12,7 @@ from solarwinds_apm import apm_config
 from .fixtures.cnf_dict import (
     fixture_cnf_dict,
     fixture_cnf_dict_enabled_false,
+    fixture_cnf_dict_enabled_false_mixed_case,
 )
 
 
@@ -190,6 +191,23 @@ class TestSolarWindsApmConfigAgentEnabled:
         assert not resulting_config._calculate_agent_enabled()
         assert resulting_config.service_name == ""
 
+    def test_calculate_agent_enabled_env_var_false_mixed_case(self, mocker):
+        mocker.patch.dict(os.environ, {
+            "SW_APM_SERVICE_KEY": "valid:key",
+            "SW_APM_AGENT_ENABLED": "fALsE",
+        })
+        mock_iter_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.iter_entry_points"
+        )
+        mock_points = mocker.MagicMock()
+        mock_points.__iter__.return_value = ["foo"]
+        mock_iter_entry_points.configure_mock(
+            return_value=mock_points
+        )
+        resulting_config = apm_config.SolarWindsApmConfig()
+        assert not resulting_config._calculate_agent_enabled()
+        assert resulting_config.service_name == ""
+
     def test_calculate_agent_enabled_env_var_not_set_cnf_file_false(
         self,
         mocker,
@@ -212,6 +230,33 @@ class TestSolarWindsApmConfigAgentEnabled:
         # cnf with "agentEnabled": False
         mock_get_cnf_dict.configure_mock(
             return_value=fixture_cnf_dict_enabled_false
+        )
+        resulting_config = apm_config.SolarWindsApmConfig()
+        assert not resulting_config.agent_enabled
+        assert resulting_config.service_name == ""
+
+    def test_calculate_agent_enabled_env_var_not_set_cnf_file_false_mixed_case(
+        self,
+        mocker,
+        fixture_cnf_dict_enabled_false_mixed_case,
+    ):
+        mock_iter_entry_points = mocker.patch(
+            "solarwinds_apm.apm_config.iter_entry_points"
+        )
+        mock_points = mocker.MagicMock()
+        mock_points.__iter__.return_value = ["foo"]
+        mock_iter_entry_points.configure_mock(
+            return_value=mock_points
+        )
+        mocker.patch.dict(os.environ, {
+            "SW_APM_SERVICE_KEY": "valid:key",
+        })
+        mock_get_cnf_dict = mocker.patch(
+            "solarwinds_apm.apm_config.SolarWindsApmConfig.get_cnf_dict"
+        )
+        # cnf with "agentEnabled": False
+        mock_get_cnf_dict.configure_mock(
+            return_value=fixture_cnf_dict_enabled_false_mixed_case
         )
         resulting_config = apm_config.SolarWindsApmConfig()
         assert not resulting_config.agent_enabled


### PR DESCRIPTION
This fixes the accepted values for those APM Python configs that are booleans... which is really only `SW_APM_AGENT_ENABLED` after #163, #164, #165. Other similar configs accept "enabled"/"disabled".

The customer can now set bool (from JSON config) or case-insensitive string rep of bool (from JSON config or env vars) (e.g. `"true"`, `"False"`, `"fALsE"`). Integers are ignored, which is different from [AO Python](https://documentation.solarwinds.com/en/success_center/appoptics/content/kb/apm_tracing/python/configure.htm?cshid=appoptics_kb/apm_tracing/python/configure/#booleans-note) and imo less complicated. Therefore I've moved and repurposed the method `_convert_to_bool`. More tests added too.

Please let me know what you think 😺 