### PR TITLE
NH-62722 Update PAT setup for workflow EC2 runners

### DIFF
--- a/.github/workflows/build_publish_pypi_and_draft_release.yaml
+++ b/.github/workflows/build_publish_pypi_and_draft_release.yaml
@@ -52,6 +52,11 @@ jobs:
       label: ${{ steps.launch.outputs.label }} # github runner label
       instance-id: ${{ steps.launch.outputs.instance-id }} # ec2 instance id
     steps:
+      - uses: getsentry/action-github-app-token@v2
+        id: github-token
+        with:
+          app_id: ${{ vars.APPLICATION_ID }}
+          private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       - uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
@@ -61,7 +66,7 @@ jobs:
         uses: solarwindscloud/ec2-runner-action@main
         with:
           action: launch
-          github-token: ${{ secrets.APM_CI_GHA_GITHUB_TOKEN }}
+          github-token: ${{ steps.github-token.outputs.token }}
           runner-user: github
           runner-directory: /gh
           instance-type: t4g.medium
@@ -99,6 +104,11 @@ jobs:
       - build_publish_aarch64
     runs-on: ubuntu-latest
     steps:
+      - uses: getsentry/action-github-app-token@v2
+        id: github-token
+        with:
+          app_id: ${{ vars.APPLICATION_ID }}
+          private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       - uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
@@ -107,7 +117,7 @@ jobs:
       - uses: solarwindscloud/ec2-runner-action@main
         with:
           action: terminate
-          github-token: ${{ secrets.APM_CI_GHA_GITHUB_TOKEN }}
+          github-token: ${{ steps.github-token.outputs.token }}
           label: ${{ needs.launch_arm64.outputs.label }}
           instance-id: ${{ needs.launch_arm64.outputs.instance-id }}
 

--- a/.github/workflows/build_publish_pypi_and_draft_release.yaml
+++ b/.github/workflows/build_publish_pypi_and_draft_release.yaml
@@ -126,12 +126,17 @@ jobs:
     needs: [build_publish_sdist_and_x86_64, build_publish_aarch64]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Initialize git
-      run: |
-       git config user.name "GitHub Actions"
-       git config user.email noreply@github.com
-    - name: Create draft release
-      run: gh release create ${{ env.RELEASE_NAME }} --title "${{ env.RELEASE_NAME }}" --target release/${{ env.RELEASE_NAME }} --draft
-      env:
-        GITHUB_TOKEN: ${{secrets.APM_CI_GHA_GITHUB_TOKEN}}
+      - uses: getsentry/action-github-app-token@v2
+        id: github-token
+        with:
+          app_id: ${{ vars.APPLICATION_ID }}
+          private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+      - uses: actions/checkout@v3
+      - name: Initialize git
+        run: |
+        git config user.name "GitHub Actions"
+        git config user.email noreply@github.com
+      - name: Create draft release
+        run: gh release create ${{ env.RELEASE_NAME }} --title "${{ env.RELEASE_NAME }}" --target release/${{ env.RELEASE_NAME }} --draft
+        env:
+          GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}

--- a/.github/workflows/build_publish_testpypi.yaml
+++ b/.github/workflows/build_publish_testpypi.yaml
@@ -38,6 +38,11 @@ jobs:
       label: ${{ steps.launch.outputs.label }} # github runner label
       instance-id: ${{ steps.launch.outputs.instance-id }} # ec2 instance id
     steps:
+      - uses: getsentry/action-github-app-token@v2
+        id: github-token
+        with:
+          app_id: ${{ vars.APPLICATION_ID }}
+          private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       - uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
@@ -47,7 +52,7 @@ jobs:
         uses: solarwindscloud/ec2-runner-action@main
         with:
           action: launch
-          github-token: ${{ secrets.APM_CI_GHA_GITHUB_TOKEN }}
+          github-token: ${{ steps.github-token.outputs.token }}
           runner-user: github
           runner-directory: /gh
           instance-type: t4g.medium
@@ -85,6 +90,11 @@ jobs:
       - build_publish_aarch64
     runs-on: ubuntu-latest
     steps:
+      - uses: getsentry/action-github-app-token@v2
+        id: github-token
+        with:
+          app_id: ${{ vars.APPLICATION_ID }}
+          private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       - uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
@@ -93,6 +103,6 @@ jobs:
       - uses: solarwindscloud/ec2-runner-action@main
         with:
           action: terminate
-          github-token: ${{ secrets.APM_CI_GHA_GITHUB_TOKEN }}
+          github-token: ${{ steps.github-token.outputs.token }}
           label: ${{ needs.launch_arm64.outputs.label }}
           instance-id: ${{ needs.launch_arm64.outputs.instance-id }}

--- a/.github/workflows/create_release_pr.yaml
+++ b/.github/workflows/create_release_pr.yaml
@@ -21,29 +21,34 @@ jobs:
   create_release_pr:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Initialize git
