### PR TITLE
NH-101930 Remove special warning of dropped export_logs_enabled config

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -87,7 +87,6 @@ class SolarWindsApmConfig:
             "service_key": "",
             "transaction_filters": [],
             "transaction_name": None,
-            "export_logs_enabled": False,
             "export_metrics_enabled": True,
             "log_filepath": "",
         }
@@ -680,8 +679,7 @@ class SolarWindsApmConfig:
                 self.__config[key] = val
             elif keys == ["transaction_name"]:
                 self.__config[key] = val
-            # TODO NH-101930 remove export_logs_enabled
-            elif keys in [["export_logs_enabled"], ["export_metrics_enabled"]]:
+            elif keys == ["export_metrics_enabled"]:
                 val = self.convert_to_bool(val)
                 if val not in (True, False):
                     raise ValueError

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -152,15 +152,6 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                 _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED, False
             )
         )
-        # TODO NH-101930 remove this check
-        sw_log_enabled = self.apm_config.get("export_logs_enabled")
-        if sw_log_enabled:
-            logger.warning(
-                "Support for SW_APM_EXPORT_LOG_ENABLED / exportLogsEnabled "
-                "has been dropped. Please update use "
-                "OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED instead."
-            )
-
         _init_logging(log_exporters, apm_resource, setup_logging_handler)
 
         # Set up additional custom SW components

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -52,9 +52,6 @@ class TestSolarWindsApmConfig:
         old_trustedpath = os.environ.get("SW_APM_TRUSTEDPATH", None)
         if old_trustedpath:
             del os.environ["SW_APM_TRUSTEDPATH"]
-        old_expt_logs = os.environ.get("SW_APM_EXPORT_LOGS_ENABLED", None)
-        if old_expt_logs:
-            del os.environ["SW_APM_EXPORT_LOGS_ENABLED"]
         old_expt_metrics = os.environ.get("SW_APM_EXPORT_METRICS_ENABLED", None)
         if old_expt_metrics:
             del os.environ["SW_APM_EXPORT_METRICS_ENABLED"]
@@ -75,8 +72,6 @@ class TestSolarWindsApmConfig:
             os.environ["SW_APM_COLLECTOR"] = old_collector
         if old_trustedpath:
             os.environ["SW_APM_TRUSTEDPATH"] = old_trustedpath
-        if old_expt_logs:
-            os.environ["SW_APM_EXPORT_LOGS_ENABLED"] = old_expt_logs
         if old_expt_metrics:
             os.environ["SW_APM_EXPORT_METRICS_ENABLED"] = old_expt_metrics
 
@@ -368,66 +363,6 @@ class TestSolarWindsApmConfig:
         test_config._set_config_value("debug_level", "not-valid-level")
         assert test_config.get("debug_level") == 2
         assert "Ignore config option" in caplog.text
