### PR TITLE
Remove `boto` instrumentor dropped from OTel 1.41.0/0.62b0+

### DIFF
--- a/image/requirements.txt
+++ b/image/requirements.txt
@@ -25,7 +25,6 @@ opentelemetry-instrumentation-asgi==0.61b0
 opentelemetry-instrumentation-asyncio==0.61b0
 opentelemetry-instrumentation-asyncpg==0.61b0
 opentelemetry-instrumentation-aws-lambda==0.61b0
-opentelemetry-instrumentation-boto==0.61b0
 opentelemetry-instrumentation-boto3sqs==0.61b0
 opentelemetry-instrumentation-botocore==0.61b0
 opentelemetry-instrumentation-cassandra==0.61b0

--- a/lambda/requirements.txt
+++ b/lambda/requirements.txt
@@ -10,7 +10,6 @@ opentelemetry-instrumentation-aiohttp-client==0.61b0
 opentelemetry-util-http==0.61b0
 opentelemetry-instrumentation-asgi==0.61b0
 opentelemetry-instrumentation-asyncpg==0.61b0
-opentelemetry-instrumentation-boto==0.61b0
 opentelemetry-instrumentation-boto3sqs==0.61b0
 opentelemetry-instrumentation-celery==0.61b0
 opentelemetry-instrumentation-dbapi==0.61b0


### PR DESCRIPTION
Removes k8s image pre-install and a test dependency on OTel Python `boto` instrumentor, which is no longer being released as of 1.41.0/0.62b0