### PR TITLE
NH-62605 tox test Flask dependency matches upstream instrumentor

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,5 +5,5 @@ pytest
 pytest-cov
 pytest-mock
 requests
-flask
+flask<3.0.0
 werkzeug


### PR DESCRIPTION
Adjust tox dev-requirements file's Flask dependency so that it matches that of the current upsteam Otel Python Flask instrumentor ([this pyproject.toml](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/e318c947a23152c8ff1700f0aad44261be0588cd/instrumentation/opentelemetry-instrumentation-flask/pyproject.toml#L37-L39)):

```
instruments = [
  "flask >= 1.0, < 3.0",
]
```

The lack of Flask version restriction started making the APM Python automated tests fail with the release of Flask 3.0.0 two days ago (https://github.com/pallets/flask/releases/tag/3.0.0): `ERROR    opentelemetry.instrumentation.instrumentor:instrumentor.py:105 DependencyConflict: requested: "flask >= 1.0, < 3.0" but found: "flask 3.0.0"`.

Trying to instrument a Flask 3 app with plain upstream Otel Python quietly fails -- startup doesn't crash but Flask spans are missing from traces. I am working on an Otel Python issue with steps to reproduce. Therefore this PR is a quick fix.

EDIT: 2nd NH ticket to fix instrumentor
* https://swicloud.atlassian.net/browse/NH-62613