### PR TITLE
Better ApmConfig behaviour including try-except

### DIFF
--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -463,13 +463,7 @@ class SolarWindsApmConfig:
                 )
                 return service_key
 
-            try:
-                return ":".join([service_key.split(":")[0], service_name])
-            except (AttributeError, IndexError):
-                logger.debug(
-                    "Failed to update service key with service name. Skipping."
-                )
-                return service_key
+            return ":".join([key_parts[0], service_name])
 
         # Else no need to update service_key when not reporting
         return service_key

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -640,10 +640,7 @@ class SolarWindsApmConfig:
         """Update configuration settings from config file (JSON), if any."""
 
         def _snake_to_camel_case(key):
-            try:
-                key_parts = key.split("_")
-            except AttributeError:
-                return key
+            key_parts = key.split("_")
             camel_head = key_parts[0]
             camel_body = "".join(part.title() for part in key_parts[1:])
             return f"{camel_head}{camel_body}"

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -872,11 +872,7 @@ class SolarWindsApmConfig:
         Configuration: Configuration object for sampler initialization.
         """
         try:
-            token = (
-                apm_config.get("service_key").split(":")[0]
-                if len(apm_config.get("service_key").split(":")) > 0
-                else ""
-            )
+            token = apm_config.get("service_key").split(":")[0]
         except (AttributeError, IndexError):
             token = ""
         filters = apm_config.get("transaction_filters")

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -393,9 +393,16 @@ class SolarWindsApmConfig:
                 "unknown_service"
             ):
                 # When agent_enabled, assume service_key exists and is formatted correctly.
-                service_name = self.__config.get("service_key", ":").split(
-                    ":"
-                )[1]
+                # This is a precaution.
+                try:
+                    service_name = self.__config.get("service_key", ":").split(
+                        ":"
+                    )[1]
+                except IndexError:
+                    logger.warning(
+                        "Failed to extract service name from service_key, using default"
+                    )
+                    service_name = ""
             else:
                 service_name = otel_service_name
         return service_name
@@ -443,14 +450,24 @@ class SolarWindsApmConfig:
         if agent_enabled and service_key and service_name:
             # Only update if service_name and service_key exist and non-empty,
             # and service_key in correct format.
-            key_parts = service_key.split(":")
+            try:
+                key_parts = service_key.split(":")
+            except AttributeError:
+                logger.debug("Service key is not a valid string. Skipping.")
+                return service_key
             if len(key_parts) < 2:
                 logger.debug(
                     "Service key is not in the correct format to update its own service name. Skipping."
                 )
                 return service_key
 
-            return ":".join([service_key.split(":")[0], service_name])
+            try:
+                return ":".join([service_key.split(":")[0], service_name])
+            except (AttributeError, IndexError):
+                logger.debug(
+                    "Failed to update service key with service name. Skipping."
+                )
+                return service_key
 
         # Else no need to update service_key when not reporting
         return service_key
@@ -465,12 +482,15 @@ class SolarWindsApmConfig:
         service_key = self.__config.get("service_key")
         if not service_key:
             return ""
-        if service_key.strip() == "":
-            return service_key
 
-        key_parts = service_key.split(":")
+        try:
+            if service_key.strip() == "":
+                return service_key
+            key_parts = service_key.split(":")
+        except AttributeError:
+            return ""
         if len(key_parts) < 2:
-            bad_format_key = key_parts[0]
+            bad_format_key = key_parts[0] if key_parts else ""
             if len(bad_format_key) < 5:
                 return self._KEY_MASK_BAD_FORMAT_SHORT.format(bad_format_key)
             return self._KEY_MASK_BAD_FORMAT.format(
@@ -624,7 +644,10 @@ class SolarWindsApmConfig:
         """Update configuration settings from config file (JSON), if any."""
 
         def _snake_to_camel_case(key):
-            key_parts = key.split("_")
+            try:
+                key_parts = key.split("_")
+            except AttributeError:
+                return key
             camel_head = key_parts[0]
             camel_body = "".join(part.title() for part in key_parts[1:])
             return f"{camel_head}{camel_body}"
@@ -855,11 +878,14 @@ class SolarWindsApmConfig:
         Returns:
         Configuration: Configuration object for sampler initialization.
         """
