### PR TITLE
try-except more things

### DIFF
--- a/solarwinds_apm/apm_logging.py
+++ b/solarwinds_apm/apm_logging.py
@@ -148,7 +148,13 @@ def _get_logger() -> logging.Logger:
             )
             _logger.warning("")
         else:
-            log_level = int(envv_val)
+            try:
+                log_level = int(envv_val)
+            except (ValueError, TypeError) as exc:
+                _logger.warning(
+                    "Failed to parse SW_APM_DEBUG_LEVEL, using default: %s",
+                    exc,
+                )
 
     _logger.setLevel(ApmLoggingLevel.logging_map[log_level])
 

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -122,7 +122,11 @@ class SolarWindsDistro(BaseDistro):
             logger.debug("Missing service key")
             return None
         # Key must be at least one char + ":" + at least one other char
-        key_parts = [p for p in service_key.split(":") if len(p) > 0]
+        try:
+            key_parts = [p for p in service_key.split(":") if len(p) > 0]
+        except AttributeError:
+            logger.debug("Invalid service key format")
+            return None
         if len(key_parts) != 2:
             logger.debug("Incorrect service key format")
             return None

--- a/solarwinds_apm/oboe/http_sampler.py
+++ b/solarwinds_apm/oboe/http_sampler.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import socket
 import threading
@@ -65,7 +66,13 @@ class HttpSampler(Sampler):
             self._url = f"https://{self._url}"
         self._service = config.service
         self._headers = config.headers
-        self._hostname = socket.gethostname()
+        try:
+            self._hostname = socket.gethostname()
+        except OSError as exc:
+            logger.warning(
+                "Failed to get hostname, using 'localhost': %s", exc
+            )
+            self._hostname = "localhost"
         self._last_warning_message = None
         self._shutdown_event = threading.Event()
         self._daemon_thread = threading.Thread(
@@ -152,4 +159,10 @@ class HttpSampler(Sampler):
         detach(token)
         response.raise_for_status()
         logger.debug("received sampling settings response %s", response.text)
-        return response.json()
+        try:
+            return response.json()
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                "Failed to parse JSON response from sampling settings: %s", exc
+            )
+            return {}

--- a/solarwinds_apm/oboe/http_sampler.py
+++ b/solarwinds_apm/oboe/http_sampler.py
@@ -161,7 +161,7 @@ class HttpSampler(Sampler):
         logger.debug("received sampling settings response %s", response.text)
         try:
             return response.json()
-        except json.JSONDecodeError as exc:
+        except (ValueError, json.JSONDecodeError) as exc:
             logger.warning(
                 "Failed to parse JSON response from sampling settings: %s", exc
             )

--- a/solarwinds_apm/oboe/http_sampler.py
+++ b/solarwinds_apm/oboe/http_sampler.py
@@ -8,7 +8,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import socket
 import threading
@@ -161,7 +160,7 @@ class HttpSampler(Sampler):
         logger.debug("received sampling settings response %s", response.text)
         try:
             return response.json()
-        except (ValueError, json.JSONDecodeError) as exc:
+        except ValueError as exc:
             logger.warning(
                 "Failed to parse JSON response from sampling settings: %s", exc
             )

--- a/solarwinds_apm/oboe/json_sampler.py
+++ b/solarwinds_apm/oboe/json_sampler.py
@@ -121,12 +121,4 @@ class JsonSampler(Sampler):
         """
         with open(self._path, encoding="utf-8") as file:
             contents = file.read()
-        try:
-            return json.loads(contents)
-        except json.JSONDecodeError as exc:
-            logger.warning(
-                "Failed to parse JSON from settings file %s: %s",
-                self._path,
-                exc,
-            )
-            raise
+        return json.loads(contents)

--- a/solarwinds_apm/oboe/json_sampler.py
+++ b/solarwinds_apm/oboe/json_sampler.py
@@ -121,4 +121,12 @@ class JsonSampler(Sampler):
         """
         with open(self._path, encoding="utf-8") as file:
             contents = file.read()
-        return json.loads(contents)
+        try:
+            return json.loads(contents)
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                "Failed to parse JSON from settings file %s: %s",
+                self._path,
+                exc,
+            )
+            raise

--- a/solarwinds_apm/oboe/oboe_sampler.py
+++ b/solarwinds_apm/oboe/oboe_sampler.py
@@ -449,7 +449,14 @@ class OboeSampler(Sampler, ABC):
 
         if s.settings and s.settings.flags & Flags.SAMPLE_THROUGH_ALWAYS:
             logger.debug("SAMPLE_THROUGH_ALWAYS is set; parent-based sampling")
