### PR TITLE
NH-44210 metric format one or other not both

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Builds run on EC2 ([#170](https://github.com/solarwindscloud/solarwinds-apm-python/pull/170))
+- Metric format for AO backend is `TransactionResponseTime` instead of both ([#172](https://github.com/solarwindscloud/solarwinds-apm-python/pull/172))
 
 ## [0.12.1](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.12.1) - 2023-06-13
 ### Added

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -356,13 +356,14 @@ class SolarWindsApmConfig:
         return service_key
 
     def _calculate_metric_format(self) -> int:
-        """Return one of 0 (both) or 1 (TransactionResponseTime only). Future: return 2 (ResponseTime only) instead of 0. Based on collector URL which may have a port e.g. foo-collector.com:443"""
-        metric_format = 0
+        """Return one of 1 (TransactionResponseTime only) or 2 (default; ResponseTime only). Note: 0 (both) is no longer supported. Based on collector URL which may have a port e.g. foo-collector.com:443"""
+        metric_format = 2
         host = self.get("collector")
         if host:
-            if len(host.split(":")) > 1:
-                host = host.split(":")[0]
-            if host in [INTL_SWO_AO_COLLECTOR, INTL_SWO_AO_STG_COLLECTOR]:
+            if (
+                INTL_SWO_AO_COLLECTOR in host
+                or INTL_SWO_AO_STG_COLLECTOR in host
+            ):
                 logger.warning(
                     "AO collector detected. Only exporting TransactionResponseTime metrics"
                 )

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -160,7 +160,7 @@ class TestSolarWindsApmConfig:
         old_collector = os.environ.get("SW_APM_COLLECTOR", None)
         if old_collector:
             del os.environ["SW_APM_COLLECTOR"]
-        assert apm_config.SolarWindsApmConfig()._calculate_metric_format() == 0
+        assert apm_config.SolarWindsApmConfig()._calculate_metric_format() == 2
         # Restore old collector
         if old_collector:
             os.environ["SW_APM_COLLECTOR"] = old_collector
@@ -169,7 +169,7 @@ class TestSolarWindsApmConfig:
         mocker.patch.dict(os.environ, {
             "SW_APM_COLLECTOR": "foo-collector-not-ao"
         })
-        assert apm_config.SolarWindsApmConfig()._calculate_metric_format() == 0
+        assert apm_config.SolarWindsApmConfig()._calculate_metric_format() == 2
 
     def test_calculate_metric_format_ao_prod(self, mocker):
         mocker.patch.dict(os.environ, {


### PR DESCRIPTION
Metric format is `TransactionResponseTime` when reporting to AO (same as before) or `ResponseTime` when reporting to SWO (instead of both). Also simplified the condition.