### PR TITLE
NH-102374 Docker scout scans consistency

### DIFF
--- a/.github/workflows/build_publish_image_autoinstrumentation.yaml
+++ b/.github/workflows/build_publish_image_autoinstrumentation.yaml
@@ -7,9 +7,6 @@
 name: "Publish APM Python Auto-Instrumentation"
 
 on:
-  push:
-    branches:
-      - NH-102374-update-scout-scans
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Docker scout scan results more consistent like APM Java. Splits image build with first `load=true`, and removes fs scan. See ticket comment for result.