### PR TITLE
NH-42453 Build APM Python on EC2

### DIFF
--- a/.github/actions/package_solarwinds_apm_aarch64/action.yaml
+++ b/.github/actions/package_solarwinds_apm_aarch64/action.yaml
@@ -1,0 +1,16 @@
+# © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+name: package_solarwinds_apm_aarch64
+
+description: Package solarwinds_apm for aarch64
+
+runs:
+  using: 'docker'
+  image: quay.io/pypa/manylinux_2_28_aarch64:latest
+  entrypoint: 'make'
+  args:
+    - 'package'

--- a/.github/actions/package_solarwinds_apm_aarch64/action.yaml
+++ b/.github/actions/package_solarwinds_apm_aarch64/action.yaml
@@ -14,3 +14,5 @@ runs:
   entrypoint: 'make'
   args:
     - 'package'
+  env:
+    PLATFORM: aarch64

--- a/.github/workflows/build_publish_packagecloud.yaml
+++ b/.github/workflows/build_publish_packagecloud.yaml
@@ -10,7 +10,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_publish:
+  build_publish_sdist_and_x86_64:
+    name: Build and publish sdist and x86_64
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -36,26 +37,78 @@ jobs:
         dist/solarwinds_apm-$(grep __version__ ./solarwinds_apm/version.py | cut -d= -f 2 | tr -d ' "')*.whl
     - name: Remove sdist, x86_64 builds and intermediates
       uses: ./.github/actions/clean_builds_intermediates
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-    - name: Build aarch64 in container with QEMU
-      run: |
-        sudo docker run \
-          --platform linux/arm64 \
-          -e PLATFORM=aarch64 \
-          -e TWINE_NON_INTERACTIVE=1 \
-          -e TWINE_USERNAME=__token__ \
-          -e TWINE_PASSWORD=${{ secrets.SW_APM_PYPI_UPLOAD_TOKEN }} \
-          -v $(pwd):/home \
-          -w /home \
-          --rm quay.io/pypa/manylinux_2_28_aarch64:latest \
-          /bin/bash -c "yum update -y; yum install -y python3-pip; \
-          update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1; \
-          pip install --upgrade pip; \
-          make package"
-    - name: Upload aarch64 to PackageCloud
-      env:
-        PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
-      run: |
-        /home/runner/.rvm/bin/rvm 3.1.1 do package_cloud push solarwinds/solarwinds-apm-python/python \
-        dist/solarwinds_apm-$(grep __version__ ./solarwinds_apm/version.py | cut -d= -f 2 | tr -d ' "')*.whl
+
+  launch_arm64:
+    name: Launch arm64 ec2 runners
+    needs:
+      - build_publish_sdist_and_x86_64
+    runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.launch.outputs.label }} # github runner label
+      instance-id: ${{ steps.launch.outputs.instance-id }} # ec2 instance id
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.CI_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CI_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - id: launch
+        uses: solarwindscloud/ec2-runner-action@main
+        with:
+          action: launch
+          github-token: ${{ secrets.CI_GITHUB_TOKEN }}
+          runner-user: github
+          runner-directory: /gh
+          instance-type: t4g.medium
+          ami-name: gha-arm64-ubuntu22-.*
+          ami-owner: "858939916050"
+          subnet-id: subnet-0fd499f8a50e41807
+          security-group-ids: sg-0fd8d8cd6effda4a5
+
+  build_publish_aarch64:
+    name: Build and publish aarch64
+    needs:
+      - launch_arm64
+    runs-on: ${{ needs.launch_arm64.outputs.label }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Ruby 3.1.1
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install libssl-dev libreadline-dev libgdbm-dev openssl
+          gpg --keyserver hkp://pgp.mit.edu --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB && \
+          curl -sSL https://get.rvm.io | bash -s stable && \
+          source /home/runner/.rvm/scripts/rvm && \
+          /home/runner/.rvm/bin/rvm install 3.1.1 --disable-binary
+      - name: Install PackageCloud CLI
+        run: /home/runner/.rvm/bin/rvm 3.1.1 do gem install package_cloud
+      - name: Build aarch64
+        uses: ./.github/actions/package_solarwinds_apm_aarch64
+      - name: Upload aarch64 to PackageCloud
+        env:
+          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+        run: |
+          /home/runner/.rvm/bin/rvm 3.1.1 do package_cloud push solarwinds/solarwinds-apm-python/python \
+          dist/solarwinds_apm-$(grep __version__ ./solarwinds_apm/version.py | cut -d= -f 2 | tr -d ' "')*.whl
+      - name: Remove sdist, aarch64 builds and intermediates
+        uses: ./.github/actions/clean_builds_intermediates
+
+  terminate_arm64:
+    name: Terminate ec2 instances
+    if: ${{ always() }}
+    needs:
+      - launch_arm64
+      - build_publish_aarch64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.CI_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CI_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - uses: solarwindscloud/ec2-runner-action@main
+        with:
+          action: terminate
+          github-token: ${{ secrets.CI_GITHUB_TOKEN }}
+          label: ${{ needs.launch_arm64.outputs.label }}
+          instance-id: ${{ needs.launch_arm64.outputs.instance-id }}

--- a/.github/workflows/build_publish_pypi_and_draft_release.yaml
+++ b/.github/workflows/build_publish_pypi_and_draft_release.yaml
@@ -36,39 +36,79 @@ jobs:
       run: pip install --upgrade --no-cache-dir --prefer-binary twine
     - name: Check distribution artifacts
       run: twine check dist/*
-    - name: Publish to PyPi
+    - name: Publish sdist and x86_64 wheels to PyPi
       env:
         TWINE_NON_INTERACTIVE: 1
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.SW_APM_PYPI_UPLOAD_TOKEN }}
       run: twine upload dist/*
 
+  launch_arm64:
+    name: Launch arm64 ec2 runners
+    needs:
+      - build_publish_sdist_and_x86_64
+    runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.launch.outputs.label }} # github runner label
+      instance-id: ${{ steps.launch.outputs.instance-id }} # ec2 instance id
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.CI_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CI_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - id: launch
+        uses: solarwindscloud/ec2-runner-action@main
+        with:
+          action: launch
+          github-token: ${{ secrets.CI_GITHUB_TOKEN }}
+          runner-user: github
+          runner-directory: /gh
+          instance-type: t4g.medium
+          ami-name: gha-arm64-ubuntu22-.*
+          ami-owner: "858939916050"
+          subnet-id: subnet-0fd499f8a50e41807
+          security-group-ids: sg-0fd8d8cd6effda4a5
+
   build_publish_aarch64:
     name: Build and publish aarch64
-    needs: is_publishable
+    needs:
+      - launch_arm64
+    runs-on: ${{ needs.launch_arm64.outputs.label }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build aarch64
+        uses: ./.github/actions/package_solarwinds_apm_aarch64
+      - name: Install Twine
+        run: pip install --upgrade --no-cache-dir --prefer-binary twine
+      - name: Check distribution artifacts
+        run: /gh/.local/bin/twine check dist/*
+      - name: Publish aarch64 wheels to TestPyPi
+        env:
+          TWINE_NON_INTERACTIVE: 1
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.SW_APM_PYPI_UPLOAD_TOKEN }}
+        run: /gh/.local/bin/twine upload dist/*.whl
+
+  terminate_arm64:
+    name: Terminate ec2 instances
+    if: ${{ always() }}
+    needs:
+      - launch_arm64
+      - build_publish_aarch64
     runs-on: ubuntu-latest
     steps:
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-    - uses: actions/checkout@v3
-    - name: Build aarch64 in container with QEMU
-      run: |
-        sudo docker run \
-          --platform linux/arm64 \
-          -e PLATFORM=aarch64 \
-          -e TWINE_NON_INTERACTIVE=1 \
-          -e TWINE_USERNAME=__token__ \
-          -e TWINE_PASSWORD=${{ secrets.SW_APM_PYPI_UPLOAD_TOKEN }} \
-          -v $(pwd):/home \
-          -w /home \
-          --rm quay.io/pypa/manylinux_2_28_aarch64:latest \
-          /bin/bash -c "yum update -y; yum install -y python3-pip; \
-          update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1; \
-          pip install --upgrade pip; \
-          pip install --upgrade twine; \
-          make package; \
-          twine check dist/*; \
-          twine upload dist/*.whl"
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.CI_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CI_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - uses: solarwindscloud/ec2-runner-action@main
+        with:
+          action: terminate
+          github-token: ${{ secrets.CI_GITHUB_TOKEN }}
+          label: ${{ needs.launch_arm64.outputs.label }}
+          instance-id: ${{ needs.launch_arm64.outputs.instance-id }}
 
   create_release:
     name: Create draft release

--- a/.github/workflows/build_publish_pypi_and_draft_release.yaml
+++ b/.github/workflows/build_publish_pypi_and_draft_release.yaml
@@ -73,6 +73,7 @@ jobs:
   build_publish_aarch64:
     name: Build and publish aarch64
     needs:
+      - is_publishable
       - launch_arm64
     runs-on: ${{ needs.launch_arm64.outputs.label }}
     steps:

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -21,7 +21,7 @@ jobs:
       run: pip install --upgrade --no-cache-dir --prefer-binary twine
     - name: Check distribution artifacts
       run: twine check dist/*
-    - name: Publish to TestPyPi
+    - name: Publish sdist and x86_64 wheels to TestPyPi
       env:
         TWINE_NON_INTERACTIVE: 1
         TWINE_REPOSITORY: testpypi
@@ -29,29 +29,66 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.SW_APM_TESTPYPI_UPLOAD_TOKEN }}
       run: twine upload dist/*
 
+  launch_arm64:
+    runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.launch.outputs.label }} # github runner label
+      instance-id: ${{ steps.launch.outputs.instance-id }} # ec2 instance id
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.CI_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CI_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - id: launch
+        uses: solarwindscloud/ec2-runner-action@main
+        with:
+          action: launch
+          github-token: ${{ secrets.CI_GITHUB_TOKEN }}
+          runner-user: github
+          runner-directory: /gh
+          instance-type: t4g.medium
+          ami-name: gha-arm64-ubuntu22-.*
+          ami-owner: "858939916050"
+          subnet-id: subnet-0fd499f8a50e41807
+          security-group-ids: sg-0fd8d8cd6effda4a5
+
   build_publish_aarch64:
-    name: Build and publish aarch64
+    needs:
+      - launch_arm64
+    runs-on: ${{ needs.launch_arm64.outputs.label }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build aarch64
+        uses: ./.github/actions/package_solarwinds_apm_aarch64
+      - name: Install Twine
+        run: pip install --upgrade --no-cache-dir --prefer-binary twine
+      - name: Check distribution artifacts
+        run: twine check dist/*
+      - name: Publish aarch64 wheels to TestPyPi
+        env:
+          PLATFORM: aarch64
+          TWINE_NON_INTERACTIVE: 1
+          TWINE_REPOSITORY: testpypi
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.SW_APM_TESTPYPI_UPLOAD_TOKEN }}
+        run: twine upload dist/*.whl
+
+  terminate_arm64:
+    if: ${{ always() }}
+    needs:
+      - launch_arm64
+      - build_publish_aarch64
     runs-on: ubuntu-latest
     steps:
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-    - uses: actions/checkout@v3
-    - name: Build aarch64 in container with QEMU
-      run: |
-        sudo docker run \
-          --platform linux/arm64 \
-          -e PLATFORM=aarch64 \
-          -e TWINE_NON_INTERACTIVE=1 \
-          -e TWINE_REPOSITORY=testpypi \
-          -e TWINE_USERNAME=__token__ \
-          -e TWINE_PASSWORD=${{ secrets.SW_APM_TESTPYPI_UPLOAD_TOKEN }} \
-          -v $(pwd):/home \
-          -w /home \
-          --rm quay.io/pypa/manylinux_2_28_aarch64:latest \
-          /bin/bash -c "yum update -y; yum install -y python3-pip; \
-          update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1; \
-          pip install --upgrade pip; \
-          pip install --upgrade twine; \
-          make package; \
-          twine check dist/*; \
-          twine upload dist/*.whl"
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.CI_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CI_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - uses: solarwindscloud/ec2-runner-action@main
+        with:
+          action: terminate
+          github-token: ${{ secrets.CI_GITHUB_TOKEN }}
+          label: ${{ needs.launch_arm64.outputs.label }}
+          instance-id: ${{ needs.launch_arm64.outputs.instance-id }}

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -68,14 +68,14 @@ jobs:
       - name: Install Twine
         run: pip install --upgrade --no-cache-dir --prefer-binary twine
       - name: Check distribution artifacts
-        run: twine check dist/*
+        run: /gh/.local/bin/twine check dist/*
       - name: Publish aarch64 wheels to TestPyPi
         env:
           TWINE_NON_INTERACTIVE: 1
           TWINE_REPOSITORY: testpypi
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.SW_APM_TESTPYPI_UPLOAD_TOKEN }}
-        run: twine upload dist/*.whl
+        run: /gh/.local/bin/twine upload dist/*.whl
 
   terminate_arm64:
     name: Terminate ec2 instances

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -30,6 +30,8 @@ jobs:
       run: twine upload dist/*
 
   launch_arm64:
+    needs:
+      - build_publish_sdist_and_x86_64
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.launch.outputs.label }} # github runner label

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -65,13 +65,14 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build aarch64
         uses: ./.github/actions/package_solarwinds_apm_aarch64
+        env:
+          PLATFORM: aarch64
       - name: Install Twine
         run: pip install --upgrade --no-cache-dir --prefer-binary twine
       - name: Check distribution artifacts
         run: twine check dist/*
       - name: Publish aarch64 wheels to TestPyPi
         env:
-          PLATFORM: aarch64
           TWINE_NON_INTERACTIVE: 1
           TWINE_REPOSITORY: testpypi
           TWINE_USERNAME: __token__

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -65,8 +65,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build aarch64
         uses: ./.github/actions/package_solarwinds_apm_aarch64
-        env:
-          PLATFORM: aarch64
       - name: Install Twine
         run: pip install --upgrade --no-cache-dir --prefer-binary twine
       - name: Check distribution artifacts

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -30,6 +30,7 @@ jobs:
       run: twine upload dist/*
 
   launch_arm64:
+    name: Launch arm64 ec2 runners
     needs:
       - build_publish_sdist_and_x86_64
     runs-on: ubuntu-latest
@@ -56,6 +57,7 @@ jobs:
           security-group-ids: sg-0fd8d8cd6effda4a5
 
   build_publish_aarch64:
+    name: Build and publish aarch64
     needs:
       - launch_arm64
     runs-on: ${{ needs.launch_arm64.outputs.label }}
@@ -77,6 +79,7 @@ jobs:
         run: twine upload dist/*.whl
 
   terminate_arm64:
+    name: Terminate ec2 instances
     if: ${{ always() }}
     needs:
       - launch_arm64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.12.1...HEAD)
 
+### Changed
+- Builds run on EC2 ([#170](https://github.com/solarwindscloud/solarwinds-apm-python/pull/170))
+
 ## [0.12.1](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.12.1) - 2023-06-13
 ### Added
 - Add log warning when `set_transaction_name` with empty name ([#162](https://github.com/solarwindscloud/solarwinds-apm-python/pull/162))

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.12.2.1"
+__version__ = "0.12.2.2"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.12.2.0"
+__version__ = "0.12.2.1"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.12.1"
+__version__ = "0.12.2.0"


### PR DESCRIPTION
Updates APM Python build workflows to use our [ec2-runner-action](https://github.com/solarwindscloud/ec2-runner-action) (fast) instead of QEMU (slow), required for aarch64 support.

The TestPyPI publish was successful for testrelease 0.12.2.2:
* https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/5468641263
* https://test.pypi.org/project/solarwinds-apm/0.12.2.2/#files

The resulting sdist and wheels seem ok as smoke/install-from-testpypi tests passed: https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/5468792291

The x86_64 builds still run first and separately on GHA runners. For readability I'll merge them in a future PR.

Please let me know what you think!