### PR TITLE
NH-138702 Add AWS Lambda container example

### DIFF
--- a/examples/aws_lambda_container/Dockerfile
+++ b/examples/aws_lambda_container/Dockerfile
@@ -2,12 +2,13 @@
 # OpenTelemetry Collector extension, and function definition.
 # Download the layer first: ./download-layer.sh
 
-FROM public.ecr.aws/lambda/python:3.12-arm64
+FROM public.ecr.aws/lambda/python:3.12-arm64@sha256:211bec50ee0bf880deacdb9f3a4a940e03d21bea3e4728488642f4c6ef358232
 
 # Download and extract the latest SolarWinds OTel Lambda extension for ARM64
 ARG SOLARWINDS_OTEL_VERSION=0.0.13
+ARG SOLARWINDS_OTEL_SHA256=a44d6aaebe3e21f54a61dff2b75d73feb9a9a606c518f6184c1fe3f84e3779c0
 ARG LAYER_ZIP=solarwinds_apm_lambda.zip
-ADD https://github.com/solarwinds/opentelemetry-lambda/releases/download/layer-collector/${SOLARWINDS_OTEL_VERSION}/opentelemetry-collector-layer-arm64.zip /tmp/swo-otel-extension.zip
+ADD --checksum=sha256:${SOLARWINDS_OTEL_SHA256} https://github.com/solarwinds/opentelemetry-lambda/releases/download/layer-collector/${SOLARWINDS_OTEL_VERSION}/opentelemetry-collector-layer-arm64.zip /tmp/swo-otel-extension.zip
 RUN python -m zipfile -e /tmp/swo-otel-extension.zip /opt && rm /tmp/swo-otel-extension.zip
 RUN mv /opt/extensions/collector /opt/extensions/otel-extension && chmod +x /opt/extensions/otel-extension
 ENV OPENTELEMETRY_COLLECTOR_CONFIG_URI=file:///opt/collector-config/config.yaml

--- a/examples/aws_lambda_container/Dockerfile
+++ b/examples/aws_lambda_container/Dockerfile
@@ -1,0 +1,29 @@
+# Dockerfile for AWS Lambda container image build with SolarWinds APM Python,
+# OpenTelemetry Collector extension, and function definition.
+# Download the layer first: ./download-layer.sh
+
+FROM public.ecr.aws/lambda/python:3.12-arm64
+
+# Download and extract the latest SolarWinds OTel Lambda extension for ARM64
+ARG SOLARWINDS_OTEL_VERSION=0.0.13
+ARG LAYER_ZIP=solarwinds_apm_lambda.zip
+ADD https://github.com/solarwinds/opentelemetry-lambda/releases/download/layer-collector/${SOLARWINDS_OTEL_VERSION}/opentelemetry-collector-layer-arm64.zip /tmp/swo-otel-extension.zip
+RUN python -m zipfile -e /tmp/swo-otel-extension.zip /opt && rm /tmp/swo-otel-extension.zip
+RUN mv /opt/extensions/collector /opt/extensions/otel-extension && chmod +x /opt/extensions/otel-extension
+ENV OPENTELEMETRY_COLLECTOR_CONFIG_URI=file:///opt/collector-config/config.yaml
+
+# Extract the pre-downloaded APM Python Lambda Layer
+COPY ${LAYER_ZIP} /tmp/apm-python-layer.zip
+RUN python -m zipfile -e /tmp/apm-python-layer.zip /opt && rm /tmp/apm-python-layer.zip
+RUN chmod +x /opt/python/bin/opentelemetry-instrument
+RUN chmod +x /opt/solarwinds-apm/wrapper
+RUN mv /opt/python/otel_wrapper.py ${LAMBDA_TASK_ROOT}/otel_wrapper.py
+
+# Required configuration for OpenTelemetry auto-instrumentation
+ENV AWS_LAMBDA_EXEC_WRAPPER=/opt/solarwinds-apm/wrapper
+ENV ORIG_HANDLER=lambda_function.lambda_handler \
+    _HANDLER=otel_wrapper.lambda_handler
+COPY lambda_function.py ${LAMBDA_TASK_ROOT}/
+
+# Run auto-instrumented AWS Lambda function
+CMD ["otel_wrapper.lambda_handler"]

