### PR TITLE
NH-52515 Remove cached custom name at calculate_custom

### DIFF
--- a/solarwinds_apm/inbound_metrics_processor.py
+++ b/solarwinds_apm/inbound_metrics_processor.py
@@ -181,6 +181,9 @@ class SolarWindsInboundMetricsSpanProcessor(SpanProcessor):
         custom_name = self.apm_txname_manager.get(trace_span_id)
         if custom_name:
             trans_name = custom_name
+            # Remove custom name from cache in case not sampled.
+            # If sampled, should be re-added at on_end.
+            del self.apm_txname_manager[trace_span_id]
         return trans_name
 
     def calculate_span_time(

--- a/tests/unit/test_inbound_metrics_processor.py
+++ b/tests/unit/test_inbound_metrics_processor.py
@@ -717,6 +717,38 @@ class TestSolarWindsInboundMetricsSpanProcessor():
         )
         assert False == processor.is_span_http(mock_span)
 
+    def test_is_span_http_false_no_server_kind_no_method(self, mocker):
+        mock_spankind = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SpanKind"
+        )
+        mock_spankind.configure_mock(
+            **{
+                "SERVER": "foo"
+            }
+        )
+        mock_spanattributes = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SpanAttributes"
+        )
+        mock_spanattributes.configure_mock(
+            **{
+                "HTTP_METHOD": "http.method"
+            }
+        )
+        mock_span = mocker.Mock()
+        mock_span.configure_mock(
+            **{
+                "kind": "not-foo-hehe",
+                "attributes": {
+                    "NOT.http.method.hehehehe": "bar"
+                }
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert False == processor.is_span_http(mock_span)
+
     def test_has_error_true(self, mocker):
         mock_statuscode = mocker.patch(
             "solarwinds_apm.inbound_metrics_processor.StatusCode"

--- a/tests/unit/test_inbound_metrics_processor.py
+++ b/tests/unit/test_inbound_metrics_processor.py
@@ -128,11 +128,59 @@ class TestSolarWindsInboundMetricsSpanProcessor():
         )
         assert False == processor.is_span_http(mock_span)
 
-    def test_has_error_true(self):
-        pass
+    def test_has_error_true(self, mocker):
+        mock_statuscode = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.StatusCode"
+        )
+        mock_statuscode.configure_mock(
+            **{
+                "ERROR": "foo"
+            }
+        )
+        mock_span = mocker.Mock()
+        mock_status = mocker.Mock()
+        mock_status.configure_mock(
+            **{
+                "status_code": "foo"
+            }
+        )
+        mock_span.configure_mock(
+            **{
+                "status": mock_status
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert True == processor.has_error(mock_span)
 
-    def test_has_error_false(self):
-        pass
+    def test_has_error_false(self, mocker):
+        mock_statuscode = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.StatusCode"
+        )
+        mock_statuscode.configure_mock(
+            **{
+                "ERROR": "foo"
+            }
+        )
+        mock_span = mocker.Mock()
+        mock_status = mocker.Mock()
+        mock_status.configure_mock(
+            **{
+                "status_code": "not-foo-hehehe"
+            }
+        )
+        mock_span.configure_mock(
+            **{
+                "status": mock_status
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert False == processor.has_error(mock_span)
 
     def test_get_http_status_code_default(self):
         pass

--- a/tests/unit/test_inbound_metrics_processor.py
+++ b/tests/unit/test_inbound_metrics_processor.py
@@ -851,6 +851,37 @@ class TestSolarWindsInboundMetricsSpanProcessor():
         )
         assert 0 == processor.get_http_status_code(mock_span)
 
+    def test_calculate_transaction_names_span_name_default(self, mocker):
+        """Otel Python span.name should always exist"""
+        mock_spanattributes = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SpanAttributes"
+        )
+        mock_spanattributes.configure_mock(
+            **{
+                "HTTP_URL": "http.url",
+                "HTTP_ROUTE": "http.route"
+            }
+        )
+        mock_calculate_custom = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SolarWindsInboundMetricsSpanProcessor.calculate_custom_transaction_name"
+        )
+        mock_calculate_custom.configure_mock(return_value=None)
+        mock_span = mocker.Mock()
+        mock_span.configure_mock(
+            **{
+                "name": "foo",
+                "attributes": {
+                    "http.route": None,
+                    "http.url": None
+                }
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert ("foo", None) == processor.calculate_transaction_names(mock_span)
+
     def test_calculate_transaction_names_custom(self, mocker):
         mock_spanattributes = mocker.patch(
             "solarwinds_apm.inbound_metrics_processor.SpanAttributes"
@@ -908,7 +939,7 @@ class TestSolarWindsInboundMetricsSpanProcessor():
         )
         assert "foo", "bar" == processor.calculate_transaction_names(mock_span)
 
-    def test_calculate_transaction_names_span_name(self, mocker):
+    def test_calculate_transaction_names_span_name_and_url(self, mocker):
         mock_spanattributes = mocker.patch(
             "solarwinds_apm.inbound_metrics_processor.SpanAttributes"
         )

--- a/tests/unit/test_inbound_metrics_processor.py
+++ b/tests/unit/test_inbound_metrics_processor.py
@@ -908,7 +908,8 @@ class TestSolarWindsInboundMetricsSpanProcessor():
             mocker.Mock(),
             mocker.Mock(),
         )
-        assert "foo", "bar" == processor.calculate_transaction_names(mock_span)
+        result = processor.calculate_transaction_names(mock_span)
+        assert "foo", "bar" == result
 
     def test_calculate_transaction_names_http_route(self, mocker):
         mock_spanattributes = mocker.patch(
@@ -937,7 +938,8 @@ class TestSolarWindsInboundMetricsSpanProcessor():
             mocker.Mock(),
             mocker.Mock(),
         )
-        assert "foo", "bar" == processor.calculate_transaction_names(mock_span)
+        result = processor.calculate_transaction_names(mock_span)
+        assert "foo", "bar" == result
 
     def test_calculate_transaction_names_span_name_and_url(self, mocker):
         mock_spanattributes = mocker.patch(
@@ -967,7 +969,8 @@ class TestSolarWindsInboundMetricsSpanProcessor():
             mocker.Mock(),
             mocker.Mock(),
         )
-        assert "foo", "bar" == processor.calculate_transaction_names(mock_span)
+        result = processor.calculate_transaction_names(mock_span)
+        assert "foo", "bar" == result
 
     def test_calculate_custom_transaction_name_none(self, mocker):
         mocker.patch(

--- a/tests/unit/test_inbound_metrics_processor.py
+++ b/tests/unit/test_inbound_metrics_processor.py
@@ -45,6 +45,7 @@ class TestSolarWindsInboundMetricsSpanProcessor():
         return mock_swo_baggage_key, mock_set_baggage, mock_attach
 
     def test_on_start_valid_local_parent_span(self, mocker):
+        mock_swo_baggage_key, mock_set_baggage, mock_attach = self.patch_for_on_start(mocker)
         mock_span = mocker.Mock()
         mock_parent = mocker.Mock()
         mock_parent.configure_mock(
@@ -63,6 +64,9 @@ class TestSolarWindsInboundMetricsSpanProcessor():
             mocker.Mock(),
         )
         assert processor.on_start(mock_span, None) is None
+        mock_swo_baggage_key.assert_not_called()
+        mock_set_baggage.assert_not_called()
+        mock_attach.assert_not_called()
 
     def test_on_start_valid_remote_parent_span(self, mocker):
         mock_swo_baggage_key, mock_set_baggage, mock_attach = self.patch_for_on_start(mocker)
@@ -239,6 +243,7 @@ class TestSolarWindsInboundMetricsSpanProcessor():
         return mock_get_http_status_code, mock_create_http_span, mock_create_span, mock_apm_config, mock_txname_manager, mock_set
 
     def test_on_end_valid_local_parent_span(self, mocker):
+        mock_get_http_status_code, mock_create_http_span, mock_create_span, mock_apm_config, mock_txname_manager, mock_set = self.patch_for_on_end(mocker)
         mock_span = mocker.Mock()
         mock_parent = mocker.Mock()
         mock_parent.configure_mock(
@@ -257,6 +262,12 @@ class TestSolarWindsInboundMetricsSpanProcessor():
             mocker.Mock(),
         )
         assert processor.on_end(mock_span) is None
+        mock_get_http_status_code.assert_not_called()
+        mock_create_http_span.assert_not_called()
+        mock_create_span.assert_not_called()
+        mock_apm_config.assert_not_called()
+        mock_txname_manager.assert_not_called()
+        mock_set.assert_not_called()
 
     def test_on_end_is_span_http(self, mocker):
         mock_get_http_status_code, mock_create_http_span, mock_create_span, mock_apm_config, mock_txname_manager, mock_set = self.patch_for_on_end(mocker, is_span_http=True)

--- a/tests/unit/test_inbound_metrics_processor.py
+++ b/tests/unit/test_inbound_metrics_processor.py
@@ -230,14 +230,92 @@ class TestSolarWindsInboundMetricsSpanProcessor():
         )
         assert 0 == processor.get_http_status_code(mock_span)
 
-    def test_calculate_transaction_names_custom(self):
-        pass
+    def test_calculate_transaction_names_custom(self, mocker):
+        mock_spanattributes = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SpanAttributes"
+        )
+        mock_spanattributes.configure_mock(
+            **{
+                "HTTP_URL": "http.url",
+                "HTTP_ROUTE": "http.route"
+            }
+        )
+        mock_calculate_custom = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SolarWindsInboundMetricsSpanProcessor.calculate_transaction_names"
+        )
+        mock_calculate_custom.configure_mock(return_value="foo")
+        mock_span = mocker.Mock()
+        mock_span.configure_mock(
+            **{
+                "attributes": {
+                    "http.url": "bar"
+                }
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert "foo", "bar" == processor.calculate_transaction_names(mock_span)
 
-    def test_calculate_transaction_names_http_route(self):
-        pass
+    def test_calculate_transaction_names_http_route(self, mocker):
+        mock_spanattributes = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SpanAttributes"
+        )
+        mock_spanattributes.configure_mock(
+            **{
+                "HTTP_URL": "http.url",
+                "HTTP_ROUTE": "http.route"
+            }
+        )
+        mock_calculate_custom = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SolarWindsInboundMetricsSpanProcessor.calculate_transaction_names"
+        )
+        mock_calculate_custom.configure_mock(return_value=None)
+        mock_span = mocker.Mock()
+        mock_span.configure_mock(
+            **{
+                "attributes": {
+                    "http.route": "foo",
+                    "http.url": "bar",
+                }
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert "foo", "bar" == processor.calculate_transaction_names(mock_span)
 
-    def test_calculate_transaction_names_span_name(self):
-        pass
+    def test_calculate_transaction_names_span_name(self, mocker):
+        mock_spanattributes = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SpanAttributes"
+        )
+        mock_spanattributes.configure_mock(
+            **{
+                "HTTP_URL": "http.url",
+                "HTTP_ROUTE": "http.route"
+            }
+        )
+        mock_calculate_custom = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SolarWindsInboundMetricsSpanProcessor.calculate_transaction_names"
+        )
+        mock_calculate_custom.configure_mock(return_value=None)
+        mock_span = mocker.Mock()
+        mock_span.configure_mock(
+            **{
+                "name": "foo",
+                "attributes": {
+                    "not.http.route.hehe": "baz",
+                    "http.url": "bar",
+                }
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert "foo", "bar" == processor.calculate_transaction_names(mock_span)
 
     def test_calculate_custom_transaction_name_none(self, mocker):
         mocker.patch(

--- a/tests/unit/test_inbound_metrics_processor.py
+++ b/tests/unit/test_inbound_metrics_processor.py
@@ -1,0 +1,122 @@
+# © 2023 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+import pytest  # pylint: disable=unused-import
+
+from solarwinds_apm.inbound_metrics_processor import SolarWindsInboundMetricsSpanProcessor
+
+
+class TestSolarWindsInboundMetricsSpanProcessor():
+
+    def test_on_start_valid_local_parent_span(self):
+        pass
+
+    def test_on_start(self):
+        pass
+
+    def test_on_end_valid_local_parent_span(self):
+        pass
+
+    def test_on_end_is_span_http(self):
+        pass
+
+    def test_on_end_not_is_span_http(self):
+        pass
+
+    def test_on_end_sampled(self):
+        pass
+
+    def test_on_end_not_sampled(self):
+        pass
+
+    def test_is_span_http_true(self):
+        pass
+
+    def test_is_span_http_false(self):
+        pass
+
+    def test_has_error_true(self):
+        pass
+
+    def test_has_error_false(self):
+        pass
+
+    def test_get_http_status_code_default(self):
+        pass
+
+    def test_get_http_status_code_from_span(self):
+        pass
+
+    def test_calculate_transaction_names_custom(self):
+        pass
+
+    def test_calculate_transaction_names_http_route(self):
+        pass
+
+    def test_calculate_transaction_names_span_name(self):
+        pass
+
+    def test_calculate_custom_transaction_name_none(self, mocker):
+        mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.W3CTransformer"
+        )
+        mock_txname_manager = mocker.Mock()
+        mock_get = mocker.Mock(return_value=None)
+        mock_del = mocker.Mock()
+        mock_txname_manager.configure_mock(
+            **{
+                "get": mock_get,
+                "__delitem__": mock_del,
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mock_txname_manager,
+            mocker.Mock(),
+        )
+        assert processor.calculate_custom_transaction_name(mocker.Mock()) is None
+        mock_del.assert_not_called()
+
+    def test_calculate_custom_transaction_name_present(self, mocker):
+        mock_w3c = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.W3CTransformer"
+        )
+        mock_ts_id = mocker.Mock(return_value="some-id")
+        mock_w3c.configure_mock(
+            **{
+                "trace_and_span_id_from_context": mock_ts_id
+            }
+        )
+        mock_txname_manager = mocker.Mock()
+        mock_get = mocker.Mock(return_value="foo")
+        mock_del = mocker.Mock()
+        mock_txname_manager.configure_mock(
+            **{
+                "get": mock_get,
+                "__delitem__": mock_del,
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mock_txname_manager,
+            mocker.Mock(),
+        )
+        assert "foo" == processor.calculate_custom_transaction_name(mocker.Mock())
+        mock_del.assert_called_once_with("some-id")
+
+    def test_calculate_span_time_missing(self, mocker):
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert 0 == processor.calculate_span_time(0, 0)
+        assert 0 == processor.calculate_span_time(0, 1000)
+        assert 0 == processor.calculate_span_time(1000, 0)
+
+    def test_calculate_span_time(self, mocker):
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert 1 == processor.calculate_span_time(2000, 3000)

--- a/tests/unit/test_inbound_metrics_processor.py
+++ b/tests/unit/test_inbound_metrics_processor.py
@@ -862,7 +862,7 @@ class TestSolarWindsInboundMetricsSpanProcessor():
             }
         )
         mock_calculate_custom = mocker.patch(
-            "solarwinds_apm.inbound_metrics_processor.SolarWindsInboundMetricsSpanProcessor.calculate_transaction_names"
+            "solarwinds_apm.inbound_metrics_processor.SolarWindsInboundMetricsSpanProcessor.calculate_custom_transaction_name"
         )
         mock_calculate_custom.configure_mock(return_value="foo")
         mock_span = mocker.Mock()
@@ -890,7 +890,7 @@ class TestSolarWindsInboundMetricsSpanProcessor():
             }
         )
         mock_calculate_custom = mocker.patch(
-            "solarwinds_apm.inbound_metrics_processor.SolarWindsInboundMetricsSpanProcessor.calculate_transaction_names"
+            "solarwinds_apm.inbound_metrics_processor.SolarWindsInboundMetricsSpanProcessor.calculate_custom_transaction_name"
         )
         mock_calculate_custom.configure_mock(return_value=None)
         mock_span = mocker.Mock()
