### PR TITLE
NH-125600 Add `ServiceEntrySpanProcessor._on_ending` implementation to reduce overall name pool registrations

### DIFF
--- a/solarwinds_apm/api/__init__.py
+++ b/solarwinds_apm/api/__init__.py
@@ -14,11 +14,10 @@ from opentelemetry.trace import NoOpTracerProvider, get_tracer_provider
 from solarwinds_apm.apm_constants import (
     INTL_SWO_OTEL_CONTEXT_ENTRY_SPAN,
     INTL_SWO_TRANSACTION_ATTR_KEY,
+    INTL_SWO_TRANSACTION_ATTR_MAX,
 )
-from solarwinds_apm.oboe import get_transaction_name_pool
 from solarwinds_apm.oboe.http_sampler import HttpSampler
 from solarwinds_apm.oboe.json_sampler import JsonSampler
-from solarwinds_apm.oboe.transaction_name_pool import TRANSACTION_NAME_DEFAULT
 from solarwinds_apm.sampler import ParentBasedSwSampler
 from solarwinds_apm.tracer_provider import SolarwindsTracerProvider
 from solarwinds_apm.w3c_transformer import W3CTransformer
@@ -82,19 +81,11 @@ def set_transaction_name(custom_name: str) -> bool:
         custom_name,
     )
 
-    # check limit pool; set as "other" if reached and log debug/warning
-    pool = get_transaction_name_pool()
-    registered_name = pool.registered(custom_name)
-    if registered_name == TRANSACTION_NAME_DEFAULT:
-        logger.warning(
-            "Transaction name pool is full; set as %s for span %s",
-            TRANSACTION_NAME_DEFAULT,
-            W3CTransformer.trace_and_span_id_from_context(
-                current_trace_entry_span.context
-            ),
-        )
+    # Set transaction name attribute (will be finalized via pool in _on_ending)
+    # Truncate to max length
     current_trace_entry_span.set_attribute(
-        INTL_SWO_TRANSACTION_ATTR_KEY, registered_name
+        INTL_SWO_TRANSACTION_ATTR_KEY,
+        custom_name[:INTL_SWO_TRANSACTION_ATTR_MAX],
     )
     return True
 

--- a/solarwinds_apm/api/__init__.py
+++ b/solarwinds_apm/api/__init__.py
@@ -34,7 +34,7 @@ def set_transaction_name(custom_name: str) -> bool:
     Takes precedence over transaction_name set in environment variable or config file.
 
     Any uppercase to lowercase conversions or special character replacements
-    are done by the platform. Name length is limited to 256 characters;
+    are done by the platform. Name length is limited to 255 characters;
     anything longer is truncated by APM library.
 
     Parameters:

--- a/solarwinds_apm/trace/serviceentry_processor.py
+++ b/solarwinds_apm/trace/serviceentry_processor.py
@@ -33,8 +33,6 @@ from solarwinds_apm.w3c_transformer import W3CTransformer
 if TYPE_CHECKING:
     from opentelemetry.sdk.trace import ReadableSpan
 
-    from solarwinds_apm.oboe.transaction_name_pool import TransactionNamePool
-
 logger = logging.getLogger(__name__)
 
 
@@ -55,30 +53,27 @@ class ServiceEntrySpanProcessor(SpanProcessor):
     def set_default_transaction_name(
         self,
         span: Span,
-        pool: TransactionNamePool,
         attribute_value: str,
         resolve: bool = False,
     ) -> None:
         """
-        Register transaction name in pool and set as span attribute.
+        Set initial transaction name as span attribute.
+
+        Pool registration is deferred to _on_ending() for all transaction names.
 
         Parameters:
         span (Span): The span to set the transaction name on.
-        pool (TransactionNamePool): The transaction name pool for registration.
-        attribute_value (str): The transaction name value to register.
+        attribute_value (str): The transaction name value.
         resolve (bool): Whether to resolve the transaction name (e.g., for URL paths). Defaults to False.
         """
         transaction_name = attribute_value
         if resolve:
             transaction_name = resolve_transaction_name(attribute_value)
-        registered_name = pool.registered(transaction_name)
-        if registered_name == TRANSACTION_NAME_DEFAULT:
-            logger.warning(
-                "Transaction name pool is full; set as %s for span %s",
-                TRANSACTION_NAME_DEFAULT,
-                W3CTransformer.trace_and_span_id_from_context(span.context),
-            )
-        span.set_attribute(INTL_SWO_TRANSACTION_ATTR_KEY, registered_name)
+        # Set attribute without pool registration (finalized in _on_ending)
+        span.set_attribute(
+            INTL_SWO_TRANSACTION_ATTR_KEY,
+            transaction_name[:INTL_SWO_TRANSACTION_ATTR_MAX],
+        )
 
     def on_start(
         self,
@@ -114,31 +109,26 @@ class ServiceEntrySpanProcessor(SpanProcessor):
 
         # Calculate non-custom txn name for entry span if we can retrieve the URL
         # or serverless name. Otherwise, use the span's name
-        pool = get_transaction_name_pool()
-
         sw_apm_txn_name = os.environ.get("SW_APM_TRANSACTION_NAME", None)
         faas_name = span.attributes.get(ResourceAttributes.FAAS_NAME, None)
         lambda_function_name = os.environ.get("AWS_LAMBDA_FUNCTION_NAME", None)
         http_route = span.attributes.get(SpanAttributes.HTTP_ROUTE, None)
         url_path = span.attributes.get(SpanAttributes.URL_PATH, None)
         if sw_apm_txn_name:
-            self.set_default_transaction_name(span, pool, sw_apm_txn_name)
+            self.set_default_transaction_name(span, sw_apm_txn_name)
         elif faas_name:
-            self.set_default_transaction_name(span, pool, faas_name)
+            self.set_default_transaction_name(span, faas_name)
         elif lambda_function_name:
             self.set_default_transaction_name(
                 span,
-                pool,
                 lambda_function_name[:INTL_SWO_TRANSACTION_ATTR_MAX],
             )
         elif http_route:
-            self.set_default_transaction_name(span, pool, http_route)
+            self.set_default_transaction_name(span, http_route)
         elif url_path:
-            self.set_default_transaction_name(
-                span, pool, url_path, resolve=True
-            )
+            self.set_default_transaction_name(span, url_path, resolve=True)
         else:
-            self.set_default_transaction_name(span, pool, span.name)
+            self.set_default_transaction_name(span, span.name)
 
         # Cache the entry span in current context to use upstream-managed
         # execution scope and handle async tracing, for custom naming
@@ -163,6 +153,42 @@ class ServiceEntrySpanProcessor(SpanProcessor):
             entry_trace_span_id,
         )
         self.context_tokens[entry_trace_span_id] = token
