### PR TITLE
Add Requests version constraint to image build

### DIFF
--- a/image/requirements.txt
+++ b/image/requirements.txt
@@ -4,6 +4,7 @@ opentelemetry-sdk==1.41.1
 opentelemetry-instrumentation==0.62b1
 
 urllib3 < 2.7.0
+requests >= 2.33.0, < 3.0
 # We don't use the otlp_proto_grpc option since gRPC is not appropriate for
 # injected auto-instrumentation, where it has a strict dependency on the OS / Python version the artifact is built for.
 opentelemetry-exporter-otlp-proto-http==1.41.1


### PR DESCRIPTION
Adds a `requests` version constraint to image build, to work around Insecure Temporary File vulnerability and upstream instrumentor's too-open project.optional-dependencies.