### PR TITLE
solarwinds-apm 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.16.0...HEAD)
 
-## [0.16.0.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.16.0) - 2023-08-24
+## [0.16.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.16.0) - 2023-08-24
 
 ### Changed
 - Updated to liboboe version 13.0.0 (skipped 12.4.1) ([#192](https://github.com/solarwindscloud/solarwinds-apm-python/pull/192))

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.16.0.0"
+__version__ = "0.16.0"


### PR DESCRIPTION
For PyPI release of solarwinds-apm 0.16.0. See also CHANGELOG.md.

tox tests pass on this PR.

Test traces:
* [SWO Django](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/0D5C6E2BB79681DC895223A4A16736A2/4C71F8952AB0287E/details/breakdown?perspective=requests&serviceId=e-1540126275982954496&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending)
* [SWO FastAPI](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/ED23FBCE98D4410588A086DE3D3DB3F0/E03BA554F9101F12/details/breakdown?perspective=requests&serviceId=e-1563388155741380608&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending)
* [AO Django](https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/6072BE56E7F632F324A77375E7DBA92C00000000?duration=3600)
* [AO FastAPI](https://my.appoptics.com/apm/123092/services/asgi_app_ot/traces/C4110D0940E308809CEA411E0392AB9E00000000?duration=3600)

Smoke tests will be run after merging and PyPI publish.
