### PR TITLE
NH-59208 Testrelease 0.17.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.16.0...HEAD)
+## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.17.0...HEAD)
+
+## [0.17.0.2](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.17.0) - 2023-09-20
 
 ### Changed
 - OpenTelemetry API/SDK and instrumentation 1.20.0/0.41b0 ([#195](https://github.com/solarwindscloud/solarwinds-apm-python/pull/195))
+- Update CODEOWNERS ([#196](https://github.com/solarwindscloud/solarwinds-apm-python/pull/196))
 
 ## [0.16.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.16.0) - 2023-08-24
 

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.16.0"
+__version__ = "0.17.0.2"


### PR DESCRIPTION
Test release publish of version 0.17.0.2. Note that versions 0.17.0.0, 0.17.0.1 were used for PoC of APM Python lambda layer creation ([this PR](https://github.com/solarwindscloud/solarwinds-apm-python/pull/197)) with a Reporter init hardcoded kwarg and a revert. This version 0.17.0.2 does _not_ include those PoC changes and they will not be included in the next publish to prod/PyPI.

Published at TestPyPI: https://test.pypi.org/project/solarwinds-apm/0.17.0.2/

tox tests pass on this PR.

Test traces:
* [SWO Django](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/DC7A3C2600232FE6E2822E63AB6B0CD2/BD5D0D538EF5D20B/details/breakdown?perspective=requests&serviceId=e-1639104873316855808&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending)
* [SWO FastAPI](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/E8A58AD41392C0332BEB7CC363AA87C9/41E62FE4605E682B/details/breakdown?perspective=requests&serviceId=e-1563388155741380608&duration=3600&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending)
* [AO Django](https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/228B4F90977FFD7B92AC2EDE4CB2E8A500000000?duration=3600)
* [AO FastAPI](https://my.appoptics.com/apm/123092/services/asgi_app_ot/traces/74151AADF42B4C9DAE13F7802B395A4100000000?duration=3600)

Smoke tests/Install-from-testpypi tests: TODO