### PR TITLE
Fix Dependabot updater

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,19 +2,6 @@ version: 2
 
 updates:
 - package-ecosystem: pip
-  directory: "/lambda/tests"
-  schedule:
-    interval: weekly
-
-  groups:
-    otel-dependencies:
-      patterns:
-        - "opentelemetry-*"
-      update-types:
-        - minor
-        - patch
-
-- package-ecosystem: pip
   directory: "/"
   schedule:
     interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,8 +28,6 @@ updates:
         - patch
 
     misc:
-      exclude-patterns:
-        - "opentelemetry-*"
       update-types:
         - minor
         - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,8 @@ updates:
         - patch
 
     misc:
+      exclude-patterns:
+        - "opentelemetry-*"
       update-types:
         - minor
         - patch


### PR DESCRIPTION
Dependabot failed to create two `pip` PRs for OTel last month, i.e. only [this one](https://github.com/solarwinds/apm-python/pull/769) when we'd expect two like [lambda](https://github.com/solarwinds/apm-python/pull/760) and ["all else"](https://github.com/solarwinds/apm-python/pull/761). The config seems complicated and should work with only one `package-ecosystem: pip` for `directory: "/"` anyway, right? So removed one if only one for `pip` actually gets picked up.