+
+    def _on_ending(self, span: Span) -> None:
+        """
+        Finalize transaction name by registering with pool.
+
+        This is called before the span becomes immutable, allowing us to update
+        the transaction name attribute with the pool-registered version.
+        Processes all transaction names (both initial and user-set via set_transaction_name).
+
+        Parameters:
+        span (Span): The span that is ending (still mutable).
+        """
+        # Only process entry spans
+        parent_span_context = span.parent
+        if (
+            parent_span_context
+            and parent_span_context.is_valid
+            and not parent_span_context.is_remote
+        ):
+            return
+
+        # Read whatever transaction name is set (initial OR user-set)
+        txn_name = span.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+        if txn_name:
+            pool = get_transaction_name_pool()
+            registered_name = pool.registered(txn_name)
+            if registered_name == TRANSACTION_NAME_DEFAULT:
+                logger.warning(
+                    "Transaction name pool is full; set as %s for span %s",
+                    TRANSACTION_NAME_DEFAULT,
+                    W3CTransformer.trace_and_span_id_from_context(
+                        span.context
+                    ),
+                )
+            # Update with pool-registered name
+            span.set_attribute(INTL_SWO_TRANSACTION_ATTR_KEY, registered_name)
 
     def on_end(self, span: ReadableSpan) -> None:
         """

--- a/solarwinds_apm/trace/serviceentry_processor.py
+++ b/solarwinds_apm/trace/serviceentry_processor.py
@@ -90,7 +90,7 @@ class ServiceEntrySpanProcessor(SpanProcessor):
         3. AWS_LAMBDA_FUNCTION_NAME
         4. Any instrumentor-set span attributes for HTTP
         5. Span name (default)
-        6. "other" (when the transaction name pool limit reached)
+        6. "other" (when the transaction name pool limit reached at span _on_ending)
 
         If entry span, caches it in context for custom transaction naming.
 
@@ -159,8 +159,11 @@ class ServiceEntrySpanProcessor(SpanProcessor):
         Finalize transaction name by registering with pool.
 
         This is called before the span becomes immutable, allowing us to update
-        the transaction name attribute with the pool-registered version.
-        Processes all transaction names (both initial and user-set via set_transaction_name).
+        the transaction name attribute with the final pool-registered version.
+
+        See span on_start for order of precendence for transaction name setting.
+        If transaction name pool limit is reached here at _on_ending, then
+        name is set here as "other".
 
         Parameters:
         span (Span): The span that is ending (still mutable).

--- a/tests/integration/test_base_sw_headers_attrs.py
+++ b/tests/integration/test_base_sw_headers_attrs.py
@@ -15,8 +15,10 @@ from werkzeug.wrappers import Response
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.flask import FlaskInstrumentor
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
+from opentelemetry.metrics import set_meter_provider
 from opentelemetry.propagate import get_global_textmap
 from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 from opentelemetry.sdk.trace import TracerProvider, export
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
@@ -124,7 +126,9 @@ class TestBaseSwHeadersAndAttributes(TestBase):
         reset_trace_globals()
         reset_metrics_globals()
         # Init parent-based with JsonSampler to guarantee sampling decision for tests
-        self.meter_provider = MeterProvider()
+        self.metric_reader = InMemoryMetricReader()
+        self.meter_provider = MeterProvider(metric_readers=[self.metric_reader])
+        set_meter_provider(self.meter_provider)
         sampler_configuration = SolarWindsApmConfig.to_configuration(apm_config)
         json_sampler = JsonSampler(
             self.meter_provider,

--- a/tests/integration/test_set_transaction_name.py
+++ b/tests/integration/test_set_transaction_name.py
@@ -22,6 +22,9 @@ from werkzeug.serving import make_server
 
 from solarwinds_apm.api import set_transaction_name
 from solarwinds_apm.apm_constants import INTL_SWO_TRANSACTION_ATTR_KEY
+from solarwinds_apm.trace.response_time_processor import (
+    ResponseTimeProcessor,
+)
 from solarwinds_apm.trace.serviceentry_processor import (
     ServiceEntrySpanProcessor,
 )
@@ -37,6 +40,27 @@ class TestSetTransactionNameBasic(TestBaseSwHeadersAndAttributes):
     def setUp(self):
         super().setUp()
         self.tracer_provider.add_span_processor(ServiceEntrySpanProcessor())
+        self.tracer_provider.add_span_processor(
+            ResponseTimeProcessor(self.configurator.apm_config)
+        )
+
+    def _get_metrics_for_transaction(self, transaction_name):
+        """Helper to get metrics data filtered by transaction name"""
+        self.metric_reader.collect()
+        metrics_data = self.metric_reader.get_metrics_data()
+        if not metrics_data or not metrics_data.resource_metrics:
+            return []
+        
+        matching_data_points = []
+        for resource_metric in metrics_data.resource_metrics:
+            for scope_metric in resource_metric.scope_metrics:
+                for metric in scope_metric.metrics:
+                    if metric.name == "trace.service.response_time":
+                        for data_point in metric.data.data_points:
+                            txn = data_point.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                            if txn == transaction_name:
+                                matching_data_points.append(data_point)
+        return matching_data_points
 
     def _setup_endpoints(self):
         """Set up test routes before Flask instrumentation"""
@@ -101,6 +125,11 @@ class TestSetTransactionNameBasic(TestBaseSwHeadersAndAttributes):
                 == "custom-name"
             )
 
+            # Verify metrics also have correct transaction name
+            metrics = self._get_metrics_for_transaction("custom-name")
+            assert len(metrics) == 1
+            assert metrics[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-name"
+
     def test_multiple_calls_last_wins(self):
         """Test multiple calls to set_transaction_name, last one wins"""
         timestamp = int(time.time())
@@ -145,6 +174,11 @@ class TestSetTransactionNameBasic(TestBaseSwHeadersAndAttributes):
                 == "second"
             )
 
+            # Verify metrics also have correct transaction name
+            metrics = self._get_metrics_for_transaction("second")
+            assert len(metrics) == 1
+            assert metrics[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "second"
+
 
 class TestSetTransactionNameEdgeCases(TestBaseSwHeadersAndAttributes):
     """Edge case tests for set_transaction_name()"""
@@ -152,6 +186,27 @@ class TestSetTransactionNameEdgeCases(TestBaseSwHeadersAndAttributes):
     def setUp(self):
         super().setUp()
         self.tracer_provider.add_span_processor(ServiceEntrySpanProcessor())
+        self.tracer_provider.add_span_processor(
+            ResponseTimeProcessor(self.configurator.apm_config)
+        )
+
+    def _get_metrics_for_transaction(self, transaction_name):
+        """Helper to get metrics data filtered by transaction name"""
+        self.metric_reader.collect()
+        metrics_data = self.metric_reader.get_metrics_data()
+        if not metrics_data or not metrics_data.resource_metrics:
+            return []
+        
+        matching_data_points = []
+        for resource_metric in metrics_data.resource_metrics:
+            for scope_metric in resource_metric.scope_metrics:
+                for metric in scope_metric.metrics:
+                    if metric.name == "trace.service.response_time":
+                        for data_point in metric.data.data_points:
+                            txn = data_point.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                            if txn == transaction_name:
+                                matching_data_points.append(data_point)
+        return matching_data_points
 
     def _setup_endpoints(self):
         """Set up test routes before Flask instrumentation"""
@@ -222,6 +277,11 @@ class TestSetTransactionNameEdgeCases(TestBaseSwHeadersAndAttributes):
             assert txn_name != ""
             assert txn_name == "/test_empty_string/"
 
+            # Verify metrics also have correct transaction name
+            metrics = self._get_metrics_for_transaction("/test_empty_string/")
+            assert len(metrics) == 1
+            assert metrics[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "/test_empty_string/"
+
     def test_none_value_rejected(self):
         """Test None value is rejected and original name preserved"""
         timestamp = int(time.time())
@@ -268,6 +328,11 @@ class TestSetTransactionNameEdgeCases(TestBaseSwHeadersAndAttributes):
                 "test_none_value" in txn_name
                 or txn_name == "/test_none_value/"
             )
+
+            # Verify metrics also have correct transaction name
+            metrics = self._get_metrics_for_transaction(txn_name)
+            assert len(metrics) == 1
+            assert metrics[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == txn_name
 
     def test_no_active_span_returns_false(self):
         """Test calling set_transaction_name outside request context
@@ -321,6 +386,11 @@ class TestSetTransactionNameEdgeCases(TestBaseSwHeadersAndAttributes):
             assert len(txn_name) == 256
             assert txn_name == "a" * 256
 
