### PR TITLE
NH-65932 Testrelease 0.18.0.X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.17.0...HEAD)
+## [Unreleased](https://github.com/solarwindscloud/solarwinds-apm-python/compare/rel-0.18.0...HEAD)
+
+## [0.18.0.16](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.18.0) - 2023-10-30
 
 ### Added
 - Add experimental configuration of OpenTelemetry metrics ([#200](https://github.com/solarwindscloud/solarwinds-apm-python/pull/200))
 - Add generation and OTLP export of `trace.service.response_time` metrics ([#201](https://github.com/solarwindscloud/solarwinds-apm-python/pull/201))
 - Add support for `SW_APM_TRANSACTION_NAME` ([#206](https://github.com/solarwindscloud/solarwinds-apm-python/pull/206))
+
+### Changed
+- Fixed test dependency for support of Flask < 3 ([#202](https://github.com/solarwindscloud/solarwinds-apm-python/pull/202))
+- Fixed EC2 runner publish actions ([#203](https://github.com/solarwindscloud/solarwinds-apm-python/pull/203))
+- Updated install test coverage for Debian 11 ([#204](https://github.com/solarwindscloud/solarwinds-apm-python/pull/204))
+- Updated Codeowners ([#205](https://github.com/solarwindscloud/solarwinds-apm-python/pull/205))
 
 ## [0.17.0](https://github.com/solarwindscloud/solarwinds-apm-python/releases/tag/rel-0.17.0) - 2023-09-20
 

--- a/solarwinds_apm/version.py
+++ b/solarwinds_apm/version.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 """Version of SolarWinds Custom-Distro for OpenTelemetry agents"""
-__version__ = "0.18.0.6"
+__version__ = "0.18.0.16"


### PR DESCRIPTION
Testrelease 0.18.0.16

Notes:
* Quite a few changes since 0.17.0 I forgot to add to Changelog, so added here
* Testrelease version is high because of several previous publishes used to lambda layer tests

tox tests pass on this PR.

Test traces, still with spaces in span names yay:
* [SWO Django](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/282E6A921A38B0792BC55D28990514C7/F8F5CC5153A62C5F/details/breakdown?perspective=requests&serviceId=e-1655756171056209920&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending)
* [SWO FastAPI](https://my.na-01.cloud.solarwinds.com/140638900734749696/traces/CADC48DA1D144830EFF7D7DE76C05E97/B6EEA8A984AEBE22/details/breakdown?perspective=requests&serviceId=e-1655757500269252608&sort_by_breakdown=spanLayer&sort_order_breakdown=ascending)
* [AO Django](https://my.appoptics.com/apm/123092/services/django-app-a-ot/traces/7CF445562EB5A2B283CE2244C127AC9800000000?duration=3600&search=django)
* [AO FastAPI](https://my.appoptics.com/apm/123092/services/asgi_app_ot/traces/EFF4D4B38420BC128E5EE84FA2B8D8C700000000?duration=3600&search=asgi)

Published to TestPyPI at: https://test.pypi.org/project/solarwinds-apm/0.18.0.16/#files

Install-from-TestPyPI tests: https://github.com/solarwindscloud/solarwinds-apm-python/actions/runs/6699082317