### PR TITLE
Potential fix for code scanning alert no. 465: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_tox_tests.yaml
+++ b/.github/workflows/run_tox_tests.yaml
@@ -6,6 +6,9 @@
 
 name: Run tox tests
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/solarwinds/apm-python/security/code-scanning/465](https://github.com/solarwinds/apm-python/security/code-scanning/465)

Add an explicit top-level `permissions` block in `.github/workflows/run_tox_tests.yaml` so all jobs in this workflow get least-privilege token access by default.

Best minimal fix (no functionality change):
- Insert at workflow root (after `name` is a good location):
  - `permissions:`
  - `contents: read`

Why this works:
- `actions/checkout` needs `contents: read`.
- No shown step requires write permissions.
- Applying it at root covers current and future jobs unless overridden.

No imports, methods, or additional definitions are needed (YAML workflow edit only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