--- a/examples/aws_lambda_container/README.md
+++ b/examples/aws_lambda_container/README.md
@@ -38,7 +38,7 @@ apm-python/
 This downloads `solarwinds_apm_lambda.zip` which can be committed or stored in your artifact registry. APM Python library version `>=6.1.1` is required.
 
 ```bash
-cd <path_to>/apm-python/examples/aws_lambda_container/README.md
+cd <path_to>/apm-python/examples/aws_lambda_container
 
 # Authenticate with your AWS account
 # with permission to call lambda:GetLayerVersionByArn

--- a/examples/aws_lambda_container/README.md
+++ b/examples/aws_lambda_container/README.md
@@ -1,4 +1,4 @@
-# Example: AWS Lambda container image publish with APM Python auto-instrumentation
+# Example: AWS Lambda container image publishing with APM Python auto-instrumentation
 
 This directory contains an example container image setup for an AWS Lambda Python function with SolarWinds APM Python auto-instrumentation, with instructions for configuration and deployment to AWS ECR and AWS Lambda.
 

--- a/examples/aws_lambda_container/README.md
+++ b/examples/aws_lambda_container/README.md
@@ -17,8 +17,8 @@ apm-python/
 ## Prerequisites
 
 ### For APM layer download (once per APM install/upgrade)
-- AWS credentials configured (`~/.aws/credentials`)
 - AWS CLI installed
+- AWS authentication configured (credentials file, SSO, environment variables, etc.)
 - permission to call `lambda:GetLayerVersionByArn`
 
 ### For container build
@@ -40,11 +40,10 @@ This downloads `solarwinds_apm_lambda.zip` which can be committed or stored in y
 ```bash
 cd <path_to>/apm-python/examples/aws_lambda_container
 
-# Authenticate with your AWS account
+# Ensure you are authenticated with your AWS account
 # with permission to call lambda:GetLayerVersionByArn
-# For example:
-aws configure --profile <my-cool-profile>
-export AWS_PROFILE=<my-cool-profile>
+# Verify your authentication:
+aws sts get-caller-identity
 
 ./download-layer.sh
 ```
@@ -75,20 +74,20 @@ This configures environment variables for an existing AWS Lambda function, `my-c
 
 ```bash
 # a valid SolarWinds Observability SaaS API token
-export API_TOKEN=<valid_swo_api_token>
+export SW_APM_API_TOKEN=<valid_swo_api_token>
 # the AWS region of your choice
 export AWS_REGION=us-east-1
 
 # Option 1: only the required and highly recommended variables
 aws lambda update-function-configuration \
     --function-name my-cool-lambda \
-    --environment '{"Variables":{"SW_APM_API_TOKEN":"'"${API_TOKEN}"'","OTEL_SERVICE_NAME":"my-cool-lambda"}}' \
+    --environment '{"Variables":{"SW_APM_API_TOKEN":"'"${SW_APM_API_TOKEN}"'","OTEL_SERVICE_NAME":"my-cool-lambda"}}' \
     --region ${AWS_REGION}
 
 # Option 2: additional options
 aws lambda update-function-configuration \
     --function-name my-cool-lambda \
-    --environment '{"Variables":{"SW_APM_API_TOKEN":"'"${API_TOKEN}"'","OTEL_SERVICE_NAME":"my-cool-lambda","SW_APM_DATA_CENTER":"na-02","SW_APM_TELEMETRY_API_SUBSCRIPTION":"platform,function","OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION":"true","SW_APM_DEBUG_LEVEL":"6"}}' \
+    --environment '{"Variables":{"SW_APM_API_TOKEN":"'"${SW_APM_API_TOKEN}"'","OTEL_SERVICE_NAME":"my-cool-lambda","SW_APM_DATA_CENTER":"na-02","SW_APM_TELEMETRY_API_SUBSCRIPTION":"platform,function","OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION":"true","SW_APM_DEBUG_LEVEL":"6"}}' \
     --region ${AWS_REGION}
 ```
 

