### PR TITLE
Better bit assertions in integration tests for 02,03 traceflags

### DIFF
--- a/tests/integration/test_base_sw_headers_attrs.py
+++ b/tests/integration/test_base_sw_headers_attrs.py
@@ -52,18 +52,18 @@ class TestBaseSwHeadersAndAttributes(TestBase):
 
     @staticmethod
     def assert_valid_trace_flags(trace_flags: str):
-        """Assert trace flags are valid two-digit lowercase hex (e.g. 00, 01, 02, 03)."""
-        assert re.match(r"^[0-9a-f]{2}$", trace_flags)
+        """Assert trace flags are one of the explicitly supported lowercase values."""
+        assert trace_flags in {"00", "01", "02", "03"}
 
     def assert_trace_flags_sampled(self, trace_flags: str):
-        """Assert sampled bit is set (bit 0): sampled for 01 and 03; not for 00 or 02."""
+        """Assert trace flags are one of the explicitly sampled values."""
         self.assert_valid_trace_flags(trace_flags)
-        assert int(trace_flags, 16) & 0x01 == 0x01
+        assert trace_flags in {"01", "03"}
 
     def assert_trace_flags_not_sampled(self, trace_flags: str):
-        """Assert sampled bit is clear (bit 0): not sampled for 00 and 02; not for 01 or 03."""
+        """Assert trace flags are one of the explicitly not-sampled values."""
         self.assert_valid_trace_flags(trace_flags)
-        assert int(trace_flags, 16) & 0x01 == 0x00
+        assert trace_flags in {"00", "02"}
 
     @staticmethod
     def _test_trace():

--- a/tests/integration/test_base_sw_headers_attrs.py
+++ b/tests/integration/test_base_sw_headers_attrs.py
@@ -51,6 +51,21 @@ class TestBaseSwHeadersAndAttributes(TestBase):
     ]
 
     @staticmethod
+    def assert_valid_trace_flags(trace_flags: str):
+        """Assert trace flags are valid two-digit lowercase hex (e.g. 00, 01, 02, 03)."""
+        assert re.match(r"^[0-9a-f]{2}$", trace_flags)
+
+    def assert_trace_flags_sampled(self, trace_flags: str):
+        """Assert sampled bit is set (bit 0): sampled for 01 and 03; not for 00 or 02."""
+        self.assert_valid_trace_flags(trace_flags)
+        assert int(trace_flags, 16) & 0x01 == 0x01
+
+    def assert_trace_flags_not_sampled(self, trace_flags: str):
+        """Assert sampled bit is clear (bit 0): not sampled for 00 and 02; not for 01 or 03."""
+        self.assert_valid_trace_flags(trace_flags)
+        assert int(trace_flags, 16) & 0x01 == 0x00
+
+    @staticmethod
     def _test_trace():
         incoming_headers = {}
         for k, v in flask.request.headers.items():

