### PR TITLE
Narrow version ranges for urllib3, requests in image publish

### DIFF
--- a/image/requirements.txt
+++ b/image/requirements.txt
@@ -3,7 +3,8 @@ opentelemetry-api==1.41.1
 opentelemetry-sdk==1.41.1
 opentelemetry-instrumentation==0.62b1
 
-urllib3 < 2.7.0
+urllib3 >= 2.7.0, < 3.0.0
+requests >= 2.33.0, < 3.0
 # We don't use the otlp_proto_grpc option since gRPC is not appropriate for
 # injected auto-instrumentation, where it has a strict dependency on the OS / Python version the artifact is built for.
 opentelemetry-exporter-otlp-proto-http==1.41.1


### PR DESCRIPTION
Narrows version ranges for urllib3, requests in image publish to address several CVEs with older versions.

Depends on drop of py3.9 support in https://github.com/solarwinds/apm-python/pull/778