-      run: |
-       git config user.name "GitHub Actions"
-       git config user.email noreply@github.com
-    - name: Check that tag does not exist yet
-      run: |
-        git fetch --tags --quiet
-        if git show-ref --tags ${{ env.RELEASE_NAME }} --quiet; then
-          echo "FATAL ERROR: Release tag ${{ env.RELEASE_NAME }} already exists!"
-          exit 1
-        fi
-    - name: Create release branch
-      run: git checkout -b release/${{ env.RELEASE_NAME }}
-    - name: Update agent version
-      run: sed -i -e "s/^__version__ = \".*\"$/__version__ = \"${{ env.RELEASE_VERSION }}\"/" solarwinds_apm/version.py
-    - name: Commit version.py
-      run: |
-        git add solarwinds_apm/version.py
-        git commit --message "Update agent version to ${{ env.RELEASE_VERSION }}"
-    - name: Push new release branch to remote repositories
-      run: git push origin release/${{ env.RELEASE_NAME }}
-    - name: Open draft Pull Request for version bump
-      run: gh pr create --draft --title "solarwinds-apm ${{ env.RELEASE_VERSION }}" --body "For PyPI release of solarwinds-apm ${{ env.RELEASE_VERSION }}. See also CHANGELOG.md."
-      env:
-        GITHUB_TOKEN: ${{secrets.APM_CI_GHA_GITHUB_TOKEN}}
+      - uses: getsentry/action-github-app-token@v2
+        id: github-token
+        with:
+          app_id: ${{ vars.APPLICATION_ID }}
+          private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+      - uses: actions/checkout@v3
+      - name: Initialize git
+        run: |
+        git config user.name "GitHub Actions"
+        git config user.email noreply@github.com
+      - name: Check that tag does not exist yet
+        run: |
+          git fetch --tags --quiet
+          if git show-ref --tags ${{ env.RELEASE_NAME }} --quiet; then
+            echo "FATAL ERROR: Release tag ${{ env.RELEASE_NAME }} already exists!"
+            exit 1
+          fi
+      - name: Create release branch
+        run: git checkout -b release/${{ env.RELEASE_NAME }}
+      - name: Update agent version
+        run: sed -i -e "s/^__version__ = \".*\"$/__version__ = \"${{ env.RELEASE_VERSION }}\"/" solarwinds_apm/version.py
+      - name: Commit version.py
+        run: |
+          git add solarwinds_apm/version.py
+          git commit --message "Update agent version to ${{ env.RELEASE_VERSION }}"
+      - name: Push new release branch to remote repositories
+        run: git push origin release/${{ env.RELEASE_NAME }}
+      - name: Open draft Pull Request for version bump
+        run: gh pr create --draft --title "solarwinds-apm ${{ env.RELEASE_VERSION }}" --body "For PyPI release of solarwinds-apm ${{ env.RELEASE_VERSION }}. See also CHANGELOG.md."
+        env:
+          GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}

--- a/.github/workflows/verify_install.yaml
+++ b/.github/workflows/verify_install.yaml
@@ -36,6 +36,11 @@ jobs:
     outputs:
       matrix: ${{ steps.launch.outputs.matrix }}
     steps:
+      - uses: getsentry/action-github-app-token@v2
+        id: github-token
+        with:
+          app_id: ${{ vars.APPLICATION_ID }}
+          private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       - uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
@@ -71,7 +76,7 @@ jobs:
             ubuntu:18.04
             ubuntu:20.04
             ubuntu:22.04
-          github-token: ${{ secrets.APM_CI_GHA_GITHUB_TOKEN }}
+          github-token: ${{ steps.github-token.outputs.token }}
           runner-user: github
           runner-directory: /gh
           instance-type: t4g.medium
@@ -231,6 +236,11 @@ jobs:
       - install-tests
     runs-on: ubuntu-latest
     steps:
+      - uses: getsentry/action-github-app-token@v2
+        id: github-token
+        with:
+          app_id: ${{ vars.APPLICATION_ID }}
+          private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       - uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.API_CI_GHA_ACCESS_KEY_ID }}
@@ -239,5 +249,5 @@ jobs:
       - uses: solarwindscloud/ec2-runner-action@main
         with:
           action: terminate
-          github-token: ${{ secrets.APM_CI_GHA_GITHUB_TOKEN }}
+          github-token: ${{ steps.github-token.outputs.token }}
           matrix: ${{ needs.launch-arm64.outputs.matrix }}

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.17.0"
+__version__ = "0.18.0.1"


### PR DESCRIPTION
Updates PAT setup for workflows using EC2 runner action. No more use of `secrets.APM_CI_GHA_GITHUB_TOKEN`! (I had this naming set up instead of `secrets.CI_GITHUB_TOKEN`.) Will remove the secret after merging this.

Ran the Verify Install tests (download APM Python from prod) and they worked: https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/6425692600

Did a testrelease [0.18.0.1](https://test.pypi.org/project/solarwinds-apm/0.18.0.1/) using contents of this branch and that also worked: https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/6425811924/job/17449163590
