### PR TITLE
NH-52515 set transaction name, sampled or not

### DIFF
--- a/solarwinds_apm/inbound_metrics_processor.py
+++ b/solarwinds_apm/inbound_metrics_processor.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Optional, Tuple
 from opentelemetry import baggage, context
 from opentelemetry.sdk.trace import SpanProcessor
 from opentelemetry.semconv.trace import SpanAttributes
-from opentelemetry.trace import SpanKind, StatusCode, TraceFlags
+from opentelemetry.trace import SpanKind, StatusCode
 
 from solarwinds_apm.apm_constants import (
     INTL_SWO_CURRENT_SPAN_ID,
@@ -129,11 +129,11 @@ class SolarWindsInboundMetricsSpanProcessor(SpanProcessor):
                 has_error,
             )
 
-        if span.context.trace_flags == TraceFlags.SAMPLED:
-            # Cache txn_name for span export
-            self.apm_txname_manager[
-                f"{span.context.trace_id}-{span.context.span_id}"
-            ] = liboboe_txn_name  # type: ignore
+        # Cache txn_name for metrics and span export
+        # Any span passing through here is recorded, sometimes sampled
+        self.apm_txname_manager[
+            f"{span.context.trace_id}-{span.context.span_id}"
+        ] = liboboe_txn_name  # type: ignore
 
     def is_span_http(self, span: "ReadableSpan") -> bool:
         """This span from inbound HTTP request if from a SERVER by some http.method"""


### PR DESCRIPTION
Custom span processor now always caches (custom) transaction name, even if not sampled. This is so metrics are still reported with those transaction names if sampling decision is record-only.

Tested visually with local test collector, with APM Python temporarily set to always `return Decision.RECORD_ONLY`. Request was made to Django A test app's `home_a/` route including a call to API `set_transaction_name`. We see that before the change it's not using the custom name.

Now:
```
    "histograms": [
        {
            "name": "TransactionResponseTime",
            "value": "<long_unique_value>",
            "tags": {
                "TransactionName": "custom-name-django-b-root"
            }
        }
    ]
```

Before:
```
    "histograms": [
        {
            "name": "TransactionResponseTime",
            "value": "<long_unique_value>",
            "tags": {
                "TransactionName": "home_a/"
            }
        }
    ]
```