@@ -919,7 +919,7 @@ class TestSolarWindsInboundMetricsSpanProcessor():
             }
         )
         mock_calculate_custom = mocker.patch(
-            "solarwinds_apm.inbound_metrics_processor.SolarWindsInboundMetricsSpanProcessor.calculate_transaction_names"
+            "solarwinds_apm.inbound_metrics_processor.SolarWindsInboundMetricsSpanProcessor.calculate_custom_transaction_name"
         )
         mock_calculate_custom.configure_mock(return_value=None)
         mock_span = mocker.Mock()

--- a/tests/unit/test_inbound_metrics_processor.py
+++ b/tests/unit/test_inbound_metrics_processor.py
@@ -182,11 +182,53 @@ class TestSolarWindsInboundMetricsSpanProcessor():
         )
         assert False == processor.has_error(mock_span)
 
-    def test_get_http_status_code_default(self):
-        pass
+    def test_get_http_status_code_from_span(self, mocker):
+        mock_spanattributes = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SpanAttributes"
+        )
+        mock_spanattributes.configure_mock(
+            **{
+                "HTTP_STATUS_CODE": "http.status_code"
+            }
+        )
+        mock_span = mocker.Mock()
+        mock_span.configure_mock(
+            **{
+                "kind": "foo",
+                "attributes": {
+                    "http.status_code": "foo"
+                }
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert "foo" == processor.get_http_status_code(mock_span)
 
-    def test_get_http_status_code_from_span(self):
-        pass
+    def test_get_http_status_code_default(self, mocker):
+        mock_spanattributes = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SpanAttributes"
+        )
+        mock_spanattributes.configure_mock(
+            **{
+                "HTTP_STATUS_CODE": "http.status_code"
+            }
+        )
+        mock_span = mocker.Mock()
+        mock_span.configure_mock(
+            **{
+                "kind": "foo",
+                "attributes": {
+                    "NOT.http.status_code.muahaha": "foo"
+                }
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert 0 == processor.get_http_status_code(mock_span)
 
     def test_calculate_transaction_names_custom(self):
         pass

--- a/tests/unit/test_inbound_metrics_processor.py
+++ b/tests/unit/test_inbound_metrics_processor.py
@@ -11,11 +11,155 @@ from solarwinds_apm.inbound_metrics_processor import SolarWindsInboundMetricsSpa
 
 class TestSolarWindsInboundMetricsSpanProcessor():
 
-    def test_on_start_valid_local_parent_span(self):
-        pass
+    def patch_for_on_start(self, mocker):
+        mock_otel_context = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.context"
+        )
+        mock_attach = mocker.Mock()
+        mock_otel_context.configure_mock(
+            **{
+                "attach": mock_attach
+            }
+        )
+        mock_otel_baggage = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.baggage"
+        )
+        mock_set_baggage = mocker.Mock()
+        mock_otel_baggage.configure_mock(
+            **{
+                "set_baggage": mock_set_baggage
+            }
+        )
+        mock_swo_baggage_key = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.INTL_SWO_CURRENT_TRACE_ENTRY_SPAN_ID"
+        )
+        mock_w3c = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.W3CTransformer"
+        )
+        mock_ts_id = mocker.Mock(return_value="some-id")
+        mock_w3c.configure_mock(
+            **{
+                "trace_and_span_id_from_context": mock_ts_id
+            }
+        )
+        return mock_swo_baggage_key, mock_set_baggage, mock_attach
 
