### PR TITLE
Potential fix for code scanning alert no. 420: Unused import

### DIFF
--- a/tests/unit/test_oboe/test_oboe_sampler.py
+++ b/tests/unit/test_oboe/test_oboe_sampler.py
@@ -11,7 +11,7 @@ import logging
 import os
 import time
 from collections.abc import Sequence
-from unittest.mock import Mock
+
 
 import pytest
 from opentelemetry import trace


### PR DESCRIPTION
Potential fix for [https://github.com/solarwinds/apm-python/security/code-scanning/420](https://github.com/solarwinds/apm-python/security/code-scanning/420)

To fix the problem, we will remove the unused import statement `from unittest.mock import Mock` from line 14. This will eliminate the unnecessary dependency and improve code readability without altering the functionality of the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
