### PR TITLE
NH-46870 Otel Python 1.19.0/0.40b0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
-opentelemetry-test-utils==0.39b0
-opentelemetry-instrumentation-flask==0.39b0
-opentelemetry-instrumentation-requests==0.39b0
+opentelemetry-test-utils==0.40b0
+opentelemetry-instrumentation-flask==0.40b0
+opentelemetry-instrumentation-requests==0.40b0
 pytest
 pytest-cov
 pytest-mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,10 +23,10 @@ classifiers =
 [options]
 python_requires = >=3.7
 install_requires =
-    opentelemetry-api == 1.18.0
-    opentelemetry-sdk == 1.18.0
-    opentelemetry-instrumentation == 0.39b0
-    opentelemetry-instrumentation-logging == 0.39b0
+    opentelemetry-api == 1.19.0
+    opentelemetry-sdk == 1.19.0
+    opentelemetry-instrumentation == 0.40b0
+    opentelemetry-instrumentation-logging == 0.40b0
 packages = solarwinds_apm, solarwinds_apm.api, solarwinds_apm.certs, solarwinds_apm.extension
 
 [options.package_data]

--- a/tests/integration/test_scenario_1.py
+++ b/tests/integration/test_scenario_1.py
@@ -94,7 +94,7 @@ class TestScenario1(TestBaseSwHeadersAndAttributes):
         span_client = spans[0]
         assert span_server.name == "/test_trace/"
         assert span_server.kind == trace_api.SpanKind.SERVER
-        assert span_client.name == "HTTP GET"
+        assert span_client.name == "GET"
         assert span_client.kind == trace_api.SpanKind.CLIENT
 
         # Check root span tracestate has no `sw` key

--- a/tests/integration/test_scenario_4.py
+++ b/tests/integration/test_scenario_4.py
@@ -119,7 +119,7 @@ class TestScenario4(TestBaseSwHeadersAndAttributes):
         span_client = spans[0]
         assert span_server.name == "/test_trace/"
         assert span_server.kind == trace_api.SpanKind.SERVER
-        assert span_client.name == "HTTP GET"
+        assert span_client.name == "GET"
         assert span_client.kind == trace_api.SpanKind.CLIENT
 
         # Check spans' trace_id, which should match traceparent of original request

--- a/tests/integration/test_scenario_8.py
+++ b/tests/integration/test_scenario_8.py
@@ -137,7 +137,7 @@ class TestScenario8(TestBaseSwHeadersAndAttributes):
         span_client = spans[0]
         assert span_server.name == "/test_trace/"
         assert span_server.kind == trace_api.SpanKind.SERVER
-        assert span_client.name == "HTTP GET"
+        assert span_client.name == "GET"
         assert span_client.kind == trace_api.SpanKind.CLIENT
 
         # Check spans' trace_id, which should match traceparent of original request
@@ -435,7 +435,7 @@ class TestScenario8(TestBaseSwHeadersAndAttributes):
         span_client = spans[0]
         assert span_server.name == "/test_trace/"
         assert span_server.kind == trace_api.SpanKind.SERVER
-        assert span_client.name == "HTTP GET"
+        assert span_client.name == "GET"
         assert span_client.kind == trace_api.SpanKind.CLIENT
 
         # Check spans' trace_id, which should match traceparent of original request
@@ -706,7 +706,7 @@ class TestScenario8(TestBaseSwHeadersAndAttributes):
         span_client = spans[0]
         assert span_server.name == "/test_trace/"
         assert span_server.kind == trace_api.SpanKind.SERVER
-        assert span_client.name == "HTTP GET"
+        assert span_client.name == "GET"
         assert span_client.kind == trace_api.SpanKind.CLIENT
 
         # Check root span tracestate has `xtrace_options_response` key but no `sw` key

--- a/tests/integration/test_signed_tt.py
+++ b/tests/integration/test_signed_tt.py
@@ -107,7 +107,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         span_client = spans[0]
         assert span_server.name == "/test_trace/"
         assert span_server.kind == trace_api.SpanKind.SERVER
-        assert span_client.name == "HTTP GET"
+        assert span_client.name == "GET"
         assert span_client.kind == trace_api.SpanKind.CLIENT
 
         # Check root span tracestate has `xtrace_options_response` key but no `sw` key
@@ -267,7 +267,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         span_client = spans[0]
         assert span_server.name == "/test_trace/"
         assert span_server.kind == trace_api.SpanKind.SERVER
-        assert span_client.name == "HTTP GET"
+        assert span_client.name == "GET"
         assert span_client.kind == trace_api.SpanKind.CLIENT
 
         # Check root span tracestate has `xtrace_options_response` key but no `sw` key

--- a/tests/integration/test_unsigned_tt.py
+++ b/tests/integration/test_unsigned_tt.py
@@ -107,7 +107,7 @@ class TestUnsignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         span_client = spans[0]
         assert span_server.name == "/test_trace/"
         assert span_server.kind == trace_api.SpanKind.SERVER
-        assert span_client.name == "HTTP GET"
+        assert span_client.name == "GET"
         assert span_client.kind == trace_api.SpanKind.CLIENT
 
         # Check root span tracestate has `xtrace_options_response` key but no `sw` key
@@ -426,7 +426,7 @@ class TestUnsignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         span_client = spans[0]
         assert span_server.name == "/test_trace/"
         assert span_server.kind == trace_api.SpanKind.SERVER
-        assert span_client.name == "HTTP GET"
+        assert span_client.name == "GET"
         assert span_client.kind == trace_api.SpanKind.CLIENT
 
         # Check root span tracestate has `xtrace_options_response` key but no `sw` key


### PR DESCRIPTION
Upgrade to Otel Python 1.19.0/0.40b0
* https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.19.0
* https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.40b0

Integration tests are updated I think because new OTel Python includes the Flask instrumentation update PR: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1784

tox tests pass on this PR.

Test traces:
* [SWO Django](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/B1D184BEFC24F7F1CCE4A292BA32517B/943B2952D185D7DD/details/breakdown?perspective=requests&serviceId=e-1540126275982954496&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending)
* [SWO FastAPI](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/B3AA1BB4CC3EAC69FED8FCF70E7ACAD7/6CBFB69C05576E11/details/breakdown?perspective=requests&serviceId=e-1563388155741380608&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending)
* [AO Django](https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/85A47524F2790C6FF4A450787C569B6200000000?duration=3600)
* [AO FastAPI](https://my.appoptics.com/apm/123092/services/asgi_app_ot/traces/E482DC1B8C1349A0FF7F010166FF12CF00000000?duration=3600)

Same as the integration tests, notice some changes in the Layer names for some spans (compared to [before-PR example Django trace](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/E9014DD7FC5066A8A876D8D1062885D5/88AA7D151B3DAB81/details/breakdown?perspective=requests&serviceId=e-1540126275982954496&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending)):

* `SERVER:home_a_reentry/` is now --> `SERVER:GET home_a_reentry/`
* `CLIENT:HTTP GET` --> `CLIENT:GET`