### PR TITLE
Redesign SolarWindsPropagator value collection and injection

### DIFF
--- a/solarwinds_apm/propagator.py
+++ b/solarwinds_apm/propagator.py
@@ -86,9 +86,7 @@ class SolarWindsPropagator(TraceContextTextMapPropagator):
         """
         span = trace.get_current_span(context)
         span_context = span.get_span_context()
-        if span_context == trace.INVALID_SPAN_CONTEXT:
-            return
-        if span_context.span_id == self._INVALID_SPAN_ID:
+        if not span_context.is_valid:
             return
 
         traceparent_string = W3CTransformer.traceparent_from_context(

--- a/solarwinds_apm/propagator.py
+++ b/solarwinds_apm/propagator.py
@@ -32,6 +32,7 @@ class SolarWindsPropagator(TraceContextTextMapPropagator):
     """Extract and inject SolarWinds headers and W3C trace context for trace propagation."""
 
     _INVALID_SPAN_ID = 0x0000000000000000
+    _TRACEPARENT_HEADER_NAME = "traceparent"
     _TRACESTATE_HEADER_NAME = "tracestate"
     _XTRACEOPTIONS_HEADER_NAME = "x-trace-options"
     _XTRACEOPTIONS_SIGNATURE_HEADER_NAME = "x-trace-options-signature"
@@ -83,48 +84,48 @@ class SolarWindsPropagator(TraceContextTextMapPropagator):
         context (Context | None): Optional context to inject from. Defaults to None.
         setter (textmap.Setter): Setter for injecting headers into carrier. Defaults to default_setter.
         """
-        super().inject(carrier, context, setter)
-
         span = trace.get_current_span(context)
         span_context = span.get_span_context()
-        sw_value = W3CTransformer.sw_from_context(span_context)
-        trace_state_header = carrier.get(self._TRACESTATE_HEADER_NAME, None)
+        if span_context == trace.INVALID_SPAN_CONTEXT:
+            return
+        if span_context.span_id == self._INVALID_SPAN_ID:
+            return
 
-        # Prepare carrier with carrier's or new tracestate
-        trace_state = None
-        # Note: OTel Propagation API callers (OTel instrumentors) may
-        # inject header values as dictionary, not a string.
-        if isinstance(trace_state_header, dict):
-            trace_state_header = trace_state_header.get("StringValue")
-        if not trace_state_header:
-            # Only create new trace state if valid span_id
-            if span_context.span_id == self._INVALID_SPAN_ID:
-                return
+        traceparent_string = W3CTransformer.traceparent_from_context(
+            span_context
+        )
+        setter.set(carrier, self._TRACEPARENT_HEADER_NAME, traceparent_string)
+
+        # Get sw value to add/update in tracestate
+        sw_value = W3CTransformer.sw_from_context(span_context)
+
+        # Read existing tracestate directly from span_context (not from carrier)
+        # https://opentelemetry.io/docs/specs/otel/context/api-propagators/
+        existing_trace_state = span_context.trace_state
+        if not existing_trace_state:
             logger.debug(
                 "Creating new trace state for injection with %s",
                 sw_value,
             )
             trace_state = TraceState([(INTL_SWO_TRACESTATE_KEY, sw_value)])
         else:
-            trace_state = TraceState.from_header([trace_state_header])
             # Check if trace_state already contains sw KV
-            if INTL_SWO_TRACESTATE_KEY in trace_state:
+            if INTL_SWO_TRACESTATE_KEY in existing_trace_state:
                 # If so, modify current span_id and trace_flags, and move to beginning of list
                 logger.debug(
                     "Updating trace state for injection with %s",
                     sw_value,
                 )
