### PR TITLE
NH-117180 Fix PyPI publish scan destination and workflow job names

### DIFF
--- a/.github/workflows/build_publish_pypi_and_draft_release.yaml
+++ b/.github/workflows/build_publish_pypi_and_draft_release.yaml
@@ -35,41 +35,41 @@ jobs:
     # Outputs SW_APM_VERSION
     uses: ./.github/workflows/get_apm_python_version.yaml
 
-  build_sdist_and_x86_64:
-    name: Build sdist and x86_64
+  build_sdist_and_wheel:
+    name: Build sdist and wheel
     needs: get_apm_python_version
     # Outputs artifact-name
     uses: ./.github/workflows/build_sdist_and_wheel.yaml
     with:
       version: ${{ needs.get_apm_python_version.outputs.sw-apm-version }}
   
-  scan_sdist_and_x86_64:
+  scan_sdist_and_wheel:
     name: RL scan sdist and wheel
     needs:
       - get_apm_python_version
-      - build_sdist_and_x86_64
+      - build_sdist_and_wheel
     uses: ./.github/workflows/reversinglabs_scan.yaml
     with:
-      artifact-name: ${{ needs.build_sdist_and_x86_64.outputs.artifact-name }}
-      package-name: apm-python-pypi-sdist-x86_64
+      artifact-name: ${{ needs.build_sdist_and_wheel.outputs.artifact-name }}
+      package-name: apm-python-pypi-sdist-wheel
       version: ${{ needs.get_apm_python_version.outputs.sw-apm-version }}
       rl-submit-only: false
     secrets: inherit
 
-  publish_sdist_and_x86_64:
-    name: Publish sdist and x86_64 to PyPI
+  publish_sdist_and_wheel:
+    name: Publish sdist and wheel to PyPI
     needs:
-      - build_sdist_and_x86_64
-      - scan_sdist_and_x86_64
+      - build_sdist_and_wheel
+      - scan_sdist_and_wheel
     uses: ./.github/workflows/publish_sdist_and_wheel.yaml
     with:
-      artifact-name: ${{ needs.build_sdist_and_x86_64.outputs.artifact-name }}
+      artifact-name: ${{ needs.build_sdist_and_wheel.outputs.artifact-name }}
       repository-name: pypi
     secrets: inherit
 
   create_release:
     name: Create draft release
-    needs: publish_sdist_and_x86_64
+    needs: publish_sdist_and_wheel
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Fixes PyPI publish workflow so that

1. RL scan report destination is correct and same as TestPyPI
2. workflow job names better reflect publishes -- we stopped the x86/arm split with 4.0.0