### PR TITLE
solarwinds-apm 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.13.0...HEAD)
+## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.14.0...HEAD)
 
-## [0.14.0.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.14.0) - 2023-07-20
+## [0.14.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.14.0) - 2023-07-20
 ### Changed
 - Refactored propagator and sampler ([#175](https://github.com/solarwindscloud/solarwinds-apm-python/pull/175))
 - Renamed CI secrets ([#176](https://github.com/solarwindscloud/solarwinds-apm-python/pull/176))

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.14.0.0"
+__version__ = "0.14.0"


### PR DESCRIPTION
For PyPI release of solarwinds-apm 0.14.0. See also CHANGELOG.md.

tox tests pass on this PR.

Test traces from local install:

- [SWO Django](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/646D40220C53017B4FD546980D1FD86B/77BB572D5B5B83C9/details/breakdown?perspective=requests&serviceId=e-1540126275982954496&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending)
- [SWO FastAPI](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/ED1613AB485755397A49AE3943367A80/56540D50CECAB67D/details/breakdown?perspective=requests&serviceId=e-1563388155741380608&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending)
- [AO Django](https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/77FE22144784C4195C06FE949185302F00000000?duration=3600)
- [AO FastAPI](https://my.appoptics.com/apm/123092/services/asgi_app_ot/traces/ABF554408703306E82D4D60C68E54C8400000000?duration=3600)

PyPI publish and smoke testing will be done after this PR is merged.