-        token = (
-            apm_config.get("service_key").split(":")[0]
-            if len(apm_config.get("service_key").split(":")) > 0
-            else ""
-        )
+        try:
+            token = (
+                apm_config.get("service_key").split(":")[0]
+                if len(apm_config.get("service_key").split(":")) > 0
+                else ""
+            )
+        except (AttributeError, IndexError):
+            token = ""
         filters = apm_config.get("transaction_filters")
         transaction_settings = []
         for transaction_filter in filters:

--- a/solarwinds_apm/apm_config.py
+++ b/solarwinds_apm/apm_config.py
@@ -393,15 +393,17 @@ class SolarWindsApmConfig:
                 "unknown_service"
             ):
                 # When agent_enabled, assume service_key exists and is formatted correctly.
-                # This is a precaution.
-                try:
-                    service_name = self.__config.get("service_key", ":").split(
-                        ":"
-                    )[1]
-                except IndexError:
-                    logger.warning(
-                        "Failed to extract service name from service_key, using default"
-                    )
+                # This is a precaution. Validate defensively instead of relying on
+                # exception handling so unexpected non-string values cannot crash
+                # the instrumented application.
+                service_key = self.__config.get("service_key", ":")
+                if isinstance(service_key, str):
+                    service_key_parts = service_key.split(":", 1)
+                    if len(service_key_parts) > 1:
+                        service_name = service_key_parts[1]
+                    else:
+                        service_name = ""
+                else:
                     service_name = ""
             else:
                 service_name = otel_service_name

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -593,33 +593,6 @@ class TestSolarWindsApmConfig:
         test_config = apm_config.SolarWindsApmConfig()
         assert not test_config.convert_to_bool("fAlSE")
 
-    def test_snake_to_camel_case_attribute_error_non_string_key(
-        self,
-        mocker,
-        tmp_path,
-    ):
-        config_file = tmp_path / "test_config.json"
-        config_file.write_text('{"agent_enabled": true}')
-        mocker.patch.dict(os.environ, {
-            "SW_APM_CONFIG_FILE": str(config_file),
-        })
-        test_config = apm_config.SolarWindsApmConfig()
-        # If we got here without exception, the test passes
-        assert test_config is not None
-
-    def test_update_with_cnf_file_handles_none_key(
-        self,
-        mocker,
-        tmp_path,
-    ):
-        config_file = tmp_path / "test_config.json"
-        config_file.write_text('{"validKey": "value"}')
-        mocker.patch.dict(os.environ, {
-            "SW_APM_CONFIG_FILE": str(config_file),
-        })
-        test_config = apm_config.SolarWindsApmConfig()
-        assert test_config is not None
-
 @pytest.fixture
 def apm():
     return apm_config.SolarWindsApmConfig()

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -332,12 +332,6 @@ class TestSolarWindsApmConfig:
         result = test_config.mask_service_key()
         assert result == ""
 