-            flags = int(s.trace_state[-2:], 16)
+            try:
+                flags = int(s.trace_state[-2:], 16)
+            except (ValueError, IndexError, TypeError) as exc:
+                logger.warning(
+                    "Failed to parse trace flags from trace_state; record only: %s",
+                    exc,
+                )
+                return Decision.RECORD_ONLY
             if flags & TraceFlags.SAMPLED:
                 logger.debug("parent is sampled; record and sample")
                 self.counters.trace_count.add(1, {}, parent_context)

--- a/solarwinds_apm/oboe/sampler.py
+++ b/solarwinds_apm/oboe/sampler.py
@@ -70,11 +70,14 @@ def http_span_metadata(kind: SpanKind, attributes: Attributes):
     method = str(
         attributes.get(HTTP_METHOD, attributes.get(HTTP_REQUEST_METHOD, ""))
     )
-    status = int(
-        attributes.get(
-            HTTP_RESPONSE_STATUS_CODE, attributes.get(HTTP_STATUS_CODE, 0)
+    try:
+        status = int(
+            attributes.get(
+                HTTP_RESPONSE_STATUS_CODE, attributes.get(HTTP_STATUS_CODE, 0)
+            )
         )
-    )
+    except (ValueError, TypeError):
+        status = 0
     scheme = str(
         attributes.get(URL_SCHEME, attributes.get(HTTP_SCHEME, "http"))
     )

--- a/solarwinds_apm/oboe/trace_options.py
+++ b/solarwinds_apm/oboe/trace_options.py
@@ -376,9 +376,15 @@ def validate_signature(header, signature, key, timestamp):
         return Auth.NO_SIGNATURE_KEY
     if timestamp is None or abs(int(time.time()) - timestamp) > 5 * 60:
         return Auth.BAD_TIMESTAMP
-    digest = hmac.new(
-        str.encode(key), str.encode(header), hashlib.sha1
-    ).hexdigest()
+    try:
+        digest = hmac.new(
+            str.encode(key), str.encode(header), hashlib.sha1
+        ).hexdigest()
+    except (AttributeError, TypeError) as exc:
+        logger.warning(
+            "Failed to encode key or header for signature validation: %s", exc
+        )
+        return Auth.BAD_SIGNATURE
     if signature == digest:
         return Auth.OK
     return Auth.BAD_SIGNATURE

--- a/solarwinds_apm/traceoptions.py
+++ b/solarwinds_apm/traceoptions.py
@@ -61,6 +61,8 @@ class XTraceOptions:
                 traceoptions = re.split(r";+", xtraceoptions_header)
             except (TypeError, AttributeError) as exc:
                 logger.debug("Failed to parse x-trace-options header: %s", exc)
+                self.options_header = ""
+                self.include_response = False
                 return
             for option in traceoptions:
                 # KVs (e.g. sw-keys or custom-key1) are assigned by equals

--- a/solarwinds_apm/traceoptions.py
+++ b/solarwinds_apm/traceoptions.py
@@ -57,7 +57,11 @@ class XTraceOptions:
             # If x-trace-options header given, set response header
             self.include_response = True
 
-            traceoptions = re.split(r";+", xtraceoptions_header)
+            try:
+                traceoptions = re.split(r";+", xtraceoptions_header)
+            except (TypeError, AttributeError) as exc:
+                logger.debug("Failed to parse x-trace-options header: %s", exc)
+                return
             for option in traceoptions:
                 # KVs (e.g. sw-keys or custom-key1) are assigned by equals
                 option_kv = option.split("=", 1)
@@ -106,7 +110,7 @@ class XTraceOptions:
                     try:
                         if not self.timestamp:
                             self.timestamp = int(option_kv[1])
-                    except ValueError:
+                    except (ValueError, IndexError):
                         logger.debug("ts must be base 10 int. Ignoring.")
                         self.ignored.append(self._XTRACEOPTIONS_HEADER_KEY_TS)
 

--- a/solarwinds_apm/w3c_transformer.py
+++ b/solarwinds_apm/w3c_transformer.py
@@ -45,7 +45,10 @@ class W3CTransformer:
         Returns:
         str: The span ID portion of the sw value.
         """
-        return sw_val.split("-")[0]
+        try:
+            return sw_val.split("-")[0]
+        except (AttributeError, IndexError):
+            return ""
 
     @classmethod
     def trace_flags_from_int(cls, trace_flags: int) -> str:

--- a/solarwinds_apm/w3c_transformer.py
+++ b/solarwinds_apm/w3c_transformer.py
@@ -7,7 +7,7 @@
 """Provides functionality to transform OpenTelemetry Data to SolarWinds Observability data."""
 
 from opentelemetry.sdk.trace import SpanContext
-from opentelemetry.trace.span import TraceState
+from opentelemetry.trace.span import INVALID_SPAN_ID, TraceState
 
 from solarwinds_apm.apm_constants import INTL_SWO_X_OPTIONS_RESPONSE_KEY
 
@@ -43,12 +43,13 @@ class W3CTransformer:
         sw_val (str): The sw tracestate value (format: "<span_id>-<flags>").
 
         Returns:
-        str: The span ID portion of the sw value.
+        str: The span ID portion of the sw value, or all-zero fallback when
+             input is not parseable.
         """
         try:
             return sw_val.split("-")[0]
-        except (AttributeError, IndexError):
-            return ""
+        except (AttributeError, TypeError):
+            return cls._SPAN_ID_HEX.format(INVALID_SPAN_ID)
 
     @classmethod
     def trace_flags_from_int(cls, trace_flags: int) -> str:

--- a/tests/unit/test_oboe/test_http_sampler.py
+++ b/tests/unit/test_oboe/test_http_sampler.py
@@ -3,6 +3,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+import json
 import os
 import socket
 from unittest.mock import patch, MagicMock
@@ -187,6 +188,34 @@ def test_fetch_from_collector_success(mock_get, config, meter_provider):
         timeout=10)
     # one in constructor and one in test case
     assert mock_get.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "json_error",