-                trace_state = trace_state.update(
+                trace_state = existing_trace_state.update(
                     INTL_SWO_TRACESTATE_KEY, sw_value
                 )
-
             else:
                 # If not, add sw KV to beginning of list
                 logger.debug(
                     "Adding KV to trace state for injection with %s",
                     sw_value,
                 )
-                trace_state = trace_state.add(
+                trace_state = existing_trace_state.add(
                     INTL_SWO_TRACESTATE_KEY, sw_value
                 )
 

--- a/solarwinds_apm/propagator.py
+++ b/solarwinds_apm/propagator.py
@@ -108,26 +108,24 @@ class SolarWindsPropagator(TraceContextTextMapPropagator):
                 sw_value,
             )
             trace_state = TraceState([(INTL_SWO_TRACESTATE_KEY, sw_value)])
+        elif INTL_SWO_TRACESTATE_KEY in existing_trace_state:
+            # If so, modify current span_id and trace_flags, and move to beginning of list
+            logger.debug(
+                "Updating trace state for injection with %s",
+                sw_value,
+            )
+            trace_state = existing_trace_state.update(
+                INTL_SWO_TRACESTATE_KEY, sw_value
+            )
         else:
-            # Check if trace_state already contains sw KV
-            if INTL_SWO_TRACESTATE_KEY in existing_trace_state:
-                # If so, modify current span_id and trace_flags, and move to beginning of list
-                logger.debug(
-                    "Updating trace state for injection with %s",
-                    sw_value,
-                )
-                trace_state = existing_trace_state.update(
-                    INTL_SWO_TRACESTATE_KEY, sw_value
-                )
-            else:
-                # If not, add sw KV to beginning of list
-                logger.debug(
-                    "Adding KV to trace state for injection with %s",
-                    sw_value,
-                )
-                trace_state = existing_trace_state.add(
-                    INTL_SWO_TRACESTATE_KEY, sw_value
-                )
+            # If not, add sw KV to beginning of list
+            logger.debug(
+                "Adding KV to trace state for injection with %s",
+                sw_value,
+            )
+            trace_state = existing_trace_state.add(
+                INTL_SWO_TRACESTATE_KEY, sw_value
+            )
 
         # Remove any xtrace_options_response stored for ResponsePropagator
         trace_state = W3CTransformer.remove_response_from_sw(trace_state)

--- a/tests/unit/test_propagator.py
+++ b/tests/unit/test_propagator.py
@@ -76,6 +76,7 @@ class TestSolarWindsPropagator():
                     "span_id": 0x1000100010001000,
                     "trace_flags": trace_flags,
                     "trace_state": trace_state,
+                    "is_valid": True,
                 }
             )
         else:
@@ -85,6 +86,7 @@ class TestSolarWindsPropagator():
                     "span_id": 0x0000000000000000,
                     "trace_flags": 0x00,
                     "trace_state": trace_state,
+                    "is_valid": False,
                 }
             )
         mock_get_current_span = mocker.Mock()

--- a/tests/unit/test_propagator.py
+++ b/tests/unit/test_propagator.py
@@ -7,6 +7,7 @@
 from unittest.mock import call
 
 from opentelemetry.context.context import Context
+from opentelemetry.propagators import textmap
 from opentelemetry.trace.span import TraceState
 
 from solarwinds_apm.apm_constants import INTL_SWO_X_OPTIONS_KEY
@@ -57,22 +58,33 @@ class TestSolarWindsPropagator():
         assert actual_xto.options_header == "foo"
         assert actual_xto.signature == "bar"
 
-    def mock_otel_context(self, mocker, valid_span_id=True, trace_flags=0x01):
-        """Shared mocks for OTel trace context"""
+    def mock_otel_context(self, mocker, valid_span_id=True, trace_flags=0x01, trace_state=None):
+        """Shared mocks for OTel trace context
+        
+        Parameters:
+        mocker: pytest-mock fixture
+        valid_span_id: Whether to use a valid or invalid span_id
+        trace_flags: Trace flags value
+        trace_state: TraceState object or None
+        """
         # Mock OTel trace API and current span context
         mock_get_span_context = mocker.Mock()
         if valid_span_id:
             mock_get_span_context.configure_mock(
                 **{
+                    "trace_id": 0x3A02F8A392478C3700000000DEADBEEF,
                     "span_id": 0x1000100010001000,
                     "trace_flags": trace_flags,
+                    "trace_state": trace_state,
                 }
             )
         else:
             mock_get_span_context.configure_mock(
                 **{
+                    "trace_id": 0x0000000000000000000000000000000,
                     "span_id": 0x0000000000000000,
                     "trace_flags": 0x00,
+                    "trace_state": trace_state,
                 }
             )
         mock_get_current_span = mocker.Mock()
@@ -84,9 +96,12 @@ class TestSolarWindsPropagator():
         mock_trace = mocker.patch(
             "solarwinds_apm.propagator.trace"
         )
+        # Create a unique INVALID_SPAN_CONTEXT sentinel that won't match valid mocks
+        mock_invalid_span_context = mocker.Mock()
         mock_trace.configure_mock(
             **{
                 "get_current_span.return_value": mock_get_current_span,
+                "INVALID_SPAN_CONTEXT": mock_invalid_span_context,
             }
         )
 
