### PR TITLE
NH-42453 x64 and arm64 builds on EC2

### DIFF
--- a/.github/actions/package_solarwinds_apm_aarch64/action.yaml
+++ b/.github/actions/package_solarwinds_apm_aarch64/action.yaml
@@ -11,7 +11,6 @@ description: Package solarwinds_apm for aarch64
 runs:
   using: 'docker'
   image: quay.io/pypa/manylinux_2_28_aarch64:latest
-  platform: 'linux/amd64'
   entrypoint: 'make'
   args:
     - 'package'

--- a/.github/actions/package_solarwinds_apm_aarch64/action.yaml
+++ b/.github/actions/package_solarwinds_apm_aarch64/action.yaml
@@ -14,5 +14,6 @@ runs:
   entrypoint: 'make'
   args:
     - 'package'
+    - '--platform linux/amd64'
   env:
     PLATFORM: aarch64

--- a/.github/actions/package_solarwinds_apm_aarch64/action.yaml
+++ b/.github/actions/package_solarwinds_apm_aarch64/action.yaml
@@ -11,9 +11,9 @@ description: Package solarwinds_apm for aarch64
 runs:
   using: 'docker'
   image: quay.io/pypa/manylinux_2_28_aarch64:latest
+  platform: 'linux/amd64'
   entrypoint: 'make'
   args:
     - 'package'
-    - '--platform linux/amd64'
   env:
     PLATFORM: aarch64

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -41,7 +41,7 @@ jobs:
     name: Build and publish sdist and wheels
     needs:
       - launch_arm64
-    runs-on: ${{ fromJSON(needs.launch_arm64.outputs.matrix)[matrix.image].label }}
+    runs-on: ${{ matrix.arch == 'arm64' && fromJSON(needs.launch_arm64.outputs.matrix)[matrix.image].label || 'ubuntu-latest' }}
     strategy:
       matrix:
         arch:

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -50,6 +50,11 @@ jobs:
         image:
           - x86_64
           - aarch64
+        exclude:
+          - arch: x64
+            image: aarch64
+          - arch: arm64
+            image: x86_64
     container:
       image: "quay.io/pypa/manylinux_2_28_${{ matrix.image }}:latest"
     steps:

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -26,8 +26,8 @@ jobs:
         with:
           action: launch
           matrix: |
-            x64
-            arm64
+            quay.io/pypa/manylinux_2_28_x86_64:latest
+            quay.io/pypa/manylinux_2_28_aarch64:latest
           github-token: ${{ secrets.CI_GITHUB_TOKEN }}
           runner-user: github
           runner-directory: /gh

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -48,13 +48,10 @@ jobs:
           - x64
           - arm64
         image:
