### PR TITLE
Add optional dependencies for GenAI instrumentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,15 @@ dependencies = [
     'opentelemetry-resource-detector-containerid == 0.59b0',
 ]
 
+[project.optional-dependencies]
+llm = [
+  "opentelemetry-instrumentation-google-genai ~= 0.4b0",
+  "opentelemetry-instrumentation-langchain ~= 0.48.1",
+  "opentelemetry-instrumentation-openai-agents-v2 ~= 0.1.0",
+  "opentelemetry-instrumentation-openai-v2 ~= 2.2b0",
+  "opentelemetry-instrumentation-weaviate ~= 0.49.0"
+]
+
 [project.urls]
 Homepage = "https://www.solarwinds.com/solarwinds-observability/use-cases/python-performance-monitoring"
 Download = "https://pypi.org/project/solarwinds-apm/"


### PR DESCRIPTION
This pull request adds GenAI dependencies as optional packages, enabling the collection of traces, logs, and metrics for LLM model usage when they are imported. The current implementation supports Google GenAI, LangChain, OpenAI (agents and v2), and Weaviate. This allows users to easily install additional packages for tracing and monitoring LLM frameworks and services. The changes were carried out as part of Brno Accelerate Tech Days 2025.