### PR TITLE
NH-53373 Testrelease 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.14.0...HEAD)
+## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.15.0...HEAD)
+
+## [0.15.0.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.15.0) - 2023-08-17
+
+### Added
+- Add context-in-logs configuration with `OTEL_SQLCOMMENTER_OPTIONS` ([#182](https://github.com/solarwindscloud/solarwinds-apm-python/pull/182))
+- Add CODEOWNERS file ([#189](https://github.com/solarwindscloud/solarwinds-apm-python/pull/189))
+
+### Changed
+- Remove unused baggage from propagator injection ([#184](https://github.com/solarwindscloud/solarwinds-apm-python/pull/184))
+- Simplify internal baggage setting for custom naming ([#186](https://github.com/solarwindscloud/solarwinds-apm-python/pull/186))
+- Fix custom name storage clearing when not sampled ([#187](https://github.com/solarwindscloud/solarwinds-apm-python/pull/187))
+
+### Removed
+- Remove old print statements in exporter ([#183](https://github.com/solarwindscloud/solarwinds-apm-python/pull/183))
+- Remove unneeded `Spec` key from error events ([#188](https://github.com/solarwindscloud/solarwinds-apm-python/pull/188))
 
 ## [0.14.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.14.0) - 2023-07-20
 ### Changed

--- a/solarwinds_apm/api/__init__.py
+++ b/solarwinds_apm/api/__init__.py
@@ -81,7 +81,7 @@ def set_transaction_name(custom_name: str) -> bool:
     inbound_processor.apm_txname_manager[
         current_trace_entry_span_id
     ] = custom_name
-    logger.warning(
+    logger.debug(
         "Cached custom transaction name for %s as %s",
         current_trace_entry_span_id,
         custom_name,

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.15.0"
+__version__ = "0.15.0.0"


### PR DESCRIPTION
APM Python testrelease 0.15.0
(Accidentally published without usual 4th digit but should be ok on TestPyPI).

This also changes a `warning` level log back to `debug`, which it was before an accidental change in this PR: https://github.com/solarwindscloud/solarwinds-apm-python/pull/186/files.

tox tests on this PR pass.

Test traces:
* [SWO Django](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/E24082C8B84994EA9AE6523BC5025E52/9261777F2E12D9D9/details/breakdown?perspective=requests&serviceId=e-1540126275982954496&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending)
* [SWO FastAPI](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/23E32CC384D4F01B35410A895A398A03/FD48C7BA1A592952/details/breakdown?perspective=requests&serviceId=e-1563388155741380608&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending)
* [AO Django](https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/977875BA4CCA7E211E99D3F71CD0E71E00000000?duration=3600)
* [AO FastAPI](https://my.appoptics.com/apm/123092/services/asgi_app_ot/traces/A1B28E45B49DB29037CC414893EB207A00000000?duration=3600)

Published to TestPyPI: https://test.pypi.org/project/solarwinds-apm/0.15.0/#files

Smoke/install-from-TestPyPI tests pass: https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/5895112561