-          - quay.io/pypa/manylinux_2_28_x86_64:latest
-          - quay.io/pypa/manylinux_2_28_aarch64:latest
-        include:
-          - arch: x64
-            image: quay.io/pypa/manylinux_2_28_x86_64:latest
-          - arch: arm64
-            image: quay.io/pypa/manylinux_2_28_aarch64:latest
+          - x86_64
+          - aarch64
+    container:
+      image: "quay.io/pypa/manylinux_2_28_${{ matrix.image }}:latest"
     steps:
     - uses: actions/checkout@v3
     - if: ${{ matrix.arch == 'x64' }}

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -10,33 +10,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_publish_sdist_and_x86_64:
-    name: Build and publish sdist and x86_64
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Build x86_64
-      uses: ./.github/actions/package_solarwinds_apm_x86_64
-    - name: Install Twine
-      run: pip install --upgrade --no-cache-dir --prefer-binary twine
-    - name: Check distribution artifacts
-      run: twine check dist/*
-    - name: Publish sdist and x86_64 wheels to TestPyPi
-      env:
-        TWINE_NON_INTERACTIVE: 1
-        TWINE_REPOSITORY: testpypi
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.SW_APM_TESTPYPI_UPLOAD_TOKEN }}
-      run: twine upload dist/*
-
   launch_arm64:
-    name: Launch arm64 ec2 runners
-    needs:
-      - build_publish_sdist_and_x86_64
+    name: Launch ec2 runners
     runs-on: ubuntu-latest
     outputs:
-      label: ${{ steps.launch.outputs.label }} # github runner label
-      instance-id: ${{ steps.launch.outputs.instance-id }} # ec2 instance id
+      matrix: ${{ steps.launch.outputs.matrix }}
     steps:
       - uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -47,6 +25,9 @@ jobs:
         uses: solarwindscloud/ec2-runner-action@main
         with:
           action: launch
+          matrix: |
+            - x64
+            - arm64
           github-token: ${{ secrets.CI_GITHUB_TOKEN }}
           runner-user: github
           runner-directory: /gh
@@ -56,33 +37,51 @@ jobs:
           subnet-id: subnet-0fd499f8a50e41807
           security-group-ids: sg-0fd8d8cd6effda4a5
 
-  build_publish_aarch64:
-    name: Build and publish aarch64
+  build_publish_sdist_and_wheels:
+    name: Build and publish sdist and wheels
     needs:
       - launch_arm64
-    runs-on: ${{ needs.launch_arm64.outputs.label }}
+    runs-on: ${{ matrix.arch == 'arm64' && fromJSON(needs.launch_arm64.outputs.matrix)[matrix.image].label || 'ubuntu-latest' }}
+    strategy:
+      matrix:
+        arch:
+          - x64
+          - arm64
     steps:
-      - uses: actions/checkout@v3
-      - name: Build aarch64
-        uses: ./.github/actions/package_solarwinds_apm_aarch64
-      - name: Install Twine
-        run: pip install --upgrade --no-cache-dir --prefer-binary twine
-      - name: Check distribution artifacts
-        run: /gh/.local/bin/twine check dist/*
-      - name: Publish aarch64 wheels to TestPyPi
-        env:
-          TWINE_NON_INTERACTIVE: 1
-          TWINE_REPOSITORY: testpypi
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.SW_APM_TESTPYPI_UPLOAD_TOKEN }}
-        run: /gh/.local/bin/twine upload dist/*.whl
+    - uses: actions/checkout@v3
+    - if: ${{ matrix.arch == 'x64' }}
+      name: Build sdist and x86_64
+      uses: ./.github/actions/package_solarwinds_apm_x86_64
+    - if: ${{ matrix.arch == 'arm64' }}
+      name: Build aarch64
+      uses: ./.github/actions/package_solarwinds_apm_aarch64
+    - name: Install Twine
+      run: pip install --upgrade --no-cache-dir --prefer-binary twine
+    - name: Check distribution artifacts
+      run: /gh/.local/bin/twine check dist/*
+    - if: ${{ matrix.arch == 'x64' }}
+      name: Publish sdist and x86_64 wheels to TestPyPi
+      env:
+        TWINE_NON_INTERACTIVE: 1
+        TWINE_REPOSITORY: testpypi
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.SW_APM_TESTPYPI_UPLOAD_TOKEN }}
+      run: /gh/.local/bin/twine upload dist/*
+    - if: ${{ matrix.arch == 'arm64' }}
+      name: Publish arm64 wheels to TestPyPi
+      env:
+        TWINE_NON_INTERACTIVE: 1
+        TWINE_REPOSITORY: testpypi
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.SW_APM_TESTPYPI_UPLOAD_TOKEN }}
+      run: /gh/.local/bin/twine upload dist/*
 
   terminate_arm64:
     name: Terminate ec2 instances
     if: ${{ always() }}
     needs:
       - launch_arm64
-      - build_publish_aarch64
+      - build_publish_sdist_and_wheels
     runs-on: ubuntu-latest
     steps:
       - uses: aws-actions/configure-aws-credentials@v2
@@ -94,5 +93,4 @@ jobs:
         with:
           action: terminate
           github-token: ${{ secrets.CI_GITHUB_TOKEN }}
-          label: ${{ needs.launch_arm64.outputs.label }}
-          instance-id: ${{ needs.launch_arm64.outputs.instance-id }}
+          matrix: ${{ needs.launch_arm64.outputs.matrix }}

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -26,8 +26,8 @@ jobs:
         with:
           action: launch
           matrix: |
-            quay.io/pypa/manylinux_2_28_x86_64:latest
-            quay.io/pypa/manylinux_2_28_aarch64:latest
+            x64
+            arm64
           github-token: ${{ secrets.CI_GITHUB_TOKEN }}
           runner-user: github
           runner-directory: /gh
@@ -41,12 +41,20 @@ jobs:
     name: Build and publish sdist and wheels
     needs:
       - launch_arm64
-    runs-on: ${{ matrix.arch == 'arm64' && contains(matrix.image, 'arm64') || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.arch == 'arm64' && fromJSON(needs.launch_arm64.outputs.matrix)[matrix.image].label || 'ubuntu-latest' }}
     strategy:
       matrix:
         arch:
           - x64
           - arm64
+        image:
+          - quay.io/pypa/manylinux_2_28_x86_64:latest
+          - quay.io/pypa/manylinux_2_28_aarch64:latest
+        include:
+          - arch: x64
+            image: quay.io/pypa/manylinux_2_28_x86_64:latest
+          - arch: arm64
+            image: quay.io/pypa/manylinux_2_28_aarch64:latest
     steps:
     - uses: actions/checkout@v3
     - if: ${{ matrix.arch == 'x64' }}

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -41,7 +41,7 @@ jobs:
     name: Build and publish sdist and wheels
     needs:
       - launch_arm64
-    runs-on: ${{ matrix.arch == 'arm64' && fromJSON(needs.launch_arm64.outputs.matrix)[matrix.image].label || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.arch == 'arm64' && contains(matrix.image, 'arm64') || 'ubuntu-latest' }}
     strategy:
       matrix:
         arch:

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -26,8 +26,8 @@ jobs:
         with:
           action: launch
           matrix: |
-            - x64
-            - arm64
+            x64
+            arm64
           github-token: ${{ secrets.CI_GITHUB_TOKEN }}
           runner-user: github
           runner-directory: /gh

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -41,22 +41,12 @@ jobs:
     name: Build and publish sdist and wheels
     needs:
       - launch_arm64
-    runs-on: ${{ matrix.arch == 'arm64' && fromJSON(needs.launch_arm64.outputs.matrix)[matrix.image].label || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.arch == 'arm64' && fromJSON(needs.launch_arm64.outputs.matrix)[matrix.job].label || 'ubuntu-latest' }}
     strategy:
       matrix:
         arch:
           - x64
           - arm64
-        image:
-          - x86_64
-          - aarch64
-        exclude:
-          - arch: x64
-            image: aarch64
-          - arch: arm64
-            image: x86_64
-    container:
-      image: "quay.io/pypa/manylinux_2_28_${{ matrix.image }}:latest"
     steps:
     - uses: actions/checkout@v3
     - if: ${{ matrix.arch == 'x64' }}

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -41,7 +41,7 @@ jobs:
     name: Build and publish sdist and wheels
     needs:
       - launch_arm64
-    runs-on: ${{ matrix.arch == 'arm64' && fromJSON(needs.launch_arm64.outputs.matrix)[matrix.image].label || 'ubuntu-latest' }}
+    runs-on: ${{ fromJSON(needs.launch_arm64.outputs.matrix)[matrix.image].label }}
     strategy:
       matrix:
         arch:

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -41,7 +41,7 @@ jobs:
     name: Build and publish sdist and wheels
     needs:
       - launch_arm64
-    runs-on: ${{ matrix.arch == 'arm64' && fromJSON(needs.launch_arm64.outputs.matrix)[matrix.job].label || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.arch == 'arm64' && fromJSON(needs.launch_arm64.outputs.matrix)[matrix.image].label || 'ubuntu-latest' }}
     strategy:
       matrix:
         arch:

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.12.2.11"
+__version__ = "0.12.2.12"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.12.2.8"
+__version__ = "0.12.2.9"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.12.2.9"
+__version__ = "0.12.2.10"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.12.2.2"
+__version__ = "0.12.2.3"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.12.2.6"
+__version__ = "0.12.2.7"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.12.2.3"
+__version__ = "0.12.2.4"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.12.2.4"
+__version__ = "0.12.2.5"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.12.2.10"
+__version__ = "0.12.2.11"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.12.2.7"
+__version__ = "0.12.2.8"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.12.2.5"
+__version__ = "0.12.2.6"


### PR DESCRIPTION
[Currently failing](https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/5469507876/jobs/9958544464) at "Build and publish sdist and wheels (arm64)", after `Status: Downloaded newer image for quay.io/pypa/manylinux_2_28_aarch64:latest` and before `Is SWIG installed` check:

```
Digest: sha256:209ae25787c06bc2aff620393eec7b00ab9e894304f8deee17ca6ee92ef46631
Status: Downloaded newer image for quay.io/pypa/manylinux_2_28_aarch64:latest
WARNING: The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64) and no specific platform was requested
exec /usr/bin/make: exec format error
```