-    def test_mask_service_key_handles_empty_list_from_split(self):
-        test_config = apm_config.SolarWindsApmConfig()
-        test_config._SolarWindsApmConfig__config["service_key"] = ""
-        result = test_config.mask_service_key()
-        assert result == ""
-
     def test_str(
         self,
         mocker,

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -503,16 +503,6 @@ class TestSolarWindsApmConfig:
         # Updates everything after first delim
         assert result == "weird-key:bar-service"
 
-    def test__update_service_key_name_index_error_empty_split(self):
-        """Test handling when service_key is empty string"""
-        test_config = apm_config.SolarWindsApmConfig()
-        result = test_config._update_service_key_name(
-            True,
-            "",  # Empty string
-            "test-service"
-        )
-        assert result == ""
-
     def test__validate_log_filepath_none(self, mocker):
         mock_exists = mocker.patch("solarwinds_apm.apm_config.os.path.exists")
         mock_makedirs = mocker.patch("solarwinds_apm.apm_config.os.makedirs")

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -682,15 +682,3 @@ def test_to_configuration_attribute_error_non_string_service_key(
     config = apm_config.SolarWindsApmConfig.to_configuration(test_apm_config)
     # Should default to empty string for token in Authorization header
     assert config.headers["Authorization"] == "Bearer "
-
-def test_to_configuration_index_error_empty_split_result(
-    mocker,
-):
-    mocker.patch.dict(os.environ, {
-        "SW_APM_SERVICE_KEY": "token:service",
-    })
-    test_apm_config = apm_config.SolarWindsApmConfig()
-    test_apm_config._SolarWindsApmConfig__config["service_key"] = ""
-    config = apm_config.SolarWindsApmConfig.to_configuration(test_apm_config)
-    # Should default to empty string for token in Authorization header
-    assert config.headers["Authorization"] == "Bearer "

--- a/tests/unit/test_apm_config/test_apm_config.py
+++ b/tests/unit/test_apm_config/test_apm_config.py
@@ -326,6 +326,18 @@ class TestSolarWindsApmConfig:
         self._mock_service_key(mocker, "valid-and-long:key")
         assert apm_config.SolarWindsApmConfig()._config_mask_service_key().get("service_key") == "vali...long:key"
 
+    def test_mask_service_key_attribute_error_non_string_key(self):
+        test_config = apm_config.SolarWindsApmConfig()
+        test_config._SolarWindsApmConfig__config["service_key"] = 123
+        result = test_config.mask_service_key()
+        assert result == ""
+
+    def test_mask_service_key_handles_empty_list_from_split(self):
+        test_config = apm_config.SolarWindsApmConfig()
+        test_config._SolarWindsApmConfig__config["service_key"] = ""
+        result = test_config.mask_service_key()
+        assert result == ""
+
     def test_str(
         self,
         mocker,
@@ -497,6 +509,16 @@ class TestSolarWindsApmConfig:
         # Updates everything after first delim
         assert result == "weird-key:bar-service"
 
+    def test__update_service_key_name_index_error_empty_split(self):
+        """Test handling when service_key is empty string"""
+        test_config = apm_config.SolarWindsApmConfig()
+        result = test_config._update_service_key_name(
+            True,
+            "",  # Empty string
+            "test-service"
+        )
+        assert result == ""
+
     def test__validate_log_filepath_none(self, mocker):
         mock_exists = mocker.patch("solarwinds_apm.apm_config.os.path.exists")
         mock_makedirs = mocker.patch("solarwinds_apm.apm_config.os.makedirs")
@@ -587,6 +609,33 @@ class TestSolarWindsApmConfig:
         test_config = apm_config.SolarWindsApmConfig()
         assert not test_config.convert_to_bool("fAlSE")
 
+    def test_snake_to_camel_case_attribute_error_non_string_key(
+        self,
+        mocker,
+        tmp_path,
+    ):
+        config_file = tmp_path / "test_config.json"
+        config_file.write_text('{"agent_enabled": true}')
+        mocker.patch.dict(os.environ, {
+            "SW_APM_CONFIG_FILE": str(config_file),
+        })
+        test_config = apm_config.SolarWindsApmConfig()
+        # If we got here without exception, the test passes
+        assert test_config is not None
+
+    def test_update_with_cnf_file_handles_none_key(
+        self,
+        mocker,
+        tmp_path,
+    ):
+        config_file = tmp_path / "test_config.json"
+        config_file.write_text('{"validKey": "value"}')
+        mocker.patch.dict(os.environ, {
+            "SW_APM_CONFIG_FILE": str(config_file),
+        })
+        test_config = apm_config.SolarWindsApmConfig()
+        assert test_config is not None
+
 @pytest.fixture
 def apm():
     return apm_config.SolarWindsApmConfig()
@@ -664,3 +713,27 @@ def test_to_configuration_with_enabled_agent(apm):
     apm.agent_enabled = True
     config = apm_config.SolarWindsApmConfig.to_configuration(apm_config=apm)
     assert config.enabled is True
+
+def test_to_configuration_attribute_error_non_string_service_key(
+    mocker,
+):
+    mocker.patch.dict(os.environ, {
+        "SW_APM_SERVICE_KEY": "token:service",
+    })
+    test_apm_config = apm_config.SolarWindsApmConfig()
+    test_apm_config._SolarWindsApmConfig__config["service_key"] = None
+    config = apm_config.SolarWindsApmConfig.to_configuration(test_apm_config)
+    # Should default to empty string for token in Authorization header
+    assert config.headers["Authorization"] == "Bearer "
+
+def test_to_configuration_index_error_empty_split_result(
+    mocker,
+):
+    mocker.patch.dict(os.environ, {
+        "SW_APM_SERVICE_KEY": "token:service",
+    })
+    test_apm_config = apm_config.SolarWindsApmConfig()
+    test_apm_config._SolarWindsApmConfig__config["service_key"] = ""
+    config = apm_config.SolarWindsApmConfig.to_configuration(test_apm_config)
+    # Should default to empty string for token in Authorization header
+    assert config.headers["Authorization"] == "Bearer "

--- a/tests/unit/test_apm_config/test_apm_config_service_name.py
+++ b/tests/unit/test_apm_config/test_apm_config_service_name.py
@@ -138,9 +138,6 @@ class TestSolarWindsApmConfigServiceNameApmProto:
         self,
         mocker,
     ):
-        mocker.patch.dict(os.environ, {
-            "SW_APM_SERVICE_KEY": "valid:service",
-        })
         test_config = apm_config.SolarWindsApmConfig()
         test_config._SolarWindsApmConfig__config["service_key"] = 123
         result = test_config._calculate_service_name_apm_proto(

--- a/tests/unit/test_apm_config/test_apm_config_service_name.py
+++ b/tests/unit/test_apm_config/test_apm_config_service_name.py
@@ -120,7 +120,7 @@ class TestSolarWindsApmConfigServiceNameApmProto:
         )
         assert result == "foobar"
 
-    def test__calculate_service_name_apm_proto_malformed_service_key_index_error(
+    def test__calculate_service_name_apm_proto_malformed_service_key_only_token(
         self,
         mocker,
     ):
@@ -132,8 +132,21 @@ class TestSolarWindsApmConfigServiceNameApmProto:
             True,
             Resource.create()  # default is unknown_service
         )
-        # When service_key is malformed, agent disabled
-        # causing empty string to be returned
+        assert result == ""
+
+    def test__calculate_service_name_apm_proto_non_string_service_key(
+        self,
+        mocker,
+    ):
+        mocker.patch.dict(os.environ, {
+            "SW_APM_SERVICE_KEY": "valid:service",
+        })
+        test_config = apm_config.SolarWindsApmConfig()
+        test_config._SolarWindsApmConfig__config["service_key"] = 123
+        result = test_config._calculate_service_name_apm_proto(
+            True,
+            Resource.create()  # default is unknown_service
+        )
         assert result == ""
 
 class TestSolarWindsApmConfigServiceNameLambda:

--- a/tests/unit/test_apm_config/test_apm_config_service_name.py
+++ b/tests/unit/test_apm_config/test_apm_config_service_name.py
@@ -120,6 +120,22 @@ class TestSolarWindsApmConfigServiceNameApmProto:
         )
         assert result == "foobar"
 
+    def test__calculate_service_name_apm_proto_malformed_service_key_index_error(
+        self,
+        mocker,
+    ):
+        mocker.patch.dict(os.environ, {
+            "SW_APM_SERVICE_KEY": "token:",
+        })
+        test_config = apm_config.SolarWindsApmConfig()
+        result = test_config._calculate_service_name_apm_proto(
+            True,
+            Resource.create()  # default is unknown_service
+        )
+        # When service_key is malformed, agent disabled
+        # causing empty string to be returned
+        assert result == ""
+
 class TestSolarWindsApmConfigServiceNameLambda:
     def test__calculate_service_name_lambda_no_otel_name(
         self,


### PR DESCRIPTION
Relates to https://github.com/solarwinds/apm-python/pull/756

Adds more exception handling to ApmConfig to prevent distro crashing instrumented app, even if theoretical... unless automated review insists it's dead code e.g. [this comment](https://github.com/solarwinds/apm-python/pull/757#discussion_r3082371298)