### PR TITLE
solarwinds-apm 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.17.0...HEAD)
 
-## [0.17.0.2](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.17.0) - 2023-09-20
+## [0.17.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.17.0) - 2023-09-20
 
 ### Changed
 - OpenTelemetry API/SDK and instrumentation 1.20.0/0.41b0 ([#195](https://github.com/solarwindscloud/solarwinds-apm-python/pull/195))

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.17.0.2"
+__version__ = "0.17.0"


### PR DESCRIPTION
For PyPI release of solarwinds-apm 0.17.0. See also CHANGELOG.md.

tox tests pass on this PR.

Test traces:
* [SWO Django](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/DC7A3C2600232FE6E2822E63AB6B0CD2/BD5D0D538EF5D20B/details/breakdown?perspective=requests&serviceId=e-1639104873316855808&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending)
* [SWO FastAPI](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/E8A58AD41392C0332BEB7CC363AA87C9/41E62FE4605E682B/details/breakdown?perspective=requests&serviceId=e-1563388155741380608&duration=3600&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending)
* [AO Django](https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/228B4F90977FFD7B92AC2EDE4CB2E8A500000000?duration=3600)
* [AO FastAPI](https://my.appoptics.com/apm/123092/services/asgi_app_ot/traces/74151AADF42B4C9DAE13F7802B395A4100000000?duration=3600)

Smoke tests will be run after PyPI publish.