+            # Verify metrics also have correct transaction name
+            metrics = self._get_metrics_for_transaction(txn_name)
+            assert len(metrics) == 1
+            assert metrics[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == txn_name
+
 
 class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
     """Distributed trace tests for set_transaction_name()
@@ -332,6 +402,9 @@ class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
     def setUp(self):
         super().setUp()
         self.tracer_provider.add_span_processor(ServiceEntrySpanProcessor())
+        self.tracer_provider.add_span_processor(
+            ResponseTimeProcessor(self.configurator.apm_config)
+        )
 
         # Set up a second app in addition to self.app
         # Should be done before service_a set up with call to this one
@@ -370,6 +443,24 @@ class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
         self.server.shutdown()
         self.server_thread.join(timeout=1)
         super().tearDown()
+
+    def _get_metrics_for_transaction(self, transaction_name):
+        """Helper to get metrics data filtered by transaction name"""
+        self.metric_reader.collect()
+        metrics_data = self.metric_reader.get_metrics_data()
+        if not metrics_data or not metrics_data.resource_metrics:
+            return []
+        
+        matching_data_points = []
+        for resource_metric in metrics_data.resource_metrics:
+            for scope_metric in resource_metric.scope_metrics:
+                for metric in scope_metric.metrics:
+                    if metric.name == "trace.service.response_time":
+                        for data_point in metric.data.data_points:
+                            txn = data_point.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                            if txn == transaction_name:
+                                matching_data_points.append(data_point)
+        return matching_data_points
 
     def _setup_endpoints(self):
         """Set up test routes before Flask instrumentation"""
@@ -455,6 +546,15 @@ class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
                 == "custom-service-a"
             )
 
+            # Verify metrics also have correct transaction names
+            metrics_a = self._get_metrics_for_transaction("custom-service-a")
+            assert len(metrics_a) == 1
+            assert metrics_a[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-service-a"
+            
+            metrics_b = self._get_metrics_for_transaction("custom-service-b")
+            assert len(metrics_b) == 1
+            assert metrics_b[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-service-b"
+
     def test_custom_names_across_more_complex_traces(self):
         """Test custom names work correctly when manual spans are created with OTel SDK
 
@@ -515,3 +615,12 @@ class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
             assert manual_spans[1].name == "manual-outer-b"
             assert manual_spans[2].name == "manual-inner-a"
             assert manual_spans[3].name == "manual-outer-a"
+
+            # Verify metrics also have correct transaction names
+            metrics_a = self._get_metrics_for_transaction("custom-service-a")
+            assert len(metrics_a) == 1
+            assert metrics_a[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-service-a"
+            
+            metrics_b = self._get_metrics_for_transaction("custom-service-b")
+            assert len(metrics_b) == 1
+            assert metrics_b[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-service-b"

--- a/tests/integration/test_set_transaction_name.py
+++ b/tests/integration/test_set_transaction_name.py
@@ -1,8 +1,15 @@
 # © 2026 SolarWinds Worldwide, LLC. All rights reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
 
 import threading
 import time
@@ -15,9 +22,13 @@ from werkzeug.serving import make_server
 
 from solarwinds_apm.api import set_transaction_name
 from solarwinds_apm.apm_constants import INTL_SWO_TRANSACTION_ATTR_KEY
-from solarwinds_apm.trace.serviceentry_processor import ServiceEntrySpanProcessor
+from solarwinds_apm.trace.serviceentry_processor import (
+    ServiceEntrySpanProcessor,
+)
 
-from .test_base_sw_headers_attrs import TestBaseSwHeadersAndAttributes
+from .test_base_sw_headers_attrs import (
+    TestBaseSwHeadersAndAttributes,
+)
 
 
 class TestSetTransactionNameBasic(TestBaseSwHeadersAndAttributes):
@@ -30,22 +41,24 @@ class TestSetTransactionNameBasic(TestBaseSwHeadersAndAttributes):
     def _setup_endpoints(self):
         """Set up test routes before Flask instrumentation"""
         super()._setup_endpoints()
-        
+
         def route_single_call():
             set_transaction_name("custom-name")
             return "ok"
-        
+
         def route_multiple_calls():
             set_transaction_name("first")
             set_transaction_name("second")
             return "ok"
-        
+
         # pylint: disable=no-member
         self.app.route("/test_single_call/")(route_single_call)
         self.app.route("/test_multiple_calls/")(route_multiple_calls)
 
     def test_single_call_sets_attribute(self):
-        """Test that single call to set_transaction_name sets sw.transaction attribute"""
+        """Test single call to set_transaction_name sets
+        sw.transaction attribute
+        """
         timestamp = int(time.time())
         with mock.patch(
             target="solarwinds_apm.oboe.json_sampler.JsonSampler._read",
@@ -75,15 +88,21 @@ class TestSetTransactionNameBasic(TestBaseSwHeadersAndAttributes):
             spans = self.memory_exporter.get_finished_spans()
             assert len(spans) > 0
             entry_spans = [
-                s for s in spans 
-                if not (s.parent and s.parent.is_valid and not s.parent.is_remote)
+                s
+                for s in spans
+                if not (
+                    s.parent and s.parent.is_valid and not s.parent.is_remote
+                )
             ]
             assert len(entry_spans) == 1
             entry_span = entry_spans[0]
-            assert entry_span.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-name"
+            assert (
+                entry_span.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                == "custom-name"
+            )
 
     def test_multiple_calls_last_wins(self):
-        """Test that multiple calls to set_transaction_name, last one wins"""
+        """Test multiple calls to set_transaction_name, last one wins"""
         timestamp = int(time.time())
         with mock.patch(
             target="solarwinds_apm.oboe.json_sampler.JsonSampler._read",
@@ -113,12 +132,18 @@ class TestSetTransactionNameBasic(TestBaseSwHeadersAndAttributes):
             spans = self.memory_exporter.get_finished_spans()
             assert len(spans) > 0
             entry_spans = [
-                s for s in spans 
-                if not (s.parent and s.parent.is_valid and not s.parent.is_remote)
+                s
+                for s in spans
+                if not (
+                    s.parent and s.parent.is_valid and not s.parent.is_remote
+                )
             ]
             assert len(entry_spans) == 1
             entry_span = entry_spans[0]
-            assert entry_span.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "second"
+            assert (
+                entry_span.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                == "second"
+            )
 
 
 class TestSetTransactionNameEdgeCases(TestBaseSwHeadersAndAttributes):
@@ -131,29 +156,29 @@ class TestSetTransactionNameEdgeCases(TestBaseSwHeadersAndAttributes):
     def _setup_endpoints(self):
         """Set up test routes before Flask instrumentation"""
         super()._setup_endpoints()
-        
+
         def route_empty_string():
             result = set_transaction_name("")
             assert result is False
             return "ok"
-        
+
         def route_none_value():
             result = set_transaction_name(None)
             assert result is False
             return "ok"
-        
+
         def route_long_name():
             long_name = "a" * 300
             set_transaction_name(long_name)
             return "ok"
-        
+
         # pylint: disable=no-member
         self.app.route("/test_empty_string/")(route_empty_string)
         self.app.route("/test_none_value/")(route_none_value)
         self.app.route("/test_long_name/")(route_long_name)
 
     def test_empty_string_rejected(self):
-        """Test that empty string is rejected and original name preserved"""
+        """Test empty string is rejected and original name preserved"""
         timestamp = int(time.time())
         with mock.patch(
             target="solarwinds_apm.oboe.json_sampler.JsonSampler._read",
@@ -183,19 +208,22 @@ class TestSetTransactionNameEdgeCases(TestBaseSwHeadersAndAttributes):
             spans = self.memory_exporter.get_finished_spans()
             assert len(spans) > 0
             entry_spans = [
-                s for s in spans 
-                if not (s.parent and s.parent.is_valid and not s.parent.is_remote)
+                s
+                for s in spans
+                if not (
+                    s.parent and s.parent.is_valid and not s.parent.is_remote
+                )
             ]
             assert len(entry_spans) == 1
-            
+
             entry_span = entry_spans[0]
             txn_name = entry_span.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
             assert txn_name is not None
             assert txn_name != ""
-            assert "/test_empty_string/" == txn_name
+            assert txn_name == "/test_empty_string/"
 
     def test_none_value_rejected(self):
-        """Test that None value is rejected and original name preserved"""
+        """Test None value is rejected and original name preserved"""
         timestamp = int(time.time())
         with mock.patch(
             target="solarwinds_apm.oboe.json_sampler.JsonSampler._read",
@@ -225,23 +253,31 @@ class TestSetTransactionNameEdgeCases(TestBaseSwHeadersAndAttributes):
             spans = self.memory_exporter.get_finished_spans()
             assert len(spans) > 0
             entry_spans = [
-                s for s in spans 
-                if not (s.parent and s.parent.is_valid and not s.parent.is_remote)
+                s
+                for s in spans
+                if not (
+                    s.parent and s.parent.is_valid and not s.parent.is_remote
+                )
             ]
             assert len(entry_spans) == 1
-            
+
             entry_span = entry_spans[0]
             txn_name = entry_span.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
             assert txn_name is not None
-            assert "test_none_value" in txn_name or "/test_none_value/" == txn_name
+            assert (
+                "test_none_value" in txn_name
+                or txn_name == "/test_none_value/"
+            )
 
     def test_no_active_span_returns_false(self):
-        """Test that calling set_transaction_name outside request context returns False"""
+        """Test calling set_transaction_name outside request context
+        returns False
+        """
         result = set_transaction_name("test")
         assert result is False
 
     def test_long_name_truncated(self):
-        """Test that long transaction names are truncated to 256 characters"""
+        """Test long transaction names are truncated to 256 characters"""
         timestamp = int(time.time())
         with mock.patch(
             target="solarwinds_apm.oboe.json_sampler.JsonSampler._read",
@@ -271,20 +307,24 @@ class TestSetTransactionNameEdgeCases(TestBaseSwHeadersAndAttributes):
             spans = self.memory_exporter.get_finished_spans()
             assert len(spans) > 0
             entry_spans = [
-                s for s in spans 
-                if not (s.parent and s.parent.is_valid and not s.parent.is_remote)
+                s
+                for s in spans
+                if not (
+                    s.parent and s.parent.is_valid and not s.parent.is_remote
+                )
             ]
             assert len(entry_spans) == 1
-            
+
             entry_span = entry_spans[0]
             txn_name = entry_span.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
             assert txn_name is not None
             assert len(txn_name) == 256
             assert txn_name == "a" * 256
 
+
 class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
     """Distributed trace tests for set_transaction_name()
-    
+
     Tests true distributed tracing by setting up two Flask apps where service A
     makes an HTTP request to service B, propagating trace context between them.
     """
@@ -292,18 +332,18 @@ class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
     def setUp(self):
         super().setUp()
         self.tracer_provider.add_span_processor(ServiceEntrySpanProcessor())
-        
+
         # Set up a second app in addition to self.app
         # Should be done before service_a set up with call to this one
         self.app_b = flask.Flask("service_b")
         self.flask_inst.instrument_app(self.app_b)
-        
+
         def service_b_endpoint():
             set_transaction_name("custom-service-b")
             return "service-b-response"
-        
+
         self.app_b.route("/service_b/")(service_b_endpoint)
-        
+
         self.server = make_server("127.0.0.1", 5001, self.app_b, threaded=True)
         self.server_thread = threading.Thread(target=self.server.serve_forever)
         self.server_thread.daemon = True
@@ -317,18 +357,18 @@ class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
     def _setup_endpoints(self):
         """Set up test routes before Flask instrumentation"""
         super()._setup_endpoints()
-        
+
         def service_a_endpoint():
             set_transaction_name("custom-service-a")
             resp = requests.get("http://127.0.0.1:5001/service_b/")
             return f"service-a-response: {resp.text}"
-        
+
         # pylint: disable=no-member
         self.app.route("/service_a/")(service_a_endpoint)
 
     def test_custom_names_at_all_entry_spans(self):
         """Test that custom names are set independently for each service entry span
-        
+
         Service A calls service B via HTTP, creating a distributed trace where each
         service sets its own custom transaction name on its respective entry span.
         """
@@ -361,17 +401,26 @@ class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
             spans = self.memory_exporter.get_finished_spans()
             assert len(spans) > 0
             entry_spans = [
-                s for s in spans 
-                if not (s.parent and s.parent.is_valid and not s.parent.is_remote)
+                s
+                for s in spans
+                if not (
+                    s.parent and s.parent.is_valid and not s.parent.is_remote
+                )
             ]
             assert len(entry_spans) == 2
             # leaf-most entry span will be first
-            assert entry_spans[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-service-b"
-            assert entry_spans[1].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-service-a"
+            assert (
+                entry_spans[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                == "custom-service-b"
+            )
+            assert (
+                entry_spans[1].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                == "custom-service-a"
+            )
 
     def test_custom_names_across_more_complex_traces(self):
         """Test custom names work correctly when manual spans are created with OTel SDK
-        
+
         Each service creates manual child spans using start_as_current_span before calling
         set_transaction_name. The entry spans should still get the custom names, and the
         trace should contain additional manual spans.
@@ -401,46 +450,65 @@ class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
             ],
         ):
             tracer = trace.get_tracer(__name__)
-            
+
             def service_b_with_manual_spans():
                 with tracer.start_as_current_span("manual-outer-b"):
                     current_span = trace.get_current_span()
-                    current_span.set_attribute("test.custom_attribute", "outer-b")
+                    current_span.set_attribute(
+                        "test.custom_attribute", "outer-b"
+                    )
                     with tracer.start_as_current_span("manual-inner-b"):
                         current_span = trace.get_current_span()
-                        current_span.set_attribute("test.custom_attribute", "inner-b")
+                        current_span.set_attribute(
+                            "test.custom_attribute", "inner-b"
+                        )
                         set_transaction_name("custom-service-b")
                         return "service-b-response"
-            
+
             def service_a_with_manual_spans():
                 with tracer.start_as_current_span("manual-outer-a"):
                     current_span = trace.get_current_span()
-                    current_span.set_attribute("test.custom_attribute", "outer-a")
+                    current_span.set_attribute(
+                        "test.custom_attribute", "outer-a"
+                    )
                     with tracer.start_as_current_span("manual-inner-a"):
                         current_span = trace.get_current_span()
-                        current_span.set_attribute("test.custom_attribute", "inner-a")
+                        current_span.set_attribute(
+                            "test.custom_attribute", "inner-a"
+                        )
                         set_transaction_name("custom-service-a")
-                        resp = requests.get("http://127.0.0.1:5001/service_b_manual/")
+                        resp = requests.get(
+                            "http://127.0.0.1:5001/service_b_manual/"
+                        )
                         return f"service-a-response: {resp.text}"
-            
+
             self.app_b.route("/service_b_manual/")(service_b_with_manual_spans)
             # pylint: disable=no-member
             self.app.route("/service_a_manual/")(service_a_with_manual_spans)
-            
+
             resp_a = self.client.get("/service_a_manual/")
             assert resp_a.status_code == 200
             spans = self.memory_exporter.get_finished_spans()
             assert len(spans) > 0
 
             entry_spans = [
-                s for s in spans 
-                if not (s.parent and s.parent.is_valid and not s.parent.is_remote)
+                s
+                for s in spans
+                if not (
+                    s.parent and s.parent.is_valid and not s.parent.is_remote
+                )
             ]
             assert len(entry_spans) == 2
             # leaf-most entry span will be first
-            assert entry_spans[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-service-b"
-            assert entry_spans[1].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-service-a"
-            
+            assert (
+                entry_spans[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                == "custom-service-b"
+            )
+            assert (
+                entry_spans[1].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                == "custom-service-a"
+            )
+
             manual_spans = [s for s in spans if s.name.startswith("manual-")]
             assert len(manual_spans) == 4
             assert manual_spans[0].name == "manual-inner-b"

--- a/tests/integration/test_set_transaction_name.py
+++ b/tests/integration/test_set_transaction_name.py
@@ -1,0 +1,277 @@
+# © 2026 SolarWinds Worldwide, LLC. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+import time
+from unittest import mock
+
+from solarwinds_apm.api import set_transaction_name
+from solarwinds_apm.apm_constants import INTL_SWO_TRANSACTION_ATTR_KEY
+from solarwinds_apm.trace.serviceentry_processor import ServiceEntrySpanProcessor
+
+from .test_base_sw_headers_attrs import TestBaseSwHeadersAndAttributes
+
+
+class TestSetTransactionNameBasic(TestBaseSwHeadersAndAttributes):
+    """Basic functionality tests for set_transaction_name()"""
+
+    def setUp(self):
+        super().setUp()
+        self.tracer_provider.add_span_processor(ServiceEntrySpanProcessor())
+
+    def _setup_endpoints(self):
+        """Set up test routes before Flask instrumentation"""
+        super()._setup_endpoints()
+        
+        def route_single_call():
+            set_transaction_name("custom-name")
+            return "ok"
+        
+        def route_multiple_calls():
+            set_transaction_name("first")
+            set_transaction_name("second")
+            return "ok"
+        
+        # pylint: disable=no-member
+        self.app.route("/test_single_call/")(route_single_call)
+        self.app.route("/test_multiple_calls/")(route_multiple_calls)
+
+    def test_single_call_sets_attribute(self):
+        """Test that single call to set_transaction_name sets sw.transaction attribute"""
+        timestamp = int(time.time())
+        with mock.patch(
+            target="solarwinds_apm.oboe.json_sampler.JsonSampler._read",
+            return_value=[
+                {
+                    "arguments": {
+                        "BucketCapacity": 2,
+                        "BucketRate": 1,
+                        "MetricsFlushInterval": 60,
+                        "SignatureKey": "",
+                        "TriggerRelaxedBucketCapacity": 4,
+                        "TriggerRelaxedBucketRate": 3,
+                        "TriggerStrictBucketCapacity": 6,
+                        "TriggerStrictBucketRate": 5,
+                    },
+                    "flags": "SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE",
+                    "layer": "",
+                    "timestamp": timestamp,
+                    "ttl": 120,
+                    "type": 0,
+                    "value": 1000000,
+                }
+            ],
+        ):
+            resp = self.client.get("/test_single_call/")
+            assert resp.status_code == 200
+            spans = self.memory_exporter.get_finished_spans()
+            assert len(spans) > 0
+            entry_spans = [
+                s for s in spans 
+                if not (s.parent and s.parent.is_valid and not s.parent.is_remote)
+            ]
+            assert len(entry_spans) == 1
+            entry_span = entry_spans[0]
+            assert entry_span.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-name"
+
+    def test_multiple_calls_last_wins(self):
+        """Test that multiple calls to set_transaction_name, last one wins"""
+        timestamp = int(time.time())
+        with mock.patch(
+            target="solarwinds_apm.oboe.json_sampler.JsonSampler._read",
+            return_value=[
+                {
+                    "arguments": {
+                        "BucketCapacity": 2,
+                        "BucketRate": 1,
+                        "MetricsFlushInterval": 60,
+                        "SignatureKey": "",
+                        "TriggerRelaxedBucketCapacity": 4,
+                        "TriggerRelaxedBucketRate": 3,
+                        "TriggerStrictBucketCapacity": 6,
+                        "TriggerStrictBucketRate": 5,
+                    },
+                    "flags": "SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE",
+                    "layer": "",
+                    "timestamp": timestamp,
+                    "ttl": 120,
+                    "type": 0,
+                    "value": 1000000,
+                }
+            ],
+        ):
+            resp = self.client.get("/test_multiple_calls/")
+            assert resp.status_code == 200
+            spans = self.memory_exporter.get_finished_spans()
+            assert len(spans) > 0
+            entry_spans = [
+                s for s in spans 
+                if not (s.parent and s.parent.is_valid and not s.parent.is_remote)
+            ]
+            assert len(entry_spans) == 1
+            entry_span = entry_spans[0]
+            assert entry_span.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "second"
+
+
+class TestSetTransactionNameEdgeCases(TestBaseSwHeadersAndAttributes):
+    """Edge case tests for set_transaction_name()"""
+
+    def setUp(self):
+        super().setUp()
+        self.tracer_provider.add_span_processor(ServiceEntrySpanProcessor())
+
+    def _setup_endpoints(self):
+        """Set up test routes before Flask instrumentation"""
+        super()._setup_endpoints()
+        
+        def route_empty_string():
+            result = set_transaction_name("")
+            assert result is False
+            return "ok"
+        
+        def route_none_value():
+            result = set_transaction_name(None)
+            assert result is False
+            return "ok"
+        
+        def route_long_name():
+            long_name = "a" * 300
+            set_transaction_name(long_name)
+            return "ok"
+        
+        # pylint: disable=no-member
+        self.app.route("/test_empty_string/")(route_empty_string)
+        self.app.route("/test_none_value/")(route_none_value)
+        self.app.route("/test_long_name/")(route_long_name)
+
+    def test_empty_string_rejected(self):
+        """Test that empty string is rejected and original name preserved"""
+        timestamp = int(time.time())
+        with mock.patch(
+            target="solarwinds_apm.oboe.json_sampler.JsonSampler._read",
+            return_value=[
+                {
+                    "arguments": {
+                        "BucketCapacity": 2,
+                        "BucketRate": 1,
+                        "MetricsFlushInterval": 60,
+                        "SignatureKey": "",
+                        "TriggerRelaxedBucketCapacity": 4,
+                        "TriggerRelaxedBucketRate": 3,
+                        "TriggerStrictBucketCapacity": 6,
+                        "TriggerStrictBucketRate": 5,
+                    },
+                    "flags": "SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE",
+                    "layer": "",
+                    "timestamp": timestamp,
+                    "ttl": 120,
+                    "type": 0,
+                    "value": 1000000,
+                }
+            ],
+        ):
+            resp = self.client.get("/test_empty_string/")
+            assert resp.status_code == 200
+            spans = self.memory_exporter.get_finished_spans()
+            assert len(spans) > 0
+            entry_spans = [
+                s for s in spans 
+                if not (s.parent and s.parent.is_valid and not s.parent.is_remote)
+            ]
+            assert len(entry_spans) == 1
+            
+            entry_span = entry_spans[0]
+            txn_name = entry_span.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+            assert txn_name is not None
+            assert txn_name != ""
+            assert "/test_empty_string/" == txn_name
+
+    def test_none_value_rejected(self):
+        """Test that None value is rejected and original name preserved"""
+        timestamp = int(time.time())
+        with mock.patch(
+            target="solarwinds_apm.oboe.json_sampler.JsonSampler._read",
+            return_value=[
+                {
+                    "arguments": {
+                        "BucketCapacity": 2,
+                        "BucketRate": 1,
+                        "MetricsFlushInterval": 60,
+                        "SignatureKey": "",
+                        "TriggerRelaxedBucketCapacity": 4,
+                        "TriggerRelaxedBucketRate": 3,
+                        "TriggerStrictBucketCapacity": 6,
+                        "TriggerStrictBucketRate": 5,
+                    },
+                    "flags": "SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE",
+                    "layer": "",
+                    "timestamp": timestamp,
+                    "ttl": 120,
+                    "type": 0,
+                    "value": 1000000,
+                }
+            ],
+        ):
+            resp = self.client.get("/test_none_value/")
+            assert resp.status_code == 200
+            spans = self.memory_exporter.get_finished_spans()
+            assert len(spans) > 0
+            entry_spans = [
+                s for s in spans 
+                if not (s.parent and s.parent.is_valid and not s.parent.is_remote)
+            ]
+            assert len(entry_spans) == 1
+            
+            entry_span = entry_spans[0]
+            txn_name = entry_span.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+            assert txn_name is not None
+            assert "test_none_value" in txn_name or "/test_none_value/" == txn_name
+
+    def test_no_active_span_returns_false(self):
+        """Test that calling set_transaction_name outside request context returns False"""
+        result = set_transaction_name("test")
+        assert result is False
+
+    def test_long_name_truncated(self):
+        """Test that long transaction names are truncated to 256 characters"""
+        timestamp = int(time.time())
+        with mock.patch(
+            target="solarwinds_apm.oboe.json_sampler.JsonSampler._read",
+            return_value=[
+                {
+                    "arguments": {
+                        "BucketCapacity": 2,
+                        "BucketRate": 1,
+                        "MetricsFlushInterval": 60,
+                        "SignatureKey": "",
+                        "TriggerRelaxedBucketCapacity": 4,
+                        "TriggerRelaxedBucketRate": 3,
+                        "TriggerStrictBucketCapacity": 6,
+                        "TriggerStrictBucketRate": 5,
+                    },
+                    "flags": "SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE",
+                    "layer": "",
+                    "timestamp": timestamp,
+                    "ttl": 120,
+                    "type": 0,
+                    "value": 1000000,
+                }
+            ],
+        ):
+            resp = self.client.get("/test_long_name/")
+            assert resp.status_code == 200
+            spans = self.memory_exporter.get_finished_spans()
+            assert len(spans) > 0
+            entry_spans = [
+                s for s in spans 
+                if not (s.parent and s.parent.is_valid and not s.parent.is_remote)
+            ]
+            assert len(entry_spans) == 1
+            
+            entry_span = entry_spans[0]
+            txn_name = entry_span.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+            assert txn_name is not None
+            assert len(txn_name) == 256
+            assert txn_name == "a" * 256

--- a/tests/integration/test_set_transaction_name.py
+++ b/tests/integration/test_set_transaction_name.py
@@ -4,8 +4,13 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
+import threading
 import time
 from unittest import mock
+
+import flask
+import requests
+from werkzeug.serving import make_server
 
 from solarwinds_apm.api import set_transaction_name
 from solarwinds_apm.apm_constants import INTL_SWO_TRANSACTION_ATTR_KEY
@@ -275,3 +280,90 @@ class TestSetTransactionNameEdgeCases(TestBaseSwHeadersAndAttributes):
             assert txn_name is not None
             assert len(txn_name) == 256
             assert txn_name == "a" * 256
+
+class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
+    """Distributed trace tests for set_transaction_name()
+    
+    Tests true distributed tracing by setting up two Flask apps where service A
+    makes an HTTP request to service B, propagating trace context between them.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.tracer_provider.add_span_processor(ServiceEntrySpanProcessor())
+        
+        # Set up a second app in addition to self.app
+        # Should be done before service_a set up with call to this one
+        self.app_b = flask.Flask("service_b")
+        self.flask_inst.instrument_app(self.app_b)
+        
+        def service_b_endpoint():
+            set_transaction_name("custom-service-b")
+            return "service-b-response"
+        
+        self.app_b.route("/service_b/")(service_b_endpoint)
+        
+        self.server = make_server("127.0.0.1", 5001, self.app_b, threaded=True)
+        self.server_thread = threading.Thread(target=self.server.serve_forever)
+        self.server_thread.daemon = True
+        self.server_thread.start()
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server_thread.join(timeout=1)
+        super().tearDown()
+
+    def _setup_endpoints(self):
+        """Set up test routes before Flask instrumentation"""
+        super()._setup_endpoints()
+        
+        def service_a_endpoint():
+            set_transaction_name("custom-service-a")
+            resp = requests.get("http://127.0.0.1:5001/service_b/")
+            return f"service-a-response: {resp.text}"
+        
+        # pylint: disable=no-member
+        self.app.route("/service_a/")(service_a_endpoint)
+
+    def test_custom_names_at_all_entry_spans(self):
+        """Test that custom names are set independently for each service entry span
+        
+        Service A calls service B via HTTP, creating a distributed trace where each
+        service sets its own custom transaction name on its respective entry span.
+        """
+        timestamp = int(time.time())
+        with mock.patch(
+            target="solarwinds_apm.oboe.json_sampler.JsonSampler._read",
+            return_value=[
+                {
+                    "arguments": {
+                        "BucketCapacity": 2,
+                        "BucketRate": 1,
+                        "MetricsFlushInterval": 60,
+                        "SignatureKey": "",
+                        "TriggerRelaxedBucketCapacity": 4,
+                        "TriggerRelaxedBucketRate": 3,
+                        "TriggerStrictBucketCapacity": 6,
+                        "TriggerStrictBucketRate": 5,
+                    },
+                    "flags": "SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE",
+                    "layer": "",
+                    "timestamp": timestamp,
+                    "ttl": 120,
+                    "type": 0,
+                    "value": 1000000,
+                }
+            ],
+        ):
+            resp_a = self.client.get("/service_a/")
+            assert resp_a.status_code == 200
+            spans = self.memory_exporter.get_finished_spans()
+            assert len(spans) > 0
+            entry_spans = [
+                s for s in spans 
+                if not (s.parent and s.parent.is_valid and not s.parent.is_remote)
+            ]
+            assert len(entry_spans) == 2
+            # leaf-most entry span will be first
+            assert entry_spans[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-service-b"
+            assert entry_spans[1].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-service-a"

--- a/tests/integration/test_set_transaction_name.py
+++ b/tests/integration/test_set_transaction_name.py
@@ -277,7 +277,7 @@ class TestSetTransactionNameEdgeCases(TestBaseSwHeadersAndAttributes):
         assert result is False
 
     def test_long_name_truncated(self):
-        """Test long transaction names are truncated to 256 characters"""
+        """Test long transaction names are truncated to 255 characters"""
         timestamp = int(time.time())
         with mock.patch(
             target="solarwinds_apm.oboe.json_sampler.JsonSampler._read",
@@ -318,8 +318,8 @@ class TestSetTransactionNameEdgeCases(TestBaseSwHeadersAndAttributes):
             entry_span = entry_spans[0]
             txn_name = entry_span.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
             assert txn_name is not None
-            assert len(txn_name) == 256
-            assert txn_name == "a" * 256
+            assert len(txn_name) == 255
+            assert txn_name == "a" * 255
 
 
 class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):

--- a/tests/integration/test_set_transaction_name.py
+++ b/tests/integration/test_set_transaction_name.py
@@ -34,8 +34,8 @@ from .test_base_sw_headers_attrs import (
 )
 
 
-class TestSetTransactionNameBasic(TestBaseSwHeadersAndAttributes):
-    """Basic functionality tests for set_transaction_name()"""
+class TestBaseTransactionName(TestBaseSwHeadersAndAttributes):
+    """Base class for set_transaction_name() tests with common setup and helpers"""
 
     def setUp(self):
         super().setUp()
@@ -61,6 +61,10 @@ class TestSetTransactionNameBasic(TestBaseSwHeadersAndAttributes):
                             if txn == transaction_name:
                                 matching_data_points.append(data_point)
         return matching_data_points
+
+
+class TestSetTransactionNameBasic(TestBaseTransactionName):
+    """Basic functionality tests for set_transaction_name()"""
 
     def _setup_endpoints(self):
         """Set up test routes before Flask instrumentation"""
@@ -180,33 +184,8 @@ class TestSetTransactionNameBasic(TestBaseSwHeadersAndAttributes):
             assert metrics[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "second"
 
 
-class TestSetTransactionNameEdgeCases(TestBaseSwHeadersAndAttributes):
+class TestSetTransactionNameEdgeCases(TestBaseTransactionName):
     """Edge case tests for set_transaction_name()"""
-
-    def setUp(self):
-        super().setUp()
-        self.tracer_provider.add_span_processor(ServiceEntrySpanProcessor())
-        self.tracer_provider.add_span_processor(
-            ResponseTimeProcessor(self.configurator.apm_config)
-        )
-
-    def _get_metrics_for_transaction(self, transaction_name):
-        """Helper to get metrics data filtered by transaction name"""
-        self.metric_reader.collect()
-        metrics_data = self.metric_reader.get_metrics_data()
-        if not metrics_data or not metrics_data.resource_metrics:
-            return []
-        
-        matching_data_points = []
-        for resource_metric in metrics_data.resource_metrics:
-            for scope_metric in resource_metric.scope_metrics:
-                for metric in scope_metric.metrics:
-                    if metric.name == "trace.service.response_time":
-                        for data_point in metric.data.data_points:
-                            txn = data_point.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
-                            if txn == transaction_name:
-                                matching_data_points.append(data_point)
-        return matching_data_points
 
     def _setup_endpoints(self):
         """Set up test routes before Flask instrumentation"""
@@ -392,7 +371,7 @@ class TestSetTransactionNameEdgeCases(TestBaseSwHeadersAndAttributes):
             assert metrics[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == txn_name
 
 
-class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
+class TestSetTransactionNameDistributed(TestBaseTransactionName):
     """Distributed trace tests for set_transaction_name()
 
     Tests true distributed tracing by setting up two Flask apps where service A
@@ -401,10 +380,6 @@ class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
 
     def setUp(self):
         super().setUp()
-        self.tracer_provider.add_span_processor(ServiceEntrySpanProcessor())
-        self.tracer_provider.add_span_processor(
-            ResponseTimeProcessor(self.configurator.apm_config)
-        )
 
         # Set up a second app in addition to self.app
         # Should be done before service_a set up with call to this one
@@ -443,24 +418,6 @@ class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
         self.server.shutdown()
         self.server_thread.join(timeout=1)
         super().tearDown()
-
-    def _get_metrics_for_transaction(self, transaction_name):
-        """Helper to get metrics data filtered by transaction name"""
-        self.metric_reader.collect()
-        metrics_data = self.metric_reader.get_metrics_data()
-        if not metrics_data or not metrics_data.resource_metrics:
-            return []
-        
-        matching_data_points = []
-        for resource_metric in metrics_data.resource_metrics:
-            for scope_metric in resource_metric.scope_metrics:
-                for metric in scope_metric.metrics:
-                    if metric.name == "trace.service.response_time":
-                        for data_point in metric.data.data_points:
-                            txn = data_point.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
-                            if txn == transaction_name:
-                                matching_data_points.append(data_point)
-        return matching_data_points
 
     def _setup_endpoints(self):
         """Set up test routes before Flask instrumentation"""

--- a/tests/integration/test_set_transaction_name.py
+++ b/tests/integration/test_set_transaction_name.py
@@ -10,6 +10,7 @@ from unittest import mock
 
 import flask
 import requests
+from opentelemetry import trace
 from werkzeug.serving import make_server
 
 from solarwinds_apm.api import set_transaction_name
@@ -367,3 +368,82 @@ class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
             # leaf-most entry span will be first
             assert entry_spans[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-service-b"
             assert entry_spans[1].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-service-a"
+
+    def test_custom_names_across_more_complex_traces(self):
+        """Test custom names work correctly when manual spans are created with OTel SDK
+        
+        Each service creates manual child spans using start_as_current_span before calling
+        set_transaction_name. The entry spans should still get the custom names, and the
+        trace should contain additional manual spans.
+        """
+        timestamp = int(time.time())
+        with mock.patch(
+            target="solarwinds_apm.oboe.json_sampler.JsonSampler._read",
+            return_value=[
+                {
+                    "arguments": {
+                        "BucketCapacity": 2,
+                        "BucketRate": 1,
+                        "MetricsFlushInterval": 60,
+                        "SignatureKey": "",
+                        "TriggerRelaxedBucketCapacity": 4,
+                        "TriggerRelaxedBucketRate": 3,
+                        "TriggerStrictBucketCapacity": 6,
+                        "TriggerStrictBucketRate": 5,
+                    },
+                    "flags": "SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE",
+                    "layer": "",
+                    "timestamp": timestamp,
+                    "ttl": 120,
+                    "type": 0,
+                    "value": 1000000,
+                }
+            ],
+        ):
+            tracer = trace.get_tracer(__name__)
+            
+            def service_b_with_manual_spans():
+                with tracer.start_as_current_span("manual-outer-b"):
+                    current_span = trace.get_current_span()
+                    current_span.set_attribute("test.custom_attribute", "outer-b")
+                    with tracer.start_as_current_span("manual-inner-b"):
+                        current_span = trace.get_current_span()
+                        current_span.set_attribute("test.custom_attribute", "inner-b")
+                        set_transaction_name("custom-service-b")
+                        return "service-b-response"
+            
+            def service_a_with_manual_spans():
+                with tracer.start_as_current_span("manual-outer-a"):
+                    current_span = trace.get_current_span()
+                    current_span.set_attribute("test.custom_attribute", "outer-a")
+                    with tracer.start_as_current_span("manual-inner-a"):
+                        current_span = trace.get_current_span()
+                        current_span.set_attribute("test.custom_attribute", "inner-a")
+                        set_transaction_name("custom-service-a")
+                        resp = requests.get("http://127.0.0.1:5001/service_b_manual/")
+                        return f"service-a-response: {resp.text}"
+            
+            self.app_b.route("/service_b_manual/")(service_b_with_manual_spans)
+            # pylint: disable=no-member
+            self.app.route("/service_a_manual/")(service_a_with_manual_spans)
+            
+            resp_a = self.client.get("/service_a_manual/")
+            assert resp_a.status_code == 200
+            spans = self.memory_exporter.get_finished_spans()
+            assert len(spans) > 0
+
+            entry_spans = [
+                s for s in spans 
+                if not (s.parent and s.parent.is_valid and not s.parent.is_remote)
+            ]
+            assert len(entry_spans) == 2
+            # leaf-most entry span will be first
+            assert entry_spans[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-service-b"
+            assert entry_spans[1].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-service-a"
+            
+            manual_spans = [s for s in spans if s.name.startswith("manual-")]
+            assert len(manual_spans) == 4
+            assert manual_spans[0].name == "manual-inner-b"
+            assert manual_spans[1].name == "manual-outer-b"
+            assert manual_spans[2].name == "manual-inner-a"
+            assert manual_spans[3].name == "manual-outer-a"

--- a/tests/integration/test_set_transaction_name.py
+++ b/tests/integration/test_set_transaction_name.py
@@ -338,11 +338,28 @@ class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
         self.app_b = flask.Flask("service_b")
         self.flask_inst.instrument_app(self.app_b)
 
+        # Get tracer for manual span tests
+        tracer = trace.get_tracer(__name__)
+
         def service_b_endpoint():
             set_transaction_name("custom-service-b")
             return "service-b-response"
 
+        def service_b_with_manual_spans():
+            with tracer.start_as_current_span("manual-outer-b"):
+                current_span = trace.get_current_span()
+                current_span.set_attribute("test.custom_attribute", "outer-b")
+                with tracer.start_as_current_span("manual-inner-b"):
+                    current_span = trace.get_current_span()
+                    current_span.set_attribute(
+                        "test.custom_attribute", "inner-b"
+                    )
+                    set_transaction_name("custom-service-b")
+                    return "service-b-response"
+
+        # Register all routes before starting server
         self.app_b.route("/service_b/")(service_b_endpoint)
+        self.app_b.route("/service_b_manual/")(service_b_with_manual_spans)
 
         self.server = make_server("127.0.0.1", 5001, self.app_b, threaded=True)
         self.server_thread = threading.Thread(target=self.server.serve_forever)
@@ -358,13 +375,32 @@ class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
         """Set up test routes before Flask instrumentation"""
         super()._setup_endpoints()
 
+        # Get tracer for manual span tests
+        tracer = trace.get_tracer(__name__)
+
         def service_a_endpoint():
             set_transaction_name("custom-service-a")
             resp = requests.get("http://127.0.0.1:5001/service_b/")
             return f"service-a-response: {resp.text}"
 
+        def service_a_with_manual_spans():
+            with tracer.start_as_current_span("manual-outer-a"):
+                current_span = trace.get_current_span()
+                current_span.set_attribute("test.custom_attribute", "outer-a")
+                with tracer.start_as_current_span("manual-inner-a"):
+                    current_span = trace.get_current_span()
+                    current_span.set_attribute(
+                        "test.custom_attribute", "inner-a"
+                    )
+                    set_transaction_name("custom-service-a")
+                    resp = requests.get(
+                        "http://127.0.0.1:5001/service_b_manual/"
+                    )
+                    return f"service-a-response: {resp.text}"
+
         # pylint: disable=no-member
         self.app.route("/service_a/")(service_a_endpoint)
+        self.app.route("/service_a_manual/")(service_a_with_manual_spans)
 
     def test_custom_names_at_all_entry_spans(self):
         """Test that custom names are set independently for each service entry span
@@ -449,43 +485,6 @@ class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
                 }
             ],
         ):
-            tracer = trace.get_tracer(__name__)
-
-            def service_b_with_manual_spans():
-                with tracer.start_as_current_span("manual-outer-b"):
-                    current_span = trace.get_current_span()
-                    current_span.set_attribute(
-                        "test.custom_attribute", "outer-b"
-                    )
-                    with tracer.start_as_current_span("manual-inner-b"):
-                        current_span = trace.get_current_span()
-                        current_span.set_attribute(
-                            "test.custom_attribute", "inner-b"
-                        )
-                        set_transaction_name("custom-service-b")
-                        return "service-b-response"
-
-            def service_a_with_manual_spans():
-                with tracer.start_as_current_span("manual-outer-a"):
-                    current_span = trace.get_current_span()
-                    current_span.set_attribute(
-                        "test.custom_attribute", "outer-a"
-                    )
-                    with tracer.start_as_current_span("manual-inner-a"):
-                        current_span = trace.get_current_span()
-                        current_span.set_attribute(
-                            "test.custom_attribute", "inner-a"
-                        )
-                        set_transaction_name("custom-service-a")
-                        resp = requests.get(
-                            "http://127.0.0.1:5001/service_b_manual/"
-                        )
-                        return f"service-a-response: {resp.text}"
-
-            self.app_b.route("/service_b_manual/")(service_b_with_manual_spans)
-            # pylint: disable=no-member
-            self.app.route("/service_a_manual/")(service_a_with_manual_spans)
-
             resp_a = self.client.get("/service_a_manual/")
             assert resp_a.status_code == 200
             spans = self.memory_exporter.get_finished_spans()

--- a/tests/integration/test_set_transaction_name.py
+++ b/tests/integration/test_set_transaction_name.py
@@ -380,7 +380,7 @@ class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
 
         def service_a_endpoint():
             set_transaction_name("custom-service-a")
-            resp = requests.get("http://127.0.0.1:5001/service_b/")
+            resp = requests.get("http://127.0.0.1:5001/service_b/", timeout=5)
             return f"service-a-response: {resp.text}"
 
         def service_a_with_manual_spans():
@@ -394,7 +394,8 @@ class TestSetTransactionNameDistributed(TestBaseSwHeadersAndAttributes):
                     )
                     set_transaction_name("custom-service-a")
                     resp = requests.get(
-                        "http://127.0.0.1:5001/service_b_manual/"
+                        "http://127.0.0.1:5001/service_b_manual/",
+                        timeout=5,
                     )
                     return f"service-a-response: {resp.text}"
 

--- a/tests/integration/test_set_transaction_name.py
+++ b/tests/integration/test_set_transaction_name.py
@@ -50,14 +50,16 @@ class TestBaseTransactionName(TestBaseSwHeadersAndAttributes):
         metrics_data = self.metric_reader.get_metrics_data()
         if not metrics_data or not metrics_data.resource_metrics:
             return []
-        
+
         matching_data_points = []
         for resource_metric in metrics_data.resource_metrics:
             for scope_metric in resource_metric.scope_metrics:
                 for metric in scope_metric.metrics:
                     if metric.name == "trace.service.response_time":
                         for data_point in metric.data.data_points:
-                            txn = data_point.attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                            txn = data_point.attributes.get(
+                                INTL_SWO_TRANSACTION_ATTR_KEY
+                            )
                             if txn == transaction_name:
                                 matching_data_points.append(data_point)
         return matching_data_points
@@ -132,7 +134,10 @@ class TestSetTransactionNameBasic(TestBaseTransactionName):
             # Verify metrics also have correct transaction name
             metrics = self._get_metrics_for_transaction("custom-name")
             assert len(metrics) == 1
-            assert metrics[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-name"
+            assert (
+                metrics[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                == "custom-name"
+            )
 
     def test_multiple_calls_last_wins(self):
         """Test multiple calls to set_transaction_name, last one wins"""
@@ -181,7 +186,10 @@ class TestSetTransactionNameBasic(TestBaseTransactionName):
             # Verify metrics also have correct transaction name
             metrics = self._get_metrics_for_transaction("second")
             assert len(metrics) == 1
-            assert metrics[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "second"
+            assert (
+                metrics[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                == "second"
+            )
 
 
 class TestSetTransactionNameEdgeCases(TestBaseTransactionName):
@@ -259,7 +267,10 @@ class TestSetTransactionNameEdgeCases(TestBaseTransactionName):
             # Verify metrics also have correct transaction name
             metrics = self._get_metrics_for_transaction("/test_empty_string/")
             assert len(metrics) == 1
-            assert metrics[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "/test_empty_string/"
+            assert (
+                metrics[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                == "/test_empty_string/"
+            )
 
     def test_none_value_rejected(self):
         """Test None value is rejected and original name preserved"""
@@ -311,7 +322,10 @@ class TestSetTransactionNameEdgeCases(TestBaseTransactionName):
             # Verify metrics also have correct transaction name
             metrics = self._get_metrics_for_transaction(txn_name)
             assert len(metrics) == 1
-            assert metrics[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == txn_name
+            assert (
+                metrics[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                == txn_name
+            )
 
     def test_no_active_span_returns_false(self):
         """Test calling set_transaction_name outside request context
@@ -368,7 +382,10 @@ class TestSetTransactionNameEdgeCases(TestBaseTransactionName):
             # Verify metrics also have correct transaction name
             metrics = self._get_metrics_for_transaction(txn_name)
             assert len(metrics) == 1
-            assert metrics[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == txn_name
+            assert (
+                metrics[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                == txn_name
+            )
 
 
 class TestSetTransactionNameDistributed(TestBaseTransactionName):
@@ -506,11 +523,17 @@ class TestSetTransactionNameDistributed(TestBaseTransactionName):
             # Verify metrics also have correct transaction names
             metrics_a = self._get_metrics_for_transaction("custom-service-a")
             assert len(metrics_a) == 1
-            assert metrics_a[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-service-a"
-            
+            assert (
+                metrics_a[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                == "custom-service-a"
+            )
+
             metrics_b = self._get_metrics_for_transaction("custom-service-b")
             assert len(metrics_b) == 1
-            assert metrics_b[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-service-b"
+            assert (
+                metrics_b[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                == "custom-service-b"
+            )
 
     def test_custom_names_across_more_complex_traces(self):
         """Test custom names work correctly when manual spans are created with OTel SDK
@@ -576,8 +599,14 @@ class TestSetTransactionNameDistributed(TestBaseTransactionName):
             # Verify metrics also have correct transaction names
             metrics_a = self._get_metrics_for_transaction("custom-service-a")
             assert len(metrics_a) == 1
-            assert metrics_a[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-service-a"
-            
+            assert (
+                metrics_a[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                == "custom-service-a"
+            )
+
             metrics_b = self._get_metrics_for_transaction("custom-service-b")
             assert len(metrics_b) == 1
-            assert metrics_b[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY) == "custom-service-b"
+            assert (
+                metrics_b[0].attributes.get(INTL_SWO_TRANSACTION_ATTR_KEY)
+                == "custom-service-b"
+            )

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -24,13 +24,6 @@ class TestSetTransactionName:
         mocker,
         span_ready=True,
     ):
-        mock_pool = mocker.patch(
-            "solarwinds_apm.api.get_transaction_name_pool"
-        )
-        mock_pool_instance = mocker.Mock()
-        mock_pool.return_value = mock_pool_instance
-        mock_pool_instance.registered.return_value = "mock-registered-name"
-
         mocker.patch(
             "solarwinds_apm.w3c_transformer.W3CTransformer.trace_and_span_id_from_context",
             return_value="foo",
@@ -54,39 +47,35 @@ class TestSetTransactionName:
                 "get_value": mock_get_fn
             }
         )
-        return mock_context, mock_pool_instance, mock_current_span
+        return mock_context, mock_current_span
 
     def test_empty_string(self, mocker):
-        mock_context, mock_pool, mock_current_span = self.patch_set_name(mocker)
+        mock_context, mock_current_span = self.patch_set_name(mocker)
         assert set_transaction_name("") == False
         mock_context.get_value.assert_not_called()
-        mock_pool.registered.assert_not_called()
         mock_current_span.set_attribute.assert_not_called()
 
     def test_agent_not_enabled_noop_tracer_provider(self, mocker):
-        mock_context, mock_pool, mock_current_span = self.patch_set_name(mocker)
+        mock_context, mock_current_span = self.patch_set_name(mocker)
         mocker.patch(
             "solarwinds_apm.api.get_tracer_provider",
             return_value=NoOpTracerProvider()
         )
         assert set_transaction_name("foo") == True
         mock_context.get_value.assert_not_called()
-        mock_pool.registered.assert_not_called()
         mock_current_span.set_attribute.assert_not_called()
 
     def test_span_not_started(self, mocker):
-        mock_context, mock_pool, mock_current_span = self.patch_set_name(mocker, span_ready=False)
+        mock_context, mock_current_span = self.patch_set_name(mocker, span_ready=False)
         assert set_transaction_name("foo") == False
         mock_context.get_value.assert_called_once()
-        mock_pool.registered.assert_not_called()
         mock_current_span.set_attribute.assert_not_called()
 
     def test_agent_enabled(self, mocker):
-        mock_context, mock_pool, mock_current_span = self.patch_set_name(mocker)
+        mock_context, mock_current_span = self.patch_set_name(mocker)
         assert set_transaction_name("bar") == True
         mock_context.get_value.assert_called_once_with("sw-current-trace-entry-span")
-        mock_pool.registered.assert_called_once_with("bar")
-        mock_current_span.set_attribute.assert_called_once_with("sw.transaction", "mock-registered-name")
+        mock_current_span.set_attribute.assert_called_once_with("sw.transaction", "bar")
 
 class TestSolarWindsReady:
     def test_parentbasedsw_sampler_ready(self, mocker):

--- a/tests/unit/test_processors/test_serviceentry_processor.py
+++ b/tests/unit/test_processors/test_serviceentry_processor.py
@@ -91,6 +91,7 @@ class TestServiceEntrySpanProcessor():
             **{
                 "parent": mock_parent,
                 "attributes.get": mock_attrs_get,
+                "name": "default-span-name",
             }
         )
         processor = ServiceEntrySpanProcessor()
@@ -125,6 +126,7 @@ class TestServiceEntrySpanProcessor():
             **{
                 "parent": mock_parent,
                 "attributes.get": mock_attrs_get,
+                "name": "default-span-name",
             }
         )
         processor = ServiceEntrySpanProcessor()
@@ -159,6 +161,7 @@ class TestServiceEntrySpanProcessor():
             **{
                 "parent": mock_parent,
                 "attributes.get": mock_attrs_get,
+                "name": "default-span-name",
             }
         )
         processor = ServiceEntrySpanProcessor()
@@ -186,6 +189,7 @@ class TestServiceEntrySpanProcessor():
             **{
                 "parent": None,
                 "attributes.get": mock_attrs_get,
+                "name": "default-span-name",
             }
         )
         processor = ServiceEntrySpanProcessor()
@@ -222,7 +226,7 @@ class TestServiceEntrySpanProcessor():
         processor.set_default_transaction_name = mocker.Mock()
         processor.on_start(mock_span, None)
         processor.set_default_transaction_name.assert_called_once_with(
-            mock_span, mock_pool, "sw-apm-transaction"[:INTL_SWO_TRANSACTION_ATTR_MAX]
+            mock_span, "sw-apm-transaction"[:INTL_SWO_TRANSACTION_ATTR_MAX]
         )
 
     def test_on_start_faas_name(self, mocker):
@@ -243,7 +247,7 @@ class TestServiceEntrySpanProcessor():
         processor.set_default_transaction_name = mocker.Mock()
         processor.on_start(mock_span, None)
         processor.set_default_transaction_name.assert_called_once_with(
-            mock_span, mock_pool, "faas-value"
+            mock_span, "faas-value"
         )
 
     def test_on_start_lambda_function_name(self, mocker):
@@ -263,7 +267,7 @@ class TestServiceEntrySpanProcessor():
         processor.set_default_transaction_name = mocker.Mock()
         processor.on_start(mock_span, None)
         processor.set_default_transaction_name.assert_called_once_with(
-            mock_span, mock_pool, "lambda-function"[:INTL_SWO_TRANSACTION_ATTR_MAX]
+            mock_span, "lambda-function"[:INTL_SWO_TRANSACTION_ATTR_MAX]
         )
 
     def test_on_start_http_route(self, mocker):
@@ -284,7 +288,7 @@ class TestServiceEntrySpanProcessor():
         processor.set_default_transaction_name = mocker.Mock()
         processor.on_start(mock_span, None)
         processor.set_default_transaction_name.assert_called_once_with(
-            mock_span, mock_pool, "http-route"
+            mock_span, "http-route"
         )
 
     def test_on_start_url_path(self, mocker):
@@ -305,7 +309,7 @@ class TestServiceEntrySpanProcessor():
         processor.set_default_transaction_name = mocker.Mock()
         processor.on_start(mock_span, None)
         processor.set_default_transaction_name.assert_called_once_with(
-            mock_span, mock_pool, "url-path", resolve=True
+            mock_span, "url-path", resolve=True
         )
 
     def test_on_start_default(self, mocker):
@@ -325,7 +329,7 @@ class TestServiceEntrySpanProcessor():
         processor.set_default_transaction_name = mocker.Mock()
         processor.on_start(mock_span, None)
         processor.set_default_transaction_name.assert_called_once_with(
-            mock_span, mock_pool, "default-span-name"
+            mock_span, "default-span-name"
         )
 
     def test_on_end_valid_local_parent_span(self, mocker):


### PR DESCRIPTION
Implements `ServiceEntrySpanProcessor._on_ending`, made available with OTel 1.40.0/0.61b0. This reduces total calls to `pool.registered(transaction_name)` from `n + 1` to `1`, uses the pool more efficiently (e.g. fewer intermediates taking spots). See ticket for more info.

Also includes accidental bugfix to 256 --> 255 char limit in integration tests.

API's `set_transaction_name` usage and behaviour are still the same; it will log fewer `warning` whenever pool capacity reached. Name setting and response time metrics attribute setting are also the same.