### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,4 @@
-* @solarwindscloud/apm-instrumentation
-
-# as of Sept 2023, remove after GH EMU move (see below)
 * @solarwindscloud/eng-apm-instrumentation
 
 # placeholder for GH EMU where this will move to new org for public repos
-* @solarwinds/eng-apm-instrumentation
+#* @solarwinds/eng-apm-instrumentation


### PR DESCRIPTION
Update codeowners as old `apm-instrumentation` group no longer there and middle `eng-apm-instrumentation` available.