### PR TITLE
Potential fix for code scanning alert no. 452: Unused import

### DIFF
--- a/tests/unit/test_configurator/test_configurator_configure_otel.py
+++ b/tests/unit/test_configurator/test_configurator_configure_otel.py
@@ -5,7 +5,6 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 import logging
-import os
 import pytest
 import uuid
 


### PR DESCRIPTION
Potential fix for [https://github.com/solarwinds/apm-python/security/code-scanning/452](https://github.com/solarwinds/apm-python/security/code-scanning/452)

To fix an unused import, remove the specific import statement that is never referenced.

In `tests/unit/test_configurator/test_configurator_configure_otel.py`, delete `import os` from the top import section (line 8 in the provided snippet). This is the minimal and best fix because it does not alter runtime behavior or test logic—only removes dead code. No additional methods, definitions, or new imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
