### PR TITLE
NH-138434 Add CodeQL check of GHA files

### DIFF
--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'python' ]
+        language: [ 'python', 'actions' ]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Adds CodeQL checking of GHA files in APM Python repo.

Example run: https://github.com/solarwinds/apm-python/actions/runs/26981557058/job/79621767352?pr=783