-
-    def test_set_config_value_default_export_logs_enabled(
-        self,
-    ):
-        test_config = apm_config.SolarWindsApmConfig()
-        assert test_config.get("export_logs_enabled") == False
-
-    def test_set_config_value_ignore_export_logs_enabled(
-        self,
-        caplog,
-        setup_caplog,
-        mock_env_vars,
-    ):
-        test_config = apm_config.SolarWindsApmConfig()
-        test_config._set_config_value("export_logs_enabled", "not-valid")
-        assert test_config.get("export_logs_enabled") == False
-        assert "Ignore config option" in caplog.text
-    def test_set_config_value_set_export_logs_enabled_false(
-        self,
-        caplog,
-        setup_caplog,
-        mock_env_vars,
-    ):
-        test_config = apm_config.SolarWindsApmConfig()
-        test_config._set_config_value("export_logs_enabled", "false")
-        assert test_config.get("export_logs_enabled") == False
-        assert "Ignore config option" not in caplog.text
-
-    def test_set_config_value_set_export_logs_enabled_false_mixed_case(
-        self,
-        caplog,
-        setup_caplog,
-        mock_env_vars,
-    ):
-        test_config = apm_config.SolarWindsApmConfig()
-        test_config._set_config_value("export_logs_enabled", "fALsE")
-        assert test_config.get("export_logs_enabled") == False
-        assert "Ignore config option" not in caplog.text
-
-    def test_set_config_value_set_export_logs_enabled_true(
-        self,
-        caplog,
-        setup_caplog,
-        mock_env_vars,
-    ):
-        test_config = apm_config.SolarWindsApmConfig()
-        test_config._set_config_value("export_logs_enabled", "true")
-        assert test_config.get("export_logs_enabled") == True
-        assert "Ignore config option" not in caplog.text
-
-    def test_set_config_value_set_export_logs_enabled_true_mixed_case(
-        self,
-        caplog,
-        setup_caplog,
-        mock_env_vars,
-    ):
-        test_config = apm_config.SolarWindsApmConfig()
-        test_config._set_config_value("export_logs_enabled", "tRUe")
-        assert test_config.get("export_logs_enabled") == True
-        assert "Ignore config option" not in caplog.text
 
     def test_set_config_value_default_export_metrics_enabled(
         self,

--- a/tests/unit/test_apm_config/test_apm_config_cnf_file.py
+++ b/tests/unit/test_apm_config/test_apm_config_cnf_file.py
@@ -129,7 +129,6 @@ class TestSolarWindsApmConfigCnfFile:
         assert resulting_config.get("trigger_trace") == 1
         assert resulting_config.get("collector") == "foo-bar"
         assert resulting_config.get("debug_level") == 6
-        assert resulting_config.get("export_logs_enabled") == True
 
         # update_transaction_filters was called
         mock_update_txn_filters.assert_called_once_with(fixture_cnf_dict)
@@ -189,7 +188,6 @@ class TestSolarWindsApmConfigCnfFile:
         assert resulting_config.get("tracing_mode") == -1
         assert resulting_config.get("trigger_trace") == 1
         assert resulting_config.get("debug_level") == 2
-        assert resulting_config.get("export_logs_enabled") == False
         # Meanwhile these are pretty open
         assert resulting_config.get("collector") == "False"
 
@@ -217,7 +215,6 @@ class TestSolarWindsApmConfigCnfFile:
             "SW_APM_TRIGGER_TRACE": "disabled",
             "SW_APM_COLLECTOR": "other-foo-bar",
             "SW_APM_DEBUG_LEVEL": "5",
-            "SW_APM_EXPORT_LOGS_ENABLED": "true",
         })
         mock_update_txn_filters = mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.update_transaction_filters"
@@ -250,7 +247,6 @@ class TestSolarWindsApmConfigCnfFile:
         assert resulting_config.get("trigger_trace") == 0
         assert resulting_config.get("collector") == "other-foo-bar"
         assert resulting_config.get("debug_level") == 5
-        assert resulting_config.get("export_logs_enabled") == True
 
         # Restore old collector
         if old_collector:
@@ -274,7 +270,6 @@ class TestSolarWindsApmConfigCnfFile:
             "SW_APM_TRIGGER_TRACE": "other-foo-bar",
             "SW_APM_COLLECTOR": "False",
             "SW_APM_DEBUG_LEVEL": "other-foo-bar",
-            "SW_APM_EXPORT_LOGS_ENABLED": "not-a-bool",
         })
         mock_update_txn_filters = mocker.patch(
             "solarwinds_apm.apm_config.SolarWindsApmConfig.update_transaction_filters"
@@ -307,7 +302,6 @@ class TestSolarWindsApmConfigCnfFile:
         assert resulting_config.get("tracing_mode") == 1
         assert resulting_config.get("trigger_trace") == 1
         assert resulting_config.get("debug_level") == 6
-        assert resulting_config.get("export_logs_enabled") == True
 
         # These are still valid, so env_var > cnf_file
         assert resulting_config.get("collector") == "False"

--- a/tests/unit/test_configurator/conftest.py
+++ b/tests/unit/test_configurator/conftest.py
@@ -132,16 +132,11 @@ def get_apmconfig_mocks(
     mocker,
     enabled=True,
     is_lambda=False,
-    md_is_valid=True,
-    export_logs_enabled=True,
     export_metrics_enabled=True,
 ):
     def get_side_effect(param):
         if param == "export_metrics_enabled":
             return export_metrics_enabled
-        # TODO NH-101930 remove export_logs_enabled
-        elif param == "export_logs_enabled":
-            return export_logs_enabled
         elif param == "service_key":
             return "foo:bar"
         else:
@@ -179,16 +174,6 @@ def mock_apmconfig_enabled(mocker):
         )
     )
 