@@ -131,6 +146,11 @@ class TestSolarWindsPropagator():
         mock_set.assert_has_calls([
             call(
                 mock_carrier,
+                "traceparent",
+                "00-3a02f8a392478c3700000000deadbeef-1000100010001000-01",
+            ),
+            call(
+                mock_carrier,
                 "tracestate",
                 TraceState([("sw", "1000100010001000-01")]).to_header(),
             ),
@@ -156,6 +176,11 @@ class TestSolarWindsPropagator():
             mock_setter,
         )
         mock_set.assert_has_calls([
+            call(
+                mock_carrier,
+                "traceparent",
+                "00-3a02f8a392478c3700000000deadbeef-1000100010001000-02",
+            ),
             call(
                 mock_carrier,
                 "tracestate",
@@ -185,6 +210,11 @@ class TestSolarWindsPropagator():
         mock_set.assert_has_calls([
             call(
                 mock_carrier,
+                "traceparent",
+                "00-3a02f8a392478c3700000000deadbeef-1000100010001000-03",
+            ),
+            call(
+                mock_carrier,
                 "tracestate",
                 TraceState([("sw", "1000100010001000-03")]).to_header(),
             ),
@@ -192,10 +222,9 @@ class TestSolarWindsPropagator():
 
     def test_inject_existing_tracestate_no_sw(self, mocker):
         """sw added to start, foo=bar kept, xtrace_options_response removed"""
-        self.mock_otel_context(mocker, True)
-        mock_carrier = {
-            "tracestate": "xtrace_options_response=abc123,foo=bar"
-        }
+        trace_state = TraceState([("xtrace_options_response", "abc123"), ("foo", "bar")])
+        self.mock_otel_context(mocker, True, trace_state=trace_state)
+        mock_carrier = dict()
         mock_context = mocker.Mock()
         mock_setter = mocker.Mock()
         mock_set = mocker.Mock()
@@ -211,6 +240,11 @@ class TestSolarWindsPropagator():
         )
         # OTel context mocked with span_id 0x1000100010001000, trace_flags 0x01
         mock_set.assert_has_calls([
+            call(
+                mock_carrier,
+                "traceparent",
+                "00-3a02f8a392478c3700000000deadbeef-1000100010001000-01",
+            ),
             call(
                 mock_carrier,
                 "tracestate",
@@ -220,10 +254,9 @@ class TestSolarWindsPropagator():
 
     def test_inject_existing_tracestate_existing_sw(self, mocker):
         """sw updated and moved to start, foo=bar kept, xtrace_options_response removed"""
-        self.mock_otel_context(mocker, True)
-        mock_carrier = {
-            "tracestate": "xtrace_options_response=abc123,foo=bar,sw=some-existing-value",
-        }
+        trace_state = TraceState([("xtrace_options_response", "abc123"), ("foo", "bar"), ("sw", "some-existing-value")])
+        self.mock_otel_context(mocker, True, trace_state=trace_state)
+        mock_carrier = dict()
         mock_context = mocker.Mock()
         mock_setter = mocker.Mock()
         mock_set = mocker.Mock()
@@ -241,19 +274,20 @@ class TestSolarWindsPropagator():
         mock_set.assert_has_calls([
             call(
                 mock_carrier,
+                "traceparent",
+                "00-3a02f8a392478c3700000000deadbeef-1000100010001000-01",
+            ),
+            call(
+                mock_carrier,
                 "tracestate",
                 TraceState([("sw", "1000100010001000-01"), ("foo", "bar")]).to_header(),
             ),
         ])
 
     def test_inject_existing_tracestate_dict_no_stringvalue(self, mocker):
-        """sw added to start, foo=bar kept, xtrace_options_response removed"""
-        self.mock_otel_context(mocker, True)
-        mock_carrier = {
-            "tracestate": {
-                "not-stringvalue": "unused",
-            }
-        }
+        """No tracestate creates new one"""
+        self.mock_otel_context(mocker, True, trace_state=None)
+        mock_carrier = dict()
         mock_context = mocker.Mock()
         mock_setter = mocker.Mock()
         mock_set = mocker.Mock()
@@ -269,6 +303,11 @@ class TestSolarWindsPropagator():
         )
         # OTel context mocked with span_id 0x1000100010001000, trace_flags 0x01
         mock_set.assert_has_calls([
+            call(
+                mock_carrier,
+                "traceparent",
+                "00-3a02f8a392478c3700000000deadbeef-1000100010001000-01",
+            ),
             call(
                 mock_carrier,
                 "tracestate",
@@ -278,12 +317,9 @@ class TestSolarWindsPropagator():
 
     def test_inject_existing_tracestate_dict_no_sw(self, mocker):
         """sw added to start, foo=bar kept, xtrace_options_response removed"""
-        self.mock_otel_context(mocker, True)
-        mock_carrier = {
-            "tracestate": {
-                "StringValue": "xtrace_options_response=abc123,foo=bar",
-            }
-        }
+        trace_state = TraceState([("xtrace_options_response", "abc123"), ("foo", "bar")])
+        self.mock_otel_context(mocker, True, trace_state=trace_state)
+        mock_carrier = dict()
         mock_context = mocker.Mock()
         mock_setter = mocker.Mock()
         mock_set = mocker.Mock()
@@ -299,6 +335,11 @@ class TestSolarWindsPropagator():
         )
         # OTel context mocked with span_id 0x1000100010001000, trace_flags 0x01
         mock_set.assert_has_calls([
+            call(
+                mock_carrier,
+                "traceparent",
+                "00-3a02f8a392478c3700000000deadbeef-1000100010001000-01",
+            ),
             call(
                 mock_carrier,
                 "tracestate",
@@ -308,12 +349,9 @@ class TestSolarWindsPropagator():
 
     def test_inject_existing_tracestate_dict_existing_sw(self, mocker):
         """sw updated and moved to start, foo=bar kept, xtrace_options_response removed"""
-        self.mock_otel_context(mocker, True)
-        mock_carrier = {
-            "tracestate": {
-                "StringValue": "xtrace_options_response=abc123,foo=bar,sw=some-existing-value",
-            }
-        }
+        trace_state = TraceState([("xtrace_options_response", "abc123"), ("foo", "bar"), ("sw", "some-existing-value")])
+        self.mock_otel_context(mocker, True, trace_state=trace_state)
+        mock_carrier = dict()
         mock_context = mocker.Mock()
         mock_setter = mocker.Mock()
         mock_set = mocker.Mock()
@@ -331,7 +369,237 @@ class TestSolarWindsPropagator():
         mock_set.assert_has_calls([
             call(
                 mock_carrier,
+                "traceparent",
+                "00-3a02f8a392478c3700000000deadbeef-1000100010001000-01",
+            ),
+            call(
+                mock_carrier,
                 "tracestate",
                 TraceState([("sw", "1000100010001000-01"), ("foo", "bar")]).to_header(),
             ),
         ])
+
+
+class TestSolarWindsPropagatorNonDictCarriers:
+    """Test SolarWindsPropagator with non-dict carriers from heterogeneous instrumentors"""
+
+    def mock_otel_context_with_tracestate(self, mocker, trace_state=None):
+        """Mock OTel trace context with optional existing tracestate"""
+        mock_get_span_context = mocker.Mock()
+        mock_get_span_context.configure_mock(
+            **{
+                "trace_id": 0x3A02F8A392478C3700000000DEADBEEF,
+                "span_id": 0x1000100010001000,
+                "trace_flags": 0x01,
+                "trace_state": trace_state,
+            }
+        )
+        mock_get_current_span = mocker.Mock()
+        mock_get_current_span.configure_mock(
+            **{
+                "get_span_context.return_value": mock_get_span_context
+            }
+        )
+        mock_trace = mocker.patch(
+            "solarwinds_apm.propagator.trace"
+        )
+        # Create a unique INVALID_SPAN_CONTEXT sentinel that won't match valid mocks
+        mock_invalid_span_context = mocker.Mock()
+        mock_trace.configure_mock(
+            **{
+                "get_current_span.return_value": mock_get_current_span,
+                "INVALID_SPAN_CONTEXT": mock_invalid_span_context,
+            }
+        )
+
+    def test_inject_list_carrier_no_existing_tracestate(self, mocker):
+        """Test injection into list-based carrier (like ConfluentKafka) with no existing tracestate"""
+        self.mock_otel_context_with_tracestate(mocker, None)
+        mock_carrier = []
+        mock_context = mocker.Mock()
+        # Custom setter for list-based carrier (simulates KafkaContextSetter)
+        class ListSetter(textmap.Setter):
+            def set(self, carrier, key, value):
+                carrier.append((key, value))
+        mock_setter = ListSetter()
+
+        SolarWindsPropagator().inject(
+            mock_carrier,
+            mock_context,
+            mock_setter,
+        )
+
+        tracestate_entries = [item for item in mock_carrier if item[0] == "tracestate"]
+        assert len(tracestate_entries) == 1
+        assert tracestate_entries[0][1] == "sw=1000100010001000-01"
+
+    def test_inject_list_carrier_with_existing_tracestate(self, mocker):
+        """Test injection into list carrier with existing tracestate in span_context"""
+        existing_trace_state = TraceState([("foo", "bar")])
+        self.mock_otel_context_with_tracestate(mocker, existing_trace_state)
+        mock_carrier = []
+        mock_context = mocker.Mock()
+
+        class ListSetter(textmap.Setter):
+            def set(self, carrier, key, value):
+                carrier.append((key, value))
+
+        mock_setter = ListSetter()
+        SolarWindsPropagator().inject(
+            mock_carrier,
+            mock_context,
+            mock_setter,
+        )
+
+        tracestate_entries = [item for item in mock_carrier if item[0] == "tracestate"]
+        assert len(tracestate_entries) == 1
+        assert tracestate_entries[0][1] == "sw=1000100010001000-01,foo=bar"
+
+    def test_inject_list_carrier_updates_existing_sw(self, mocker):
+        """Test injection updates existing sw in span_context.trace_state"""
+        existing_trace_state = TraceState([("sw", "old-value"), ("foo", "bar")])
+        self.mock_otel_context_with_tracestate(mocker, existing_trace_state)
+        mock_carrier = []
+        mock_context = mocker.Mock()
+
+        class ListSetter(textmap.Setter):
+            def set(self, carrier, key, value):
+                carrier.append((key, value))
+
+        mock_setter = ListSetter()
+        SolarWindsPropagator().inject(
+            mock_carrier,
+            mock_context,
+            mock_setter,
+        )
+        # Verify sw was updated and moved to front
+        tracestate_entries = [item for item in mock_carrier if item[0] == "tracestate"]
+        assert len(tracestate_entries) == 1
+        assert tracestate_entries[0][1] == "sw=1000100010001000-01,foo=bar"
+
+    def test_inject_list_carrier_no_attributeerror(self, mocker):
+        """Verify that list carrier doesn't raise AttributeError"""
+        self.mock_otel_context_with_tracestate(mocker, None)
+        mock_carrier = []
+        mock_context = mocker.Mock()
+
+        class ListSetter(textmap.Setter):
+            def set(self, carrier, key, value):
+                # Simulates KafkaContextSetter behavior
+                if isinstance(carrier, list):
+                    carrier.append((key, value))
+
+        mock_setter = ListSetter()
+        try:
+            SolarWindsPropagator().inject(
+                mock_carrier,
+                mock_context,
+                mock_setter,
+            )
+            assert True
+        except AttributeError as e:
+            if "'list' object has no attribute 'get'" in str(e):
+                raise AssertionError("Propagator incorrectly called carrier.get() on list carrier")
+            raise
+
+    def test_inject_custom_carrier_type(self, mocker):
+        """Test injection with a completely custom carrier type"""
+        existing_trace_state = TraceState([("existing", "value")])
+        self.mock_otel_context_with_tracestate(mocker, existing_trace_state)
+
+        class CustomCarrier:
+            def __init__(self):
+                self.headers = {}
+
+        mock_carrier = CustomCarrier()
+        mock_context = mocker.Mock()
+
+        class CustomSetter(textmap.Setter):
+            def set(self, carrier, key, value):
+                carrier.headers[key] = value
+
+        mock_setter = CustomSetter()
+        SolarWindsPropagator().inject(
+            mock_carrier,
+            mock_context,
+            mock_setter,
+        )
+        assert "tracestate" in mock_carrier.headers
+        assert mock_carrier.headers["tracestate"] == "sw=1000100010001000-01,existing=value"
+
+    def test_inject_tuple_carrier(self, mocker):
+        """Test that immutable carriers work with appropriate setter"""
+        self.mock_otel_context_with_tracestate(mocker, None)
+        mock_carrier = ()
+        mock_context = mocker.Mock()
+        injected_values = {}
+
+        class TupleSetter(textmap.Setter):
+            def set(self, carrier, key, value):
+                # Since tuples are immutable, store in external dict
+                injected_values[key] = value
+
+        mock_setter = TupleSetter()
+
+        SolarWindsPropagator().inject(
+            mock_carrier,
+            mock_context,
+            mock_setter,
+        )
+        assert "tracestate" in injected_values
+        assert injected_values["tracestate"] == "sw=1000100010001000-01"
+
+    def test_inject_list_carrier_no_duplicate_tracestate(self, mocker):
+        """Verify no duplicate tracestate with real span context"""
+        from opentelemetry import trace as otel_trace
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        tracer = provider.get_tracer(__name__)
+        existing_trace_state = TraceState([("foo", "bar")])
+
+        with tracer.start_as_current_span(
+            "test_span",
+            attributes={"test": "value"},
+        ) as span:
+            original_context = span.get_span_context()
+            new_span_context = otel_trace.SpanContext(
+                trace_id=original_context.trace_id,
+                span_id=original_context.span_id,
+                is_remote=original_context.is_remote,
+                trace_flags=original_context.trace_flags,
+                trace_state=existing_trace_state,
+            )
+            span._context = new_span_context
+            carrier = []
+
+            class TrackingListSetter(textmap.Setter):
+                def __init__(self):
+                    self.calls = []
+
+                def set(self, carrier, key, value):
+                    self.calls.append((key, value))
+                    carrier.append((key, value))
+
+            tracking_setter = TrackingListSetter()
+            propagator = SolarWindsPropagator()
+            propagator.inject(carrier, setter=tracking_setter)
+            tracestate_writes = [
+                call for call in tracking_setter.calls if call[0] == "tracestate"
+            ]
+            assert (
+                len(tracestate_writes) == 1
+            ), f"Expected 1 tracestate write, got {len(tracestate_writes)}: {tracestate_writes}"
+            tracestate_entries = [item for item in carrier if item[0] == "tracestate"]
+            assert (
+                len(tracestate_entries) == 1
+            ), f"Expected 1 tracestate in carrier, got {len(tracestate_entries)}: {tracestate_entries}"
+            tracestate_value = tracestate_entries[0][1]
+            assert "sw=" in tracestate_value
+            assert "foo=bar" in tracestate_value

--- a/tests/unit/test_propagator.py
+++ b/tests/unit/test_propagator.py
@@ -60,7 +60,7 @@ class TestSolarWindsPropagator():
 
     def mock_otel_context(self, mocker, valid_span_id=True, trace_flags=0x01, trace_state=None):
         """Shared mocks for OTel trace context
-        
+
         Parameters:
         mocker: pytest-mock fixture
         valid_span_id: Whether to use a valid or invalid span_id

--- a/tests/unit/test_propagator.py
+++ b/tests/unit/test_propagator.py
@@ -89,6 +89,7 @@ class TestSolarWindsPropagator():
                     "is_valid": False,
                 }
             )
+        mock_get_span_context.is_valid = bool(valid_span_id) and mock_get_span_context.trace_id != 0
         mock_get_current_span = mocker.Mock()
         mock_get_current_span.configure_mock(
             **{
@@ -396,6 +397,7 @@ class TestSolarWindsPropagatorNonDictCarriers:
                 "trace_state": trace_state,
             }
         )
+        mock_get_span_context.is_valid = True
         mock_get_current_span = mocker.Mock()
         mock_get_current_span.configure_mock(
             **{
@@ -578,7 +580,9 @@ class TestSolarWindsPropagatorNonDictCarriers:
                 trace_flags=original_context.trace_flags,
                 trace_state=existing_trace_state,
             )
-            span._context = new_span_context
+            ctxt = otel_trace.set_span_in_context(
+                otel_trace.NonRecordingSpan(new_span_context)
+            )
             carrier = []
 
             class TrackingListSetter(textmap.Setter):
@@ -591,7 +595,7 @@ class TestSolarWindsPropagatorNonDictCarriers:
 
             tracking_setter = TrackingListSetter()
             propagator = SolarWindsPropagator()
-            propagator.inject(carrier, setter=tracking_setter)
+            propagator.inject(carrier, context=ctxt, setter=tracking_setter)
             tracestate_writes = [
                 call for call in tracking_setter.calls if call[0] == "tracestate"
             ]


### PR DESCRIPTION
APM Python custom `SolarWindsPropagator` is not following the [Otel Propagators API](https://opentelemetry.io/docs/specs/otel/context/api-propagators/) very well and is taking tracestate from the carrier at time of inject instead of from span context. It’s also complicating things by calling the super’s `TraceContextTextMapPropagator.inject` and doing some `isinstance` to deal with upstream instrumentor heterogeneity when using carrier instead of context. This is therefore a `SolarWindsPropagator` small redesign/cleanup. See ticket for more test results.
