### PR TITLE
NH-47761 Renamed secrets for clarity of CI creds

### DIFF
--- a/.github/workflows/build_publish_packagecloud.yaml
+++ b/.github/workflows/build_publish_packagecloud.yaml
@@ -49,14 +49,14 @@ jobs:
     steps:
       - uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.CI_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CI_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.API_CI_GHA_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - id: launch
         uses: solarwindscloud/ec2-runner-action@main
         with:
           action: launch
-          github-token: ${{ secrets.CI_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           runner-user: github
           runner-directory: /gh
           instance-type: t4g.medium
@@ -103,12 +103,12 @@ jobs:
     steps:
       - uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.CI_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CI_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.API_CI_GHA_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - uses: solarwindscloud/ec2-runner-action@main
         with:
           action: terminate
-          github-token: ${{ secrets.CI_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           label: ${{ needs.launch_arm64.outputs.label }}
           instance-id: ${{ needs.launch_arm64.outputs.instance-id }}

--- a/.github/workflows/build_publish_packagecloud.yaml
+++ b/.github/workflows/build_publish_packagecloud.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: solarwindscloud/ec2-runner-action@main
         with:
           action: launch
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.APM_CI_GHA_GITHUB_TOKEN }}
           runner-user: github
           runner-directory: /gh
           instance-type: t4g.medium
@@ -109,6 +109,6 @@ jobs:
       - uses: solarwindscloud/ec2-runner-action@main
         with:
           action: terminate
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.APM_CI_GHA_GITHUB_TOKEN }}
           label: ${{ needs.launch_arm64.outputs.label }}
           instance-id: ${{ needs.launch_arm64.outputs.instance-id }}

--- a/.github/workflows/build_publish_pypi_and_draft_release.yaml
+++ b/.github/workflows/build_publish_pypi_and_draft_release.yaml
@@ -61,7 +61,7 @@ jobs:
         uses: solarwindscloud/ec2-runner-action@main
         with:
           action: launch
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.APM_CI_GHA_GITHUB_TOKEN }}
           runner-user: github
           runner-directory: /gh
           instance-type: t4g.medium
@@ -107,7 +107,7 @@ jobs:
       - uses: solarwindscloud/ec2-runner-action@main
         with:
           action: terminate
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.APM_CI_GHA_GITHUB_TOKEN }}
           label: ${{ needs.launch_arm64.outputs.label }}
           instance-id: ${{ needs.launch_arm64.outputs.instance-id }}
 
@@ -124,4 +124,4 @@ jobs:
     - name: Create draft release
       run: gh release create ${{ env.RELEASE_NAME }} --title "${{ env.RELEASE_NAME }}" --target release/${{ env.RELEASE_NAME }} --draft
       env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        GITHUB_TOKEN: ${{secrets.APM_CI_GHA_GITHUB_TOKEN}}

--- a/.github/workflows/build_publish_pypi_and_draft_release.yaml
+++ b/.github/workflows/build_publish_pypi_and_draft_release.yaml
@@ -54,14 +54,14 @@ jobs:
     steps:
       - uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.CI_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CI_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.API_CI_GHA_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - id: launch
         uses: solarwindscloud/ec2-runner-action@main
         with:
           action: launch
-          github-token: ${{ secrets.CI_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           runner-user: github
           runner-directory: /gh
           instance-type: t4g.medium
@@ -101,13 +101,13 @@ jobs:
     steps:
       - uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.CI_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CI_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.API_CI_GHA_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - uses: solarwindscloud/ec2-runner-action@main
         with:
           action: terminate
-          github-token: ${{ secrets.CI_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           label: ${{ needs.launch_arm64.outputs.label }}
           instance-id: ${{ needs.launch_arm64.outputs.instance-id }}
 

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -40,14 +40,14 @@ jobs:
     steps:
       - uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.CI_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CI_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.API_CI_GHA_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - id: launch
         uses: solarwindscloud/ec2-runner-action@main
         with:
           action: launch
-          github-token: ${{ secrets.CI_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           runner-user: github
           runner-directory: /gh
           instance-type: t4g.medium
@@ -87,12 +87,12 @@ jobs:
     steps:
       - uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.CI_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CI_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.API_CI_GHA_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - uses: solarwindscloud/ec2-runner-action@main
         with:
           action: terminate
-          github-token: ${{ secrets.CI_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           label: ${{ needs.launch_arm64.outputs.label }}
           instance-id: ${{ needs.launch_arm64.outputs.instance-id }}

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -47,7 +47,7 @@ jobs:
         uses: solarwindscloud/ec2-runner-action@main
         with:
           action: launch
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.APM_CI_GHA_GITHUB_TOKEN }}
           runner-user: github
           runner-directory: /gh
           instance-type: t4g.medium
@@ -93,6 +93,6 @@ jobs:
       - uses: solarwindscloud/ec2-runner-action@main
         with:
           action: terminate
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.APM_CI_GHA_GITHUB_TOKEN }}
           label: ${{ needs.launch_arm64.outputs.label }}
           instance-id: ${{ needs.launch_arm64.outputs.instance-id }}

--- a/.github/workflows/create_release_pr.yaml
+++ b/.github/workflows/create_release_pr.yaml
@@ -46,4 +46,4 @@ jobs:
     - name: Open draft Pull Request for version bump
       run: gh pr create --draft --title "solarwinds-apm ${{ env.RELEASE_VERSION }}" --body "For PyPI release of solarwinds-apm ${{ env.RELEASE_VERSION }}. See also CHANGELOG.md."
       env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        GITHUB_TOKEN: ${{secrets.APM_CI_GHA_GITHUB_TOKEN}}

--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -72,7 +72,7 @@ jobs:
             ubuntu:18.04
             ubuntu:20.04
             ubuntu:22.04
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.APM_CI_GHA_GITHUB_TOKEN }}
           runner-user: github
           runner-directory: /gh
           instance-type: t4g.medium
@@ -240,5 +240,5 @@ jobs:
       - uses: solarwindscloud/ec2-runner-action@main
         with:
           action: terminate
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.APM_CI_GHA_GITHUB_TOKEN }}
           matrix: ${{ needs.launch-arm64.outputs.matrix }}

--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -39,8 +39,8 @@ jobs:
     steps:
       - uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.CI_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CI_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.API_CI_GHA_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - id: launch
         uses: solarwindscloud/ec2-runner-action@main
@@ -72,7 +72,7 @@ jobs:
             ubuntu:18.04
             ubuntu:20.04
             ubuntu:22.04
-          github-token: ${{ secrets.CI_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           runner-user: github
           runner-directory: /gh
           instance-type: t4g.medium
@@ -234,11 +234,11 @@ jobs:
     steps:
       - uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.CI_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CI_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.API_CI_GHA_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - uses: solarwindscloud/ec2-runner-action@main
         with:
           action: terminate
-          github-token: ${{ secrets.CI_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           matrix: ${{ needs.launch-arm64.outputs.matrix }}


### PR DESCRIPTION
Not necessary but I wanted some clarity! Following their rotation, I'm updating the CI creds in 2 steps -- I've added the new ones then I'll delete the old ones after this is merged). I like the names of the new ones better to [match the doc](https://github.com/solarwindscloud/apm-ci-infra).

Tested with the Verify Install action: https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/5592768100