--- a/tests/integration/test_scenario_1.py
+++ b/tests/integration/test_scenario_1.py
@@ -93,7 +93,7 @@ class TestScenario1(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == "01"
+        self.assert_trace_flags_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
         # In this test we know there is only `sw` in tracestate

--- a/tests/integration/test_scenario_1.py
+++ b/tests/integration/test_scenario_1.py
@@ -93,6 +93,7 @@ class TestScenario1(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == "01"
         self.assert_trace_flags_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json

--- a/tests/integration/test_scenario_4.py
+++ b/tests/integration/test_scenario_4.py
@@ -103,7 +103,8 @@ class TestScenario4(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == trace_flags
+        self.assert_valid_trace_flags(new_trace_flags)
+        assert int(new_trace_flags, 16) & 0x01 == int(trace_flags, 16) & 0x01
 
         assert "tracestate" in resp_json
         # In this test we know there is only `sw` in tracestate
@@ -253,7 +254,8 @@ class TestScenario4(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == trace_flags
+        self.assert_valid_trace_flags(new_trace_flags)
+        assert int(new_trace_flags, 16) & 0x01 == int(trace_flags, 16) & 0x01
 
         assert "tracestate" in resp_json
         # In this test we know there is only `sw` in tracestate

--- a/tests/integration/test_scenario_4.py
+++ b/tests/integration/test_scenario_4.py
@@ -103,6 +103,7 @@ class TestScenario4(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == trace_flags
         self.assert_valid_trace_flags(new_trace_flags)
         assert int(new_trace_flags, 16) & 0x01 == int(trace_flags, 16) & 0x01
 
@@ -254,6 +255,7 @@ class TestScenario4(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == trace_flags
         self.assert_valid_trace_flags(new_trace_flags)
         assert int(new_trace_flags, 16) & 0x01 == int(trace_flags, 16) & 0x01
 

--- a/tests/integration/test_scenario_8.py
+++ b/tests/integration/test_scenario_8.py
@@ -10,7 +10,6 @@ import time
 from unittest import mock
 
 from opentelemetry import trace as trace_api
-from unittest import mock
 
 from .test_base_sw_headers_attrs import TestBaseSwHeadersAndAttributes
 
@@ -111,7 +110,8 @@ class TestScenario8(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == trace_flags
+        self.assert_valid_trace_flags(new_trace_flags)
+        assert int(new_trace_flags, 16) & 0x01 == int(trace_flags, 16) & 0x01
 
         assert "tracestate" in resp_json
         # In this test we know tracestate will have `sw`
@@ -307,7 +307,8 @@ class TestScenario8(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == trace_flags
+        self.assert_valid_trace_flags(new_trace_flags)
+        assert int(new_trace_flags, 16) & 0x01 == int(trace_flags, 16) & 0x01
 
         assert "tracestate" in resp_json
         # In this test we know tracestate will have `sw`
@@ -439,7 +440,8 @@ class TestScenario8(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == trace_flags
+        self.assert_valid_trace_flags(new_trace_flags)
+        assert int(new_trace_flags, 16) & 0x01 == int(trace_flags, 16) & 0x01
 
         assert "tracestate" in resp_json
         # In this test we know there is `sw` in tracestate
@@ -635,7 +637,8 @@ class TestScenario8(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == trace_flags
+        self.assert_valid_trace_flags(new_trace_flags)
+        assert int(new_trace_flags, 16) & 0x01 == int(trace_flags, 16) & 0x01
 
         assert "tracestate" in resp_json
         # In this test we know there is `sw` in tracestate
@@ -757,7 +760,7 @@ class TestScenario8(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == "01"
+        self.assert_trace_flags_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
         # In this test we know tracestate will have `sw`
@@ -932,7 +935,7 @@ class TestScenario8(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == "00"
+        self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
         # In this test we know tracestate will have `sw`

--- a/tests/integration/test_scenario_8.py
+++ b/tests/integration/test_scenario_8.py
@@ -110,6 +110,7 @@ class TestScenario8(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == trace_flags
         self.assert_valid_trace_flags(new_trace_flags)
         assert int(new_trace_flags, 16) & 0x01 == int(trace_flags, 16) & 0x01
 
@@ -307,6 +308,7 @@ class TestScenario8(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == trace_flags
         self.assert_valid_trace_flags(new_trace_flags)
         assert int(new_trace_flags, 16) & 0x01 == int(trace_flags, 16) & 0x01
 
@@ -440,6 +442,7 @@ class TestScenario8(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == trace_flags
         self.assert_valid_trace_flags(new_trace_flags)
         assert int(new_trace_flags, 16) & 0x01 == int(trace_flags, 16) & 0x01
 
@@ -637,6 +640,7 @@ class TestScenario8(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == trace_flags
         self.assert_valid_trace_flags(new_trace_flags)
         assert int(new_trace_flags, 16) & 0x01 == int(trace_flags, 16) & 0x01
 
@@ -760,6 +764,7 @@ class TestScenario8(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == "01"
         self.assert_trace_flags_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
@@ -935,6 +940,7 @@ class TestScenario8(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == "00"
         self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json

--- a/tests/integration/test_signed_tt.py
+++ b/tests/integration/test_signed_tt.py
@@ -104,7 +104,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == "01"
+        self.assert_trace_flags_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
         # In this test we know tracestate will have `sw`
@@ -281,7 +281,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == "01"
+        self.assert_trace_flags_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
         # In this test we know tracestate will have `sw`
@@ -454,7 +454,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == "00"
+        self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
         # In this test we know tracestate will have `sw`
@@ -559,7 +559,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == "00"
+        self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
         # In this test we know tracestate will have `sw`
@@ -659,7 +659,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == "00"
+        self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
         # In this test we know tracestate will have `sw`
@@ -759,7 +759,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == "00"
+        self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
         # In this test we know tracestate will have `sw`
@@ -864,7 +864,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == "00"
+        self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
         # In this test we know tracestate will have `sw`
@@ -968,7 +968,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == "00"
+        self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
         # In this test we know tracestate will have `sw`
@@ -1069,7 +1069,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == "00"
+        self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
         # In this test we know there is `sw` in tracestate

--- a/tests/integration/test_signed_tt.py
+++ b/tests/integration/test_signed_tt.py
@@ -104,6 +104,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == "01"
         self.assert_trace_flags_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
@@ -281,6 +282,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == "01"
         self.assert_trace_flags_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
@@ -454,6 +456,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == "00"
         self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
@@ -559,6 +562,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == "00"
         self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
@@ -659,6 +663,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == "00"
         self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
@@ -759,6 +764,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == "00"
         self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
@@ -864,6 +870,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == "00"
         self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
@@ -968,6 +975,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == "00"
         self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
@@ -1069,6 +1077,7 @@ class TestSignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == "00"
         self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json

--- a/tests/integration/test_unsigned_tt.py
+++ b/tests/integration/test_unsigned_tt.py
@@ -100,7 +100,7 @@ class TestUnsignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == "01"
+        self.assert_trace_flags_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
         # In this test we know tracestate will have `sw`
@@ -269,7 +269,7 @@ class TestUnsignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == "00"
+        self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
         # In this test we know tracestate will have `sw`
@@ -370,7 +370,7 @@ class TestUnsignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == "00"
+        self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
         # In this test we know tracestate will have `sw`
@@ -471,7 +471,7 @@ class TestUnsignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == "01"
+        self.assert_trace_flags_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
         # In this test we know tracestate will have `sw`
@@ -644,7 +644,7 @@ class TestUnsignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == "00"
+        self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
         # In this test we know tracestate will have `sw`

--- a/tests/integration/test_unsigned_tt.py
+++ b/tests/integration/test_unsigned_tt.py
@@ -100,6 +100,7 @@ class TestUnsignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == "01"
         self.assert_trace_flags_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
@@ -269,6 +270,7 @@ class TestUnsignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == "00"
         self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
@@ -370,6 +372,7 @@ class TestUnsignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == "00"
         self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
@@ -471,6 +474,7 @@ class TestUnsignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == "01"
         self.assert_trace_flags_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json
@@ -644,6 +648,7 @@ class TestUnsignedWithOrWithoutTt(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == "00"
         self.assert_trace_flags_not_sampled(new_trace_flags)
 
         assert "tracestate" in resp_json

--- a/tests/integration/test_xtraceoptions_validation.py
+++ b/tests/integration/test_xtraceoptions_validation.py
@@ -76,6 +76,7 @@ class TestXtraceoptionsValidation(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
+        assert new_trace_flags == "01"
         self.assert_trace_flags_sampled(new_trace_flags)
         return new_span_id, new_trace_flags
 

--- a/tests/integration/test_xtraceoptions_validation.py
+++ b/tests/integration/test_xtraceoptions_validation.py
@@ -76,7 +76,7 @@ class TestXtraceoptionsValidation(TestBaseSwHeadersAndAttributes):
         new_span_id = traceparent_re_result.group(3)
         assert new_span_id is not None
         new_trace_flags = traceparent_re_result.group(4)
-        assert new_trace_flags == "01"
+        self.assert_trace_flags_sampled(new_trace_flags)
         return new_span_id, new_trace_flags
 
     def check_some_header_ok(self, resp_json):


### PR DESCRIPTION
Updates integration tests to also assert bits for sampled/not-sampled whether trace flags are 00,01,02,03. Provides evidence that those flags are already valid for existing APM Python custom sampling and propagation logic.

See ticket for more background information.