-@pytest.fixture(name="mock_apmconfig_enabled_export_logs_false")
-def mock_apmconfig_enabled_export_logs_false(mocker):
-    return mocker.patch(
-        "solarwinds_apm.configurator.SolarWindsApmConfig",
-        get_apmconfig_mocks(
-            mocker,
-            export_logs_enabled=False
-        )
-    )
-
 @pytest.fixture(name="mock_apmconfig_enabled_md_invalid")
 def mock_apmconfig_enabled_md_invalid(mocker):
     return mocker.patch(
@@ -206,26 +191,6 @@ def mock_apmconfig_enabled_is_lambda(mocker):
         get_apmconfig_mocks(
             mocker,
             is_lambda=True,
-        )
-    )
-
-@pytest.fixture(name="mock_apmconfig_logs_enabled_false")
-def mock_apmconfig_logs_enabled_false(mocker):
-    return mocker.patch(
-        "solarwinds_apm.configurator.SolarWindsApmConfig",
-        get_apmconfig_mocks(
-            mocker,
-            export_logs_enabled=False
-        )
-    )
-
-@pytest.fixture(name="mock_apmconfig_logs_enabled_none")
-def mock_apmconfig_logs_enabled_none(mocker):
-    return mocker.patch(
-        "solarwinds_apm.configurator.SolarWindsApmConfig",
-        get_apmconfig_mocks(
-            mocker,
-            export_logs_enabled=None
         )
     )
 

--- a/tests/unit/test_configurator/test_configurator_configure_otel.py
+++ b/tests/unit/test_configurator/test_configurator_configure_otel.py
@@ -162,12 +162,10 @@ class TestConfiguratorConfigureOtelComponents:
         mock_config_propagator.assert_called_once()
         mock_config_response_propagator.assert_called_once()
 
