### PR TITLE
NH-58212 APM Python to Otel 1.12.0/0.41b0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.16.0...HEAD)
 
+### Changed
+- OpenTelemetry API/SDK and instrumentation 1.20.0/0.41b0 ([#195](https://github.com/solarwindscloud/solarwinds-apm-python/pull/195))
+
 ## [0.16.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.16.0) - 2023-08-24
 
 ### Changed

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
-opentelemetry-test-utils==0.40b0
-opentelemetry-instrumentation-flask==0.40b0
-opentelemetry-instrumentation-requests==0.40b0
+opentelemetry-test-utils==0.41b0
+opentelemetry-instrumentation-flask==0.41b0
+opentelemetry-instrumentation-requests==0.41b0
 pytest
 pytest-cov
 pytest-mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,10 +23,10 @@ classifiers =
 [options]
 python_requires = >=3.7
 install_requires =
-    opentelemetry-api == 1.19.0
-    opentelemetry-sdk == 1.19.0
-    opentelemetry-instrumentation == 0.40b0
-    opentelemetry-instrumentation-logging == 0.40b0
+    opentelemetry-api == 1.20.0
+    opentelemetry-sdk == 1.20.0
+    opentelemetry-instrumentation == 0.41b0
+    opentelemetry-instrumentation-logging == 0.41b0
 packages = solarwinds_apm, solarwinds_apm.api, solarwinds_apm.certs, solarwinds_apm.extension
 
 [options.package_data]


### PR DESCRIPTION
Upgrades to Otel Python 1.12.0/0.41b0.

tox tests pass.

Test traces:
* [Django SWO](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/013431437E8E86DD71CAF2B4F71F8FD7/5560F46E6D1BEA1F/details?perspective=requests&serviceId=e-1540126275982954496)
* [FastAPI SWO](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/6584BD13A4C445762871DFDCED90A76E/6614567363DA65C7/details/breakdown?perspective=requests&serviceId=e-1563388155741380608)
* [Django AO](https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/CA1EC61D2ACC70CFFD90D359C8F50D7900000000?duration=3600)
* [FastAPI SWO](https://my.appoptics.com/apm/123092/services/asgi_app_ot/traces/491489EA97ACC4E5A192E68896839C1800000000?duration=3600)