### PR TITLE
NH-136053 Set `max_export_batch_size=2000` for metrics

### DIFF
--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -224,6 +224,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
 
         for _, exporter_or_reader_class in exporters_or_readers.items():
             exporter_args = {
+                "max_export_batch_size": 2000,
                 "preferred_temporality": {
                     Counter: AggregationTemporality.DELTA,
                     UpDownCounter: AggregationTemporality.DELTA,
@@ -231,7 +232,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                     ObservableCounter: AggregationTemporality.DELTA,
                     ObservableUpDownCounter: AggregationTemporality.DELTA,
                     ObservableGauge: AggregationTemporality.DELTA,
-                }
+                },
             }
 
             if issubclass(exporter_or_reader_class, MetricReader):

--- a/solarwinds_apm/configurator.py
+++ b/solarwinds_apm/configurator.py
@@ -223,8 +223,7 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
         metric_readers = []
 
         for _, exporter_or_reader_class in exporters_or_readers.items():
-            exporter_args = {
-                "max_export_batch_size": 2000,
+            shared_metric_args = {
                 "preferred_temporality": {
                     Counter: AggregationTemporality.DELTA,
                     UpDownCounter: AggregationTemporality.DELTA,
@@ -237,13 +236,16 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
 
             if issubclass(exporter_or_reader_class, MetricReader):
                 metric_readers.append(
-                    exporter_or_reader_class(**exporter_args)
+                    exporter_or_reader_class(**shared_metric_args)
                 )
             elif self.apm_config.is_lambda:
                 # Inf interval to not invoke periodic collection
                 metric_readers.append(
                     PeriodicExportingMetricReader(
-                        exporter_or_reader_class(**exporter_args),
+                        exporter_or_reader_class(
+                            max_export_batch_size=2000,
+                            **shared_metric_args,
+                        ),
                         export_interval_millis=math.inf,
                     )
                 )
@@ -251,7 +253,10 @@ class SolarWindsConfigurator(_OTelSDKConfigurator):
                 # Use default interval 60s else OTEL_METRIC_EXPORT_INTERVAL
                 metric_readers.append(
                     PeriodicExportingMetricReader(
-                        exporter_or_reader_class(**exporter_args),
+                        exporter_or_reader_class(
+                            max_export_batch_size=2000,
+                            **shared_metric_args,
+                        ),
                     )
                 )
 

--- a/tests/unit/test_configurator/test_configurator_metrics_init.py
+++ b/tests/unit/test_configurator/test_configurator_metrics_init.py
@@ -107,6 +107,8 @@ class TestConfiguratorMetricsInit:
         )
         mock_exporter_spy.assert_called_once()
         _, kwargs = mock_exporter_spy.call_args
+        assert "max_export_batch_size" in kwargs
+        assert kwargs["max_export_batch_size"] == 2000
         assert "preferred_temporality" in kwargs
         assert kwargs["preferred_temporality"] == {
             mock_counter: mock_agg_temp.DELTA,
@@ -190,6 +192,8 @@ class TestConfiguratorMetricsInit:
         )
         mock_exporter_spy.assert_called_once()
         _, kwargs = mock_exporter_spy.call_args
+        assert "max_export_batch_size" in kwargs
+        assert kwargs["max_export_batch_size"] == 2000
         assert "preferred_temporality" in kwargs
         assert kwargs["preferred_temporality"] == {
             mock_counter: mock_agg_temp.DELTA,

--- a/tests/unit/test_configurator/test_configurator_metrics_init.py
+++ b/tests/unit/test_configurator/test_configurator_metrics_init.py
@@ -275,6 +275,7 @@ class TestConfiguratorMetricsInit:
         )
         mock_reader_spy.assert_called_once()
         _, kwargs = mock_reader_spy.call_args
+        assert "max_export_batch_size" not in kwargs
         assert "preferred_temporality" in kwargs
         assert kwargs["preferred_temporality"] == {
             mock_counter: mock_agg_temp.DELTA,
@@ -354,6 +355,7 @@ class TestConfiguratorMetricsInit:
         )
         mock_reader_spy.assert_called_once()
         _, kwargs = mock_reader_spy.call_args
+        assert "max_export_batch_size" not in kwargs
         assert "preferred_temporality" in kwargs
         assert kwargs["preferred_temporality"] == {
             mock_counter: mock_agg_temp.DELTA,


### PR DESCRIPTION
Set `max_export_batch_size=2000` for metrics export, to match JS and Java libraries.

See ticket for additional testing.