### PR TITLE
solarwinds-apm 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.15.0...HEAD)
 
-## [0.15.0.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.15.0) - 2023-08-17
+## [0.15.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.15.0) - 2023-08-17
 
 ### Added
 - Add context-in-logs configuration with `OTEL_SQLCOMMENTER_OPTIONS` ([#182](https://github.com/solarwindscloud/solarwinds-apm-python/pull/182))

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.15.0.0"
+__version__ = "0.15.0"


### PR DESCRIPTION
For PyPI release of solarwinds-apm 0.15.0. See also CHANGELOG.md.

tox tests on this PR pass.

Test traces:

- [SWO Django](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/E24082C8B84994EA9AE6523BC5025E52/9261777F2E12D9D9/details/breakdown?perspective=requests&serviceId=e-1540126275982954496&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending)
- [SWO FastAPI](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/23E32CC384D4F01B35410A895A398A03/FD48C7BA1A592952/details/breakdown?perspective=requests&serviceId=e-1563388155741380608&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending)
- [AO Django](https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/977875BA4CCA7E211E99D3F71CD0E71E00000000?duration=3600)
- [AO FastAPI](https://my.appoptics.com/apm/123092/services/asgi_app_ot/traces/A1B28E45B49DB29037CC414893EB207A00000000?duration=3600)

Install/smoke tests will be run after publish to PyPI.