+    [
+        ValueError("invalid json"),
+        json.JSONDecodeError("invalid json", "", 0),
+    ],
+)
+@patch("requests.get")
+def test_fetch_from_collector_invalid_json_returns_empty_dict_and_thread_survives(
+    mock_get, config, meter_provider, json_error
+):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.side_effect = json_error
+    mock_get.return_value = mock_response
+
+    sampler = HttpSampler(meter_provider=meter_provider, config=config, initial=None)
+    try:
+        result = sampler._fetch_from_collector()
+        assert result == {}
+
+        # Verify parse failures in periodic work do not terminate the daemon thread.
+        sampler._task()
+        assert sampler._daemon_thread.is_alive()
+    finally:
+        sampler.shutdown()
 
 
 def test_shutdown(config, meter_provider):

--- a/tests/unit/test_w3c_transformer.py
+++ b/tests/unit/test_w3c_transformer.py
@@ -32,7 +32,7 @@ class TestW3CTransformer():
         assert W3CTransformer.span_id_from_sw("foo-bar") == "foo"
 
     def test_span_id_from_sw_invalid_type_returns_zero_fallback(self):
-        assert W3CTransformer.span_id_from_sw(None) == "{:016x}".format(0000000000000000)
+        assert W3CTransformer.span_id_from_sw(None) == "{:016x}".format(0)
 
     def test_trace_flags_from_int(self):
         assert W3CTransformer.trace_flags_from_int(1) == "01"

--- a/tests/unit/test_w3c_transformer.py
+++ b/tests/unit/test_w3c_transformer.py
@@ -31,6 +31,9 @@ class TestW3CTransformer():
     def test_span_id_from_sw(self):
         assert W3CTransformer.span_id_from_sw("foo-bar") == "foo"
 
+    def test_span_id_from_sw_invalid_type_returns_zero_fallback(self):
+        assert W3CTransformer.span_id_from_sw(None) == "{:016x}".format(0000000000000000)
+
     def test_trace_flags_from_int(self):
         assert W3CTransformer.trace_flags_from_int(1) == "01"
 

--- a/tests/unit/test_xtraceoptions.py
+++ b/tests/unit/test_xtraceoptions.py
@@ -44,6 +44,17 @@ class TestXTraceOptions():
         assert xto.timestamp == 0
         assert not xto.include_response
 
+    def test_init_invalid_non_string_header_treated_as_absent(self):
+        xto = XTraceOptions(123, "bar")
+        assert xto.ignored == []
+        assert xto.options_header == ""
+        assert xto.signature == "bar"
+        assert xto.custom_kvs == {}
+        assert xto.sw_keys == ""
+        assert xto.trigger_trace == 0
+        assert xto.timestamp == 0
+        assert not xto.include_response
+
     def test_init_xtraceoption_and_signature(self):
         xto = XTraceOptions("foo", "bar")
         assert xto.ignored == ["foo"]


### PR DESCRIPTION
Adds more exception handling to prevent distro crashing instrumented app, even if theoretical. Logs warning or debug, depending on similar existing logs. Adds a bit of test coverage.

**What do you think of this?:** I'm keeping the `raise` in JsonSampler (restored in [fcfb05c](https://github.com/solarwinds/apm-python/pull/756/commits/fcfb05c463cb400460537554c4ccb2d75f42f4c1)) because something is very wrong with the environment. Or, we can log an `error` once and return `[]`.

Will be doing an apm_config update in a separate PR because that needs some extra test coverage: https://github.com/solarwinds/apm-python/pull/757