-    def test_configure_otel_components_logs_enabled_true_by_otel_sw_default(
+    def test_configure_otel_components_logs_enabled_true(
         self,
-        caplog,
-        setup_caplog,
         mocker,
-        mock_apmconfig_enabled_export_logs_false,
+        mock_apmconfig_enabled,
 
         mock_config_serviceentry_processor,
         mock_custom_init_tracing,
@@ -178,7 +176,7 @@ class TestConfiguratorConfigureOtelComponents:
     ):
         self.helper_test_configure_otel_components_logs_enabled(
             mocker,
-            mock_apmconfig_enabled_export_logs_false,
+            mock_apmconfig_enabled,
             mock_config_serviceentry_processor,
             mock_custom_init_tracing,
             mock_custom_init_metrics,
@@ -189,38 +187,8 @@ class TestConfiguratorConfigureOtelComponents:
             True,  # True because OTEL log instrumentation set to true
             True,
         )
-        assert "Support for SW_APM_EXPORT_LOG_ENABLED / exportLogsEnabled has been dropped" not in caplog.text
 
-    def test_configure_otel_components_logs_enabled_otel_none_sw_default(self,
-        mocker,
-        caplog,
-        setup_caplog,
-        mock_apmconfig_enabled_export_logs_false,
-
-        mock_config_serviceentry_processor,
-        mock_custom_init_tracing,
-        mock_custom_init_metrics,
-        mock_init_logging,
-        mock_config_propagator,
-        mock_config_response_propagator,
-    ):
-        self.helper_test_configure_otel_components_logs_enabled(
-            mocker,
-            mock_apmconfig_enabled_export_logs_false,
-            mock_config_serviceentry_processor,
-            mock_custom_init_tracing,
-            mock_custom_init_metrics,
-            mock_init_logging,
-            mock_config_propagator,
-            mock_config_response_propagator,
-            "",
-            None,  # none because OTEL log instrumentation not set
-        )
-        assert "Support for SW_APM_EXPORT_LOG_ENABLED / exportLogsEnabled has been dropped" not in caplog.text
-
-    def test_configure_otel_components_logs_enabled_otel_none_sw_true(self,
-        caplog,
-        setup_caplog,
+    def test_configure_otel_components_logs_enabled_none(self,
         mocker,
         mock_apmconfig_enabled,
 
@@ -243,13 +211,10 @@ class TestConfiguratorConfigureOtelComponents:
             "",
             None,  # none because OTEL log instrumentation not set
         )
-        assert "Support for SW_APM_EXPORT_LOG_ENABLED / exportLogsEnabled has been dropped" in caplog.text
 
-    def test_configure_otel_components_logs_enabled_otel_false_sw_default(self,
+    def test_configure_otel_components_logs_enabled_otel_false(self,
         mocker,
-        caplog,
-        setup_caplog,
-        mock_apmconfig_enabled_export_logs_false,
+        mock_apmconfig_enabled,
 
         mock_config_serviceentry_processor,
         mock_custom_init_tracing,
@@ -260,7 +225,7 @@ class TestConfiguratorConfigureOtelComponents:
     ):
         self.helper_test_configure_otel_components_logs_enabled(
             mocker,
-            mock_apmconfig_enabled_export_logs_false,
+            mock_apmconfig_enabled,
             mock_config_serviceentry_processor,
             mock_custom_init_tracing,
             mock_custom_init_metrics,
@@ -271,11 +236,8 @@ class TestConfiguratorConfigureOtelComponents:
             False,  # False because OTEL log instrumentation False
             False,
         )
-        assert "Support for SW_APM_EXPORT_LOG_ENABLED / exportLogsEnabled has been dropped" not in caplog.text
 
-    def test_configure_otel_components_logs_enabled_otel_false_sw_true(self,
-        caplog,
-        setup_caplog,
+    def test_configure_otel_components_logs_enabled_otel_invalid(self,
         mocker,
         mock_apmconfig_enabled,
 
@@ -295,38 +257,9 @@ class TestConfiguratorConfigureOtelComponents:
             mock_init_logging,
             mock_config_propagator,
             mock_config_response_propagator,
-            "false",
-            False,  # should be false because OTEL explicitly false, even if SW true
-            False,
-        )
-        assert "Support for SW_APM_EXPORT_LOG_ENABLED / exportLogsEnabled has been dropped" in caplog.text
-
-    def test_configure_otel_components_logs_enabled_otel_invalid(self,
-        mocker,
-        caplog,
-        setup_caplog,
-        mock_apmconfig_enabled_export_logs_false,
-
-        mock_config_serviceentry_processor,
-        mock_custom_init_tracing,
-        mock_custom_init_metrics,
-        mock_init_logging,
-        mock_config_propagator,
-        mock_config_response_propagator,
-    ):
-        self.helper_test_configure_otel_components_logs_enabled(
-            mocker,
-            mock_apmconfig_enabled_export_logs_false,
-            mock_config_serviceentry_processor,
-            mock_custom_init_tracing,
-            mock_custom_init_metrics,
-            mock_init_logging,
-            mock_config_propagator,
-            mock_config_response_propagator,
             "not-a-bool-string",
             None,  # None because OTEL log instrumentation not valid bool
         )
-        assert "Support for SW_APM_EXPORT_LOG_ENABLED / exportLogsEnabled has been dropped" not in caplog.text
 
     def test_configure_otel_components_agent_enabled(
         self,


### PR DESCRIPTION
As suggested in https://github.com/solarwinds/apm-python/pull/688, we remove the special warning that we were initially going to release about a dropped configuration, `SW_APM_EXPORT_LOGS_ENABLED`. So now we don't warn, and it's a breaking change that will go out with version 5.0.0 release.