-    def test_on_start(self):
-        pass
+    def test_on_start_valid_local_parent_span(self, mocker):
+        mock_span = mocker.Mock()
+        mock_parent = mocker.Mock()
+        mock_parent.configure_mock(
+            **{
+                "is_valid": True,
+                "is_remote": False,
+            }
+        )
+        mock_span.configure_mock(
+            **{
+                "parent": mock_parent
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert processor.on_start(mock_span, None) is None
+
+    def test_on_start_valid_remote_parent_span(self, mocker):
+        mock_swo_baggage_key, mock_set_baggage, mock_attach = self.patch_for_on_start(mocker)
+        mock_span = mocker.Mock()
+        mock_parent = mocker.Mock()
+        mock_parent.configure_mock(
+            **{
+                "is_valid": True,
+                "is_remote": True,
+            }
+        )
+        mock_span.configure_mock(
+            **{
+                "parent": mock_parent
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert processor.on_start(mock_span, None) is None
+        mock_set_baggage.assert_called_once_with(
+            mock_swo_baggage_key,
+            "some-id",
+        )
+        mock_attach.assert_called_once()
+
+    def test_on_start_invalid_remote_parent_span(self, mocker):
+        mock_swo_baggage_key, mock_set_baggage, mock_attach = self.patch_for_on_start(mocker)
+        mock_span = mocker.Mock()
+        mock_parent = mocker.Mock()
+        mock_parent.configure_mock(
+            **{
+                "is_valid": False,
+                "is_remote": True,
+            }
+        )
+        mock_span.configure_mock(
+            **{
+                "parent": mock_parent
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert processor.on_start(mock_span, None) is None
+        mock_set_baggage.assert_called_once_with(
+            mock_swo_baggage_key,
+            "some-id",
+        )
+        mock_attach.assert_called_once()
+
+    def test_on_start_invalid_local_parent_span(self, mocker):
+        mock_swo_baggage_key, mock_set_baggage, mock_attach = self.patch_for_on_start(mocker)
+        mock_span = mocker.Mock()
+        mock_parent = mocker.Mock()
+        mock_parent.configure_mock(
+            **{
+                "is_valid": False,
+                "is_remote": False,
+            }
+        )
+        mock_span.configure_mock(
+            **{
+                "parent": mock_parent
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert processor.on_start(mock_span, None) is None
+        mock_set_baggage.assert_called_once_with(
+            mock_swo_baggage_key,
+            "some-id",
+        )
+        mock_attach.assert_called_once()
+
+    def test_on_start_missing_parent(self, mocker):
+        mock_swo_baggage_key, mock_set_baggage, mock_attach = self.patch_for_on_start(mocker)
+        mock_span = mocker.Mock()
+        mock_span.configure_mock(
+            **{
+                "parent": None
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert processor.on_start(mock_span, None) is None
+        mock_set_baggage.assert_called_once_with(
+            mock_swo_baggage_key,
+            "some-id",
+        )
+        mock_attach.assert_called_once()
 
     def test_on_end_valid_local_parent_span(self):
         pass

--- a/tests/unit/test_inbound_metrics_processor.py
+++ b/tests/unit/test_inbound_metrics_processor.py
@@ -32,11 +32,101 @@ class TestSolarWindsInboundMetricsSpanProcessor():
     def test_on_end_not_sampled(self):
         pass
 
-    def test_is_span_http_true(self):
-        pass
+    def test_is_span_http_true(self, mocker):
+        mock_spankind = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SpanKind"
+        )
+        mock_spankind.configure_mock(
+            **{
+                "SERVER": "foo"
+            }
+        )
+        mock_spanattributes = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SpanAttributes"
+        )
+        mock_spanattributes.configure_mock(
+            **{
+                "HTTP_METHOD": "http.method"
+            }
+        )
+        mock_span = mocker.Mock()
+        mock_span.configure_mock(
+            **{
+                "kind": "foo",
+                "attributes": {
+                    "http.method": "bar"
+                }
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert True == processor.is_span_http(mock_span)
 
-    def test_is_span_http_false(self):
-        pass
+    def test_is_span_http_false_not_server_kind(self, mocker):
+        mock_spankind = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SpanKind"
+        )
+        mock_spankind.configure_mock(
+            **{
+                "SERVER": "foo"
+            }
+        )
+        mock_spanattributes = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SpanAttributes"
+        )
+        mock_spanattributes.configure_mock(
+            **{
+                "HTTP_METHOD": "http.method"
+            }
+        )
+        mock_span = mocker.Mock()
+        mock_span.configure_mock(
+            **{
+                "kind": "not-foo-hehe",
+                "attributes": {
+                    "http.method": "bar"
+                }
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert False == processor.is_span_http(mock_span)
+
+    def test_is_span_http_false_no_http_method(self, mocker):
+        mock_spankind = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SpanKind"
+        )
+        mock_spankind.configure_mock(
+            **{
+                "SERVER": "foo"
+            }
+        )
+        mock_spanattributes = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SpanAttributes"
+        )
+        mock_spanattributes.configure_mock(
+            **{
+                "HTTP_METHOD": "http.method"
+            }
+        )
+        mock_span = mocker.Mock()
+        mock_span.configure_mock(
+            **{
+                "kind": "foo",
+                "attributes": {
+                    "NOT.http.method.hehehehe": "bar"
+                }
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mocker.Mock(),
+        )
+        assert False == processor.is_span_http(mock_span)
 
     def test_has_error_true(self):
         pass


### PR DESCRIPTION
EDIT: Also adds several unit tests for inbound metrics processor.

Adds removal of any stored custom transaction name at the end of `calculate_custom_transaction_name`. It will only be re-added to the manager if span is sampled so that exporter will have access to the name, before removing name again after reporting. This is to stop leaking in the case where span is _not_ sampled but custom transaction name is set (used for inbound metrics reporting). Big thanks to @swi-jared for seeing this!

Step-wise:
1. Customer code calls `set_transaction_name("foo")`. Call is successful and manager stores `"<trace_id>-<span_id>": "foo"`.
2. Otel SDK ends span with that `<span_id>` and `on_end` of processors called for all recorded spans, sampled or not (already in place!)
3. `calculate_transaction_names` for inbound metrics is called. Helper `calculate_custom_transaction_name` gets `"<trace_id>-<span_id>": "foo"` from manager.
4. **_New:_** `calculate_custom_transaction_name` deletes `"<trace_id>-<span_id>": "foo"` from manager.
5. Inbound metrics are generated next in `on_end`.
6. If ended span is sampled, cache `"<trace_id>-<span_id>": "foo"` in manager. This can be a re-cache of custom name or new cache of 'regular' transaction name.
   a. Exporter gets `"<trace_id>-<span_id>": "foo"` from manager.
   b. Exporter deletes `"<trace_id>-<span_id>": "foo"` from manager.
7. If ended span _not_ sampled, there is no (re-)caching.

Test trace from Django A testbed app's "reentry" route that requests its own route and also uses API set_transaction_name -- `sw.transaction` is `custom-name-django-a-root` at the root span, and is `custom-name-reentry` at the `SERVER:GET another/` span. Just a quick smoke test to make sure custom txn naming still works: https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/E51FD08B882DA4677B26254C08F5701A/E5C99F94B8B0D44A/details/breakdown?perspective=requests&serviceId=e-1540126275982954496

I made a second request a few minutes later with APM Python hardcoded to always decide `RECORD_ONLY`. This is to make sure we get metrics blips for the same custom names even if no trace exported:

![metrics_naming](https://github.com/solarwindscloud/solarwinds-apm-python/assets/96076570/fd1c11e9-5836-4098-9ece-8dd6cdb4310b)

