### PR TITLE
Always use GenAI new semconv if instrumentors support

### DIFF
--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -229,7 +229,6 @@ class SolarWindsDistro(BaseDistro):
                 ",".join(INTL_SWO_DEFAULT_RESOURCE_DETECTORS),
             )
 
-        # TODO: Support other signal types when available
         # Always opt into new semconv for all instrumentors (if supported)
         environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = self.get_semconv_opt_in()
 
@@ -403,7 +402,4 @@ class SolarWindsDistro(BaseDistro):
         See also:
         https://github.com/open-telemetry/opentelemetry-python-contrib/blob/0a231e57f9722e6101194c6b38695addf23ab950/opentelemetry-instrumentation/src/opentelemetry/instrumentation/_semconv.py#L93-L99
         """
-        # TODO: Support other signal types when available
-        # return environ.get("OTEL_SEMCONV_STABILITY_OPT_IN")
-
-        return "http,database"
+        return "http,database,gen_ai_latest_experimental"

--- a/solarwinds_apm/distro.py
+++ b/solarwinds_apm/distro.py
@@ -394,7 +394,8 @@ class SolarWindsDistro(BaseDistro):
     def get_semconv_opt_in(self) -> str:
         """Return semantic convention opt-in configuration.
 
-        Always returns config to opt into new, stable HTTP and database semconv only.
+        Always returns config to opt into new, stable HTTP and database semconv,
+        as well as the latest experimental GenAI semconv (gen_ai_latest_experimental).
 
         Returns:
         str: Semantic convention stability opt-in string.

--- a/tests/unit/test_distro.py
+++ b/tests/unit/test_distro.py
@@ -211,7 +211,7 @@ class TestDistro:
         assert os.environ[OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION] == "base2_exponential_bucket_histogram"
         assert os.environ[OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION] == "false"
         assert os.environ[OTEL_PYTHON_LOG_CODE_ATTRIBUTES] == "true"
-        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database,gen_ai_latest_experimental"
 
     def test_configure_env_exporter(self, mocker):
         mocker.patch.dict(
@@ -233,7 +233,7 @@ class TestDistro:
         assert os.environ[OTEL_EXPORTER_OTLP_HEADERS] == "authorization=Bearer%20foo-token"
         assert os.environ[OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION] == "false"
         assert os.environ[OTEL_PYTHON_LOG_CODE_ATTRIBUTES] == "true"
-        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database,gen_ai_latest_experimental"
 
     def test_configure_env_invalid_protocol(self, mocker):
         mocker.patch.dict(
@@ -255,7 +255,7 @@ class TestDistro:
         assert os.environ[OTEL_LOGS_EXPORTER] == "otlp"
         assert os.environ[OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION] == "false"
         assert os.environ[OTEL_PYTHON_LOG_CODE_ATTRIBUTES] == "true"
-        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database,gen_ai_latest_experimental"
 
     def test_configure_env_valid_protocol_http(self, mocker):
         mocker.patch.dict(
@@ -276,7 +276,7 @@ class TestDistro:
         assert os.environ[OTEL_LOGS_EXPORTER] == "otlp"
         assert os.environ[OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION] == "false"
         assert os.environ[OTEL_PYTHON_LOG_CODE_ATTRIBUTES] == "true"
-        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database,gen_ai_latest_experimental"
 
     def test_configure_env_valid_protocol_grpc(self, mocker):
         mocker.patch.dict(
@@ -299,7 +299,7 @@ class TestDistro:
         assert os.environ[OTEL_LOGS_EXPORTER] == "otlp"
         assert os.environ[OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION] == "false"
         assert os.environ[OTEL_PYTHON_LOG_CODE_ATTRIBUTES] == "true"
-        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database,gen_ai_latest_experimental"
 
     def test_configure_env_exporter_and_valid_protocol_http(self, mocker):
         mocker.patch.dict(
@@ -323,7 +323,7 @@ class TestDistro:
         assert os.environ[OTEL_LOGS_EXPORTER] == "qux"
         assert os.environ[OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION] == "false"
         assert os.environ[OTEL_PYTHON_LOG_CODE_ATTRIBUTES] == "true"
-        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database,gen_ai_latest_experimental"
 
     def test_configure_env_exporter_and_valid_protocol_grpc(self, mocker):
         mocker.patch.dict(
@@ -347,7 +347,7 @@ class TestDistro:
         assert os.environ[OTEL_LOGS_EXPORTER] == "qux"
         assert os.environ[OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION] == "false"
         assert os.environ[OTEL_PYTHON_LOG_CODE_ATTRIBUTES] == "true"
-        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database,gen_ai_latest_experimental"
 
     def test_configure_env_endpoint(self, mocker):
         mocker.patch.dict(
@@ -368,7 +368,7 @@ class TestDistro:
         assert os.environ[OTEL_LOGS_EXPORTER] == "otlp"
         assert os.environ[OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION] == "false"
         assert os.environ[OTEL_PYTHON_LOG_CODE_ATTRIBUTES] == "true"
-        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database,gen_ai_latest_experimental"
 
     def test_configure_env_service_key_only(self, mocker):
         mocker.patch.dict(
@@ -577,7 +577,7 @@ class TestDistro:
         assert os.environ[OTEL_LOGS_EXPORTER] == "otlp"
         assert os.environ[OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION] == "false"
         assert os.environ[OTEL_PYTHON_LOG_CODE_ATTRIBUTES] == "true"
-        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database,gen_ai_latest_experimental"
 
     def test_configure_env_headers_otel_headers_endpoint_default(self, mocker):
         mocker.patch.dict(
@@ -736,7 +736,7 @@ class TestDistro:
         assert os.environ[OTEL_TRACES_EXPORTER] == "otlp"
         assert os.environ[OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION] == "false"
         assert os.environ[OTEL_PYTHON_LOG_CODE_ATTRIBUTES] == "true"
-        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database"
+        assert os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN") == "http,database,gen_ai_latest_experimental"
 
     def test_load_instrumentor_aws_lambda_not_lambda_env(self, mocker):
         mock_apm_config = mocker.patch(
@@ -1465,4 +1465,4 @@ class TestDistro:
 
     def test_get_semconv_opt_in(self):
         # TODO: Support other signal types when available
-        assert distro.SolarWindsDistro().get_semconv_opt_in() == "http,database"
+        assert distro.SolarWindsDistro().get_semconv_opt_in() == "http,database,gen_ai_latest_experimental"


### PR DESCRIPTION
Hardcode APM to always use GenAI new semconv. If a loaded instrumentor supports the config, then new attributes will be used instead of deprecated. Example: `gen_ai.input.messages`, `gen_ai.output.messages`, instead of the old `gen_ai.user.message` etc.