### PR TITLE
NH-65075 Add support for SW_APM_TRANSACTION_NAME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.17.0...HEAD)
 
+### Added
+- Add support for `SW_APM_TRANSACTION_NAME` ([#206](https://github.com/solarwindscloud/solarwinds-apm-python/pull/206))
+
 ## [0.17.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.17.0) - 2023-09-20
 
 ### Changed

--- a/solarwinds_apm/api/__init__.py
+++ b/solarwinds_apm/api/__init__.py
@@ -27,6 +27,8 @@ def set_transaction_name(custom_name: str) -> bool:
     Assign a custom transaction name to a current request. If multiple
     transaction names are set on the same trace, then the last one is used.
     Overrides default, out-of-the-box naming based on URL/controller/action.
+    Takes precedence over transaction_name set in environment variable or
+    config file.
 
     Any uppercase to lowercase conversions or special character replacements
     are done by the platform. Any truncations are done by the core extension.

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -109,6 +109,7 @@ class SolarWindsApmConfig:
             "reporter_file_single": 0,
             "proxy": "",
             "transaction_filters": [],
+            "transaction_name": None,
         }
         self.agent_enabled = True
         self.update_with_cnf_file()

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -709,6 +709,8 @@ class SolarWindsApmConfig:
                 self.__config[key] = val
                 # update logging level of agent logger
                 apm_logging.set_sw_log_level(val)
+            elif keys == ["transaction_name"]:
+                self.__config[key] = val
             elif isinstance(sub_dict, dict) and keys[-1] in sub_dict:
                 if isinstance(sub_dict[keys[-1]], bool):
                     val = self.convert_to_bool(val)

--- a/tests/unit/test_inbound_metrics_processor.py
+++ b/tests/unit/test_inbound_metrics_processor.py
@@ -877,9 +877,16 @@ class TestSolarWindsInboundMetricsSpanProcessor():
                 }
             }
         )
+        mock_get = mocker.Mock(return_value=None)
+        mock_apm_config = mocker.Mock()
+        mock_apm_config.configure_mock(
+            **{
+                "get": mock_get
+            }
+        )
         processor = SolarWindsInboundMetricsSpanProcessor(
             mocker.Mock(),
-            mocker.Mock(),
+            mock_apm_config,
         )
         assert ("foo", None) == processor.calculate_transaction_names(mock_span)
 
@@ -912,10 +919,7 @@ class TestSolarWindsInboundMetricsSpanProcessor():
         result = processor.calculate_transaction_names(mock_span)
         assert "foo", "bar" == result
 
-    def test_calculate_transaction_names_no_custom_yes_env(self, mocker):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_TRANSACTION_NAME": "foo",
-        })
+    def test_calculate_transaction_names_no_custom_yes_config(self, mocker):
         mock_spanattributes = mocker.patch(
             "solarwinds_apm.inbound_metrics_processor.SpanAttributes"
         )
@@ -937,9 +941,16 @@ class TestSolarWindsInboundMetricsSpanProcessor():
                 }
             }
         )
+        mock_get = mocker.Mock(return_value="foo")
+        mock_apm_config = mocker.Mock()
+        mock_apm_config.configure_mock(
+            **{
+                "get": mock_get
+            }
+        )
         processor = SolarWindsInboundMetricsSpanProcessor(
             mocker.Mock(),
-            mocker.Mock(),
+            mock_apm_config,
         )
         result = processor.calculate_transaction_names(mock_span)
         assert "foo", "bar" == result
@@ -1050,26 +1061,6 @@ class TestSolarWindsInboundMetricsSpanProcessor():
         )
         assert "foo" == processor.calculate_custom_transaction_name(mocker.Mock())
         mock_del.assert_called_once_with("some-id")
-
-    def test_calculate_env_transaction_name_none(self, mocker):
-        mocker.patch.dict(os.environ, {
-            "not_txn_name": "foo-bar",
-        })
-        processor = SolarWindsInboundMetricsSpanProcessor(
-            mocker.Mock(),
-            mocker.Mock(),
-        )
-        assert processor.calculate_env_transaction_name() is None
-
-    def test_calculate_env_transaction_name_present(self, mocker):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_TRANSACTION_NAME": "foo-bar",
-        })
-        processor = SolarWindsInboundMetricsSpanProcessor(
-            mocker.Mock(),
-            mocker.Mock(),
-        )
-        assert "foo-bar" == processor.calculate_env_transaction_name()
 
     def test_calculate_span_time_missing(self, mocker):
         processor = SolarWindsInboundMetricsSpanProcessor(

--- a/tests/unit/test_inbound_metrics_processor.py
+++ b/tests/unit/test_inbound_metrics_processor.py
@@ -4,7 +4,6 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-import os
 import pytest  # pylint: disable=unused-import
 
 from solarwinds_apm.inbound_metrics_processor import SolarWindsInboundMetricsSpanProcessor

--- a/tests/unit/test_inbound_metrics_processor.py
+++ b/tests/unit/test_inbound_metrics_processor.py
@@ -919,6 +919,42 @@ class TestSolarWindsInboundMetricsSpanProcessor():
         result = processor.calculate_transaction_names(mock_span)
         assert "foo", "bar" == result
 
+    def test_calculate_transaction_names_yes_custom_yes_config(self, mocker):
+        mock_spanattributes = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SpanAttributes"
+        )
+        mock_spanattributes.configure_mock(
+            **{
+                "HTTP_URL": "http.url",
+                "HTTP_ROUTE": "http.route"
+            }
+        )
+        mock_calculate_custom = mocker.patch(
+            "solarwinds_apm.inbound_metrics_processor.SolarWindsInboundMetricsSpanProcessor.calculate_custom_transaction_name"
+        )
+        mock_calculate_custom.configure_mock(return_value="foo")
+        mock_span = mocker.Mock()
+        mock_span.configure_mock(
+            **{
+                "attributes": {
+                    "http.url": "bar"
+                }
+            }
+        )
+        mock_get = mocker.Mock(return_value="not-used")
+        mock_apm_config = mocker.Mock()
+        mock_apm_config.configure_mock(
+            **{
+                "get": mock_get
+            }
+        )
+        processor = SolarWindsInboundMetricsSpanProcessor(
+            mocker.Mock(),
+            mock_apm_config,
+        )
+        result = processor.calculate_transaction_names(mock_span)
+        assert "foo", "bar" == result
+
     def test_calculate_transaction_names_no_custom_yes_config(self, mocker):
         mock_spanattributes = mocker.patch(
             "solarwinds_apm.inbound_metrics_processor.SpanAttributes"


### PR DESCRIPTION
Adds support for environment variable `SW_APM_TRANSACTION_NAME` or JSON config file `"transactionName"` to apply one custom name to all transactions. This is being introduced now for lambda instrumentation but is available outside of lambda too.

Precendence in decreasing order:
1. In-code call to existing `solarwinds_apm.api.set_transaction_name`
2. Environment variable `SW_APM_TRANSACTION_NAME` or config file KV
3. Then c-lib calculation of final txn name based on Otel span ingredients provided by language agent.

Tested manually with testbed [flask_apm_api_app](https://github.com/appoptics/solarwinds-apm-python-testbed/blob/main/flask_apm_api_app/app.py#L12). When the `set_transaction_name` call is commented out and `SW_APM_TRANSACTION_NAME` is set, the env var is used to name the transactions. When API call commented back in, the API's name is used.