--- a/examples/aws_lambda_container/README.md
+++ b/examples/aws_lambda_container/README.md
@@ -1,0 +1,119 @@
+# Example: AWS Lambda container image publish with APM Python auto-instrumentation
+
+This directory contains an example container image setup for an AWS Lambda Python function with SolarWinds APM Python auto-instrumentation, with instructions for configuration and deployment to AWS ECR and AWS Lambda.
+
+## Contents
+
+```
+apm-python/
+├── examples/
+│   ├── aws_lambda_container/        # this directory
+│   │   ├── README.md                # this file
+│   │   ├── download-layer.sh        # APM instrumentation layer download script
+│   │   ├── lambda_function.py       # sample AWS Lambda function in Python
+│   │   └── Dockerfile               # container image build definition
+```
+
+## Prerequisites
+
+### For APM layer download (once per APM install/upgrade)
+- AWS credentials configured (`~/.aws/credentials`)
+- AWS CLI installed
+- permission to call `lambda:GetLayerVersionByArn`
+
+### For container build
+- Docker installed with BuildKit enabled (Docker 18.09+)
+- downloaded layer zip: `solarwinds_apm_lambda.zip`, i.e. from `download-layer.sh`
+
+### For Deployment
+- an existing AWS ECR, e.g. `my-cool-repo`
+- an existing AWS Lambda, e.g. `my-cool-lambda`
+- an existing AWS Lambda function or IAM role with Lambda execution permissions
+- SolarWinds Observability SaaS account with API token
+
+## Instructions
+
+### (1) Download APM instrumentation layer (once per APM install/upgrade)
+
+This downloads `solarwinds_apm_lambda.zip` which can be committed or stored in your artifact registry. APM Python library version `>=6.1.1` is required.
+
+```bash
+cd <path_to>/apm-python/examples/aws_lambda_container/README.md
+
+# Authenticate with your AWS account
+# with permission to call lambda:GetLayerVersionByArn
+# For example:
+aws configure --profile <my-cool-profile>
+export AWS_PROFILE=<my-cool-profile>
+
+./download-layer.sh
+```
+
+To upgrade APM to a newer version later:
+```bash
+LAYER_VERSION=7_0_1 LAYER_VERSION_NUMBER=1 ./download-layer.sh
+```
+
+Check contents of `./download-layer.sh` for more options.
+
+### (2) Build container image with instrumentation
+
+This builds a Docker container image for `my-cool-repo` with:
+- SolarWinds OpenTelemetry Collector extension
+- APM Python auto-instrumentation
+- the function defined in `lambda_function.py`
+
+```bash
+# Example build command for ARM64 architecture
+DOCKER_BUILDKIT=1 docker build --platform linux/arm64 --provenance=false \
+  -t my-cool-repo:latest .
+```
+
+### (3) Set/Update AWS Lambda environment variables for instrumentation
+
+This configures environment variables for an existing AWS Lambda function, `my-cool-lambda`. For more information, see [SWO AWS Lambda Instrumentation](https://documentation.solarwinds.com/en/success_center/observability/content/intro/services/aws-lambda-overview.htm).
+
+```bash
+# a valid SolarWinds Observability SaaS API token
+export API_TOKEN=<valid_swo_api_token>
+# the AWS region of your choice
+export AWS_REGION=us-east-1
+
+# Option 1: only the required and highly recommended variables
+aws lambda update-function-configuration \
+    --function-name my-cool-lambda \
+    --environment '{"Variables":{"SW_APM_API_TOKEN":"'"${API_TOKEN}"'","OTEL_SERVICE_NAME":"my-cool-lambda"}}' \
+    --region ${AWS_REGION}
+
+# Option 2: additional options
+aws lambda update-function-configuration \
+    --function-name my-cool-lambda \
+    --environment '{"Variables":{"SW_APM_API_TOKEN":"'"${API_TOKEN}"'","OTEL_SERVICE_NAME":"my-cool-lambda","SW_APM_DATA_CENTER":"na-02","SW_APM_TELEMETRY_API_SUBSCRIPTION":"platform,function","OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION":"true","SW_APM_DEBUG_LEVEL":"6"}}' \
+    --region ${AWS_REGION}
+```
+
+### (4) Push to AWS ECR and deploy AWS Lambda
+
+This pushes your built image to an existing AWS ECR repository named `my-cool-repo` then updates `my-cool-lambda` to use it.
+
+```bash
+export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+aws ecr get-login-password --region ${AWS_REGION} | \
+    docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com
+
+docker tag my-cool-repo:latest \
+    ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/my-cool-repo:latest
+
+docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/my-cool-repo:latest
+
+aws lambda update-function-code \
+    --function-name my-cool-lambda \
+    --image-uri ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/my-cool-repo:latest \
+    --region ${AWS_REGION}
+
+# Wait for the update to complete before you invoke
+aws lambda wait function-updated \
+    --function-name my-cool-lambda \
+    --region ${AWS_REGION}
+```

--- a/examples/aws_lambda_container/download-layer.sh
+++ b/examples/aws_lambda_container/download-layer.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# © 2026 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Helper script to download APM Python Lambda layer from AWS.
+# Requires AWS CLI and valid AWS_PROFILE for login.
+
+set -e
+
+# Configurable values
+AWS_REGION="${AWS_REGION:-us-east-1}"
+LAYER_VERSION="${LAYER_VERSION:-6_1_1}"
+LAYER_VERSION_NUMBER="${LAYER_VERSION_NUMBER:-1}"
+OUTPUT_FILE="${OUTPUT_FILE:-solarwinds_apm_lambda.zip}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+echo -e "${GREEN}SolarWinds APM Python Lambda Layer Downloader${NC}"
+echo "=================================================="
+echo ""
+echo "Configuration:"
+echo "  AWS Profile: $AWS_PROFILE"
+echo "  AWS Region: $AWS_REGION"
+echo "  Layer Version: $LAYER_VERSION"
+echo "  Layer Version Number: $LAYER_VERSION_NUMBER"
+echo "  Output File: $OUTPUT_FILE"
+echo ""
+
+if ! command -v aws &> /dev/null; then
+    echo -e "${RED}ERROR: AWS CLI is not installed${NC}"
+    echo "Install from: https://aws.amazon.com/cli/"
+    exit 1
+fi
+if ! aws sts get-caller-identity --profile "$AWS_PROFILE" &> /dev/null; then
+    echo -e "${RED}ERROR: AWS credentials not valid${NC}"
+    exit 1
+fi
+echo -e "${GREEN}✓ AWS credentials valid${NC}"
+echo ""
+
+LAYER_NAME="solarwinds-apm-python-${LAYER_VERSION}"
+LAYER_ARN="arn:aws:lambda:${AWS_REGION}:851060098468:layer:${LAYER_NAME}:${LAYER_VERSION_NUMBER}"
+echo "Downloading layer from AWS Lambda..."
+echo "  ARN: $LAYER_ARN"
+echo ""
+echo "Getting layer download URL..."
+LAYER_URL=$(aws lambda get-layer-version-by-arn \
+    --arn "$LAYER_ARN" \
+    --query 'Content.Location' \
+    --output text \
+    --region "$AWS_REGION" \
+    --profile "$AWS_PROFILE" \
+    --no-cli-pager \
+    --no-cli-auto-prompt)
+if [ -z "$LAYER_URL" ]; then
+    echo -e "${RED}ERROR: Failed to get layer download URL${NC}"
+    exit 1
+fi
+echo -e "${GREEN}✓ Got download URL${NC}"
+echo ""
+
+echo "Downloading layer zip (this may take a moment)..."
+if curl -L "$LAYER_URL" -o "$OUTPUT_FILE"; then
+    echo -e "${GREEN}✓ Download complete${NC}"
+else
+    echo -e "${RED}ERROR: Download failed${NC}"
+    exit 1
+fi
+if [ ! -f "$OUTPUT_FILE" ]; then
+    echo -e "${RED}ERROR: Output file not found${NC}"
+    exit 1
+fi
+
+FILE_SIZE=$(du -h "$OUTPUT_FILE" | cut -f1)
+echo ""
+echo "=================================================="
+echo -e "${GREEN}Success!${NC}"
+echo ""
+echo "Downloaded: $OUTPUT_FILE"
+echo "Size: $FILE_SIZE"
+echo ""
+echo "The layer zip is ready to use with Dockerfile."
+echo "=================================================="

--- a/examples/aws_lambda_container/lambda_function.py
+++ b/examples/aws_lambda_container/lambda_function.py
@@ -1,0 +1,8 @@
+import json
+
+
+def lambda_handler(event, context):
+    return {
+        "statusCode": 200,
+        "body": json.dumps({"message": "Hello from Lambda!"}),
+    }


### PR DESCRIPTION
Adds an example for how to build a container image for AWS Lambda deployment with SolarWinds OpenTelemetry Collector extension, APM Python auto-instrumentation, and a simple Python function. Includes `download-layer.sh` helper to download APM Python from public ARN.