### PR TITLE
NH-140499 Add new `service_instance` resource detector to APM Python defaults

### DIFF
--- a/solarwinds_apm/apm_constants.py
+++ b/solarwinds_apm/apm_constants.py
@@ -26,7 +26,10 @@ INTL_SWO_DEFAULT_PROPAGATORS = [
     INTL_SWO_PROPAGATOR,
     INTL_SWO_BAGGAGE_PROPAGATOR,
 ]
+# service_instance is first to set fallback/"default" UUID,
+# instead of being appended by SDK for highest merge priority
 INTL_SWO_DEFAULT_RESOURCE_DETECTORS = [
+    "service_instance",
     "process",
     "os",
     "host",
@@ -41,6 +44,7 @@ INTL_SWO_DEFAULT_RESOURCE_DETECTORS = [
     "uams",
 ]
 INTL_SWO_DEFAULT_RESOURCE_DETECTORS_LAMBDA = [
+    "service_instance",
     "process",
     "os",
     "host",

--- a/solarwinds_apm/apm_resource.py
+++ b/solarwinds_apm/apm_resource.py
@@ -8,8 +8,6 @@
 
 from __future__ import annotations
 
-import uuid
-
 from opentelemetry.sdk.resources import Resource
 
 from solarwinds_apm.version import __version__
@@ -22,7 +20,7 @@ def create_detector_resource() -> Resource:
     Should be called after SolarWindsDistro has configured default detector list.
 
     Returns:
-        Resource: Resource with attributes from process, OS, cloud, k8s, etc. detectors.
+        Resource: Resource with attributes from service_instance, process, OS, cloud, k8s, etc. detectors.
     """
     return Resource.create()
 
@@ -54,10 +52,5 @@ def create_apm_resource(
     # This preserves all detector attributes (cloud.*, k8s.*, etc.) while ensuring
     # service.name (calculated via precedence) overrides any service.name from detectors.
     apm_resource = detector_resource.merge(Resource(sw_attributes))
-
-    if "service.instance.id" not in apm_resource.attributes:
-        apm_resource = apm_resource.merge(
-            Resource({"service.instance.id": str(uuid.uuid4())})
-        )
 
     return apm_resource

--- a/solarwinds_apm/apm_resource.py
+++ b/solarwinds_apm/apm_resource.py
@@ -31,8 +31,7 @@ def create_apm_resource(
 ) -> Resource:
     """Create final APM Resource by merging SolarWinds attributes into detector resource.
 
-    Adds sw.apm.version, sw.data.module, service.name,
-    and service.instance.id (if not already present from detectors).
+    Adds sw.apm.version, sw.data.module, and service.name.
 
     Args:
         detector_resource: Resource from detectors with all their attributes.

--- a/tests/integration/test_service_instance_id.py
+++ b/tests/integration/test_service_instance_id.py
@@ -17,7 +17,13 @@ class TestServiceInstanceIdPrecedence1ResourceAttributes(TestBaseSwHeadersAndAtt
 
     def setUp(self):
         os.environ["OTEL_RESOURCE_ATTRIBUTES"] = "service.instance.id=resource-attr-instance-123"
+        # Set a full Azure App Service environment so the azure_app_service detector is active.
+        os.environ["WEBSITE_SITE_NAME"] = "my-azure-app"
+        os.environ["WEBSITE_RESOURCE_GROUP"] = "prod-rg"
+        os.environ["WEBSITE_OWNER_NAME"] = "subscription-id+webspace-name"
         os.environ["WEBSITE_INSTANCE_ID"] = "azure-instance-456"
+        os.environ["WEBSITE_SLOT_NAME"] = "staging"
+        os.environ["REGION_NAME"] = "eastus"
         super().setUp()
 
     def tearDown(self):

--- a/tests/integration/test_service_instance_id.py
+++ b/tests/integration/test_service_instance_id.py
@@ -187,6 +187,6 @@ class TestServiceInstanceIdWithCustomDetectors(TestBaseSwHeadersAndAttributes):
             try:
                 uuid.UUID(instance_id)
                 is_valid_uuid = True
-            except (ValueError, AttributeError):
+            except (ValueError, TypeError, AttributeError):
                 is_valid_uuid = False
             assert is_valid_uuid, f"service.instance.id '{instance_id}' is not a valid UUID"

--- a/tests/integration/test_service_instance_id.py
+++ b/tests/integration/test_service_instance_id.py
@@ -62,8 +62,8 @@ class TestServiceInstanceIdPrecedence1ResourceAttributes(TestBaseSwHeadersAndAtt
             ],
         ):
             resource = self.configurator.apm_config.resource
+            assert resource.attributes.get("cloud.provider") == "azure"
             assert resource.attributes["service.instance.id"] == "resource-attr-instance-123"
-
 
 class TestServiceInstanceIdPrecedence2AzureAppService(TestBaseSwHeadersAndAttributes):
     """Test that Azure App Service WEBSITE_INSTANCE_ID overrides UUID fallback."""

--- a/tests/integration/test_service_instance_id.py
+++ b/tests/integration/test_service_instance_id.py
@@ -28,7 +28,12 @@ class TestServiceInstanceIdPrecedence1ResourceAttributes(TestBaseSwHeadersAndAtt
 
     def tearDown(self):
         os.environ.pop("OTEL_RESOURCE_ATTRIBUTES", None)
+        os.environ.pop("WEBSITE_SITE_NAME", None)
+        os.environ.pop("WEBSITE_RESOURCE_GROUP", None)
+        os.environ.pop("WEBSITE_OWNER_NAME", None)
         os.environ.pop("WEBSITE_INSTANCE_ID", None)
+        os.environ.pop("WEBSITE_SLOT_NAME", None)
+        os.environ.pop("REGION_NAME", None)
         super().tearDown()
 
     def test_resource_attributes_over_azure_detector(self):

--- a/tests/integration/test_service_instance_id.py
+++ b/tests/integration/test_service_instance_id.py
@@ -1,0 +1,192 @@
+# © 2026 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+import os
+import time
+import uuid
+from unittest import mock
+
+from .test_base_sw_headers_attrs import TestBaseSwHeadersAndAttributes
+
+
+class TestServiceInstanceIdPrecedence1ResourceAttributes(TestBaseSwHeadersAndAttributes):
+    """Test that OTEL_RESOURCE_ATTRIBUTES service.instance.id has highest priority."""
+
+    def setUp(self):
+        os.environ["OTEL_RESOURCE_ATTRIBUTES"] = "service.instance.id=resource-attr-instance-123"
+        os.environ["WEBSITE_INSTANCE_ID"] = "azure-instance-456"
+        super().setUp()
+
+    def tearDown(self):
+        os.environ.pop("OTEL_RESOURCE_ATTRIBUTES", None)
+        os.environ.pop("WEBSITE_INSTANCE_ID", None)
+        super().tearDown()
+
+    def test_resource_attributes_over_azure_detector(self):
+        timestamp = int(time.time())
+        with mock.patch(
+            target="solarwinds_apm.oboe.json_sampler.JsonSampler._read",
+            return_value=[
+                {
+                    "arguments": {
+                        "BucketCapacity": 2,
+                        "BucketRate": 1,
+                        "MetricsFlushInterval": 60,
+                        "SignatureKey": "",
+                        "TriggerRelaxedBucketCapacity": 4,
+                        "TriggerRelaxedBucketRate": 3,
+                        "TriggerStrictBucketCapacity": 6,
+                        "TriggerStrictBucketRate": 5,
+                    },
+                    "flags": "SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE",
+                    "layer": "",
+                    "timestamp": timestamp,
+                    "ttl": 120,
+                    "type": 0,
+                    "value": 1000000,
+                }
+            ],
+        ):
+            resource = self.configurator.apm_config.resource
+            assert resource.attributes["service.instance.id"] == "resource-attr-instance-123"
+
+
+class TestServiceInstanceIdPrecedence2AzureAppService(TestBaseSwHeadersAndAttributes):
+    """Test that Azure App Service WEBSITE_INSTANCE_ID overrides UUID fallback."""
+
+    def setUp(self):
+        os.environ["WEBSITE_INSTANCE_ID"] = "azure-app-instance-abc123"
+        os.environ["WEBSITE_SITE_NAME"] = "my-azure-app"
+        os.environ["WEBSITE_RESOURCE_GROUP"] = "prod-rg"
+        super().setUp()
+
+    def tearDown(self):
+        os.environ.pop("WEBSITE_INSTANCE_ID", None)
+        os.environ.pop("WEBSITE_SITE_NAME", None)
+        os.environ.pop("WEBSITE_RESOURCE_GROUP", None)
+        super().tearDown()
+
+    def test_azure_app_service_instance_id_over_uuid(self):
+        timestamp = int(time.time())
+        with mock.patch(
+            target="solarwinds_apm.oboe.json_sampler.JsonSampler._read",
+            return_value=[
+                {
+                    "arguments": {
+                        "BucketCapacity": 2,
+                        "BucketRate": 1,
+                        "MetricsFlushInterval": 60,
+                        "SignatureKey": "",
+                        "TriggerRelaxedBucketCapacity": 4,
+                        "TriggerRelaxedBucketRate": 3,
+                        "TriggerStrictBucketCapacity": 6,
+                        "TriggerStrictBucketRate": 5,
+                    },
+                    "flags": "SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE",
+                    "layer": "",
+                    "timestamp": timestamp,
+                    "ttl": 120,
+                    "type": 0,
+                    "value": 1000000,
+                }
+            ],
+        ):
+            resource = self.configurator.apm_config.resource
+            assert resource.attributes["service.instance.id"] == "azure-app-instance-abc123"
+
+
+class TestServiceInstanceIdPrecedence4UUIDFallback(TestBaseSwHeadersAndAttributes):
+    """Test that non-platform environments get UUID from ServiceInstanceIdResourceDetector."""
+
+    def setUp(self):
+        # No Azure nor AWS environment variables
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+
+    def test_uuid_fallback_in_non_platform_environment(self):
+        timestamp = int(time.time())
+        with mock.patch(
+            target="solarwinds_apm.oboe.json_sampler.JsonSampler._read",
+            return_value=[
+                {
+                    "arguments": {
+                        "BucketCapacity": 2,
+                        "BucketRate": 1,
+                        "MetricsFlushInterval": 60,
+                        "SignatureKey": "",
+                        "TriggerRelaxedBucketCapacity": 4,
+                        "TriggerRelaxedBucketRate": 3,
+                        "TriggerStrictBucketCapacity": 6,
+                        "TriggerStrictBucketRate": 5,
+                    },
+                    "flags": "SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE",
+                    "layer": "",
+                    "timestamp": timestamp,
+                    "ttl": 120,
+                    "type": 0,
+                    "value": 1000000,
+                }
+            ],
+        ):
+            resource = self.configurator.apm_config.resource
+            assert "service.instance.id" in resource.attributes
+            instance_id = resource.attributes["service.instance.id"]
+            try:
+                uuid.UUID(instance_id)
+                is_valid_uuid = True
+            except (ValueError, AttributeError):
+                is_valid_uuid = False
+            assert is_valid_uuid, f"service.instance.id '{instance_id}' is not a valid UUID"
+
+
+class TestServiceInstanceIdWithCustomDetectors(TestBaseSwHeadersAndAttributes):
+    """Test service.instance.id with custom OTEL_EXPERIMENTAL_RESOURCE_DETECTORS that excludes service_instance."""
+
+    def setUp(self):
+        # Custom detector list WITHOUT service_instance - SDK should auto-append it
+        os.environ["OTEL_EXPERIMENTAL_RESOURCE_DETECTORS"] = "process,os"
+        super().setUp()
+
+    def tearDown(self):
+        os.environ.pop("OTEL_EXPERIMENTAL_RESOURCE_DETECTORS", None)
+        super().tearDown()
+
+    def test_sdk_auto_appends_service_instance_detector(self):
+        timestamp = int(time.time())
+        with mock.patch(
+            target="solarwinds_apm.oboe.json_sampler.JsonSampler._read",
+            return_value=[
+                {
+                    "arguments": {
+                        "BucketCapacity": 2,
+                        "BucketRate": 1,
+                        "MetricsFlushInterval": 60,
+                        "SignatureKey": "",
+                        "TriggerRelaxedBucketCapacity": 4,
+                        "TriggerRelaxedBucketRate": 3,
+                        "TriggerStrictBucketCapacity": 6,
+                        "TriggerStrictBucketRate": 5,
+                    },
+                    "flags": "SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE",
+                    "layer": "",
+                    "timestamp": timestamp,
+                    "ttl": 120,
+                    "type": 0,
+                    "value": 1000000,
+                }
+            ],
+        ):
+            resource = self.configurator.apm_config.resource
+            assert "service.instance.id" in resource.attributes
+            instance_id = resource.attributes["service.instance.id"]
+            try:
+                uuid.UUID(instance_id)
+                is_valid_uuid = True
+            except (ValueError, AttributeError):
+                is_valid_uuid = False
+            assert is_valid_uuid, f"service.instance.id '{instance_id}' is not a valid UUID"

--- a/tests/integration/test_service_instance_id.py
+++ b/tests/integration/test_service_instance_id.py
@@ -139,7 +139,7 @@ class TestServiceInstanceIdPrecedence4UUIDFallback(TestBaseSwHeadersAndAttribute
             try:
                 uuid.UUID(instance_id)
                 is_valid_uuid = True
-            except (ValueError, AttributeError):
+            except (ValueError, TypeError, AttributeError):
                 is_valid_uuid = False
             assert is_valid_uuid, f"service.instance.id '{instance_id}' is not a valid UUID"
 

--- a/tests/unit/test_apm_resource.py
+++ b/tests/unit/test_apm_resource.py
@@ -104,6 +104,8 @@ class TestCreateApmResource:
         attrs = result.attributes
         assert "service.instance.id" in attrs
         # Should be a UUID string (36 chars with dashes)
+        # service_instance resource detector is always built by SDK
+        # but order in which it's built/run can be configured
         instance_id = attrs["service.instance.id"]
         assert isinstance(instance_id, str)
         assert len(instance_id) == 36


### PR DESCRIPTION
Adds new `service_instance` resource detector to APM Python defaults, as first on the list to be the default/fallback if no Azure/Lambda/etc-specific values are available. It is already part of OTel SDK as of 1.43.0/0.64b0, so no new dependencies needed.

Removes our custom writing of `service.instance.id` as a random uuid4 fallback. Even if `service_instance` isn't on the configured detector list, [OTel SDK will still build it](https://github.com/open-telemetry/opentelemetry-python/blob/9810f7acf385aa32e53cf3d02e7421615b9889e8/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py#L532) as 2nd-last by default.

Adds some integration tests around configuration precedence of setting `service.instance.id`.