### PR TITLE
Remove stray Python3.9 mentions and tox env

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ When generating code for this repository:
 
 ### Technology Stack
 
-- **Python Versions**: 3.9-3.13 (use 3.9-compatible features for maximum compatibility)
+- **Python Versions**: 3.10-3.14 (use 3.10-compatible features for maximum compatibility)
 - **Core Dependencies**: OpenTelemetry [API and SDK](https://github.com/open-telemetry/opentelemetry-python), and [instrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib/) packages (see pyproject.toml)
 - **Purpose**: Custom OpenTelemetry distribution for SolarWinds APM backend
 

--- a/.github/workflows/run_tox_lint_format.yaml
+++ b/.github/workflows/run_tox_lint_format.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-minor: ["10", "11", "12", "13"]
+        python-minor: ["10", "11", "12", "13", "14"]
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
     - name: Setup Python

--- a/.github/workflows/run_tox_ruff_format.yaml
+++ b/.github/workflows/run_tox_ruff_format.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-minor: ["10", "11", "12", "13"]
+        python-minor: ["10", "11", "12", "13", "14"]
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
     - name: Setup Python

--- a/.github/workflows/run_tox_tests.yaml
+++ b/.github/workflows/run_tox_tests.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-minor: ["10", "11", "12", "13"]
+        python-minor: ["10", "11", "12", "13", "14"]
         apm-env: ["test"]
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,18 +44,18 @@ docker-compose run aarch64
 
 ### Regression Tests
 
-Automated testing of this repo uses [tox](https://tox.readthedocs.io) and runs in Python 3.9, 3.10, 3.11 and/or 3.12 because these are the versions supported by [OTel Python](https://github.com/open-telemetry/opentelemetry-python/blob/main/tox.ini). Testing can be run inside a build container which provides all dependencies. Here is how to set up then run unit and integration tests locally:
+Automated testing of this repo uses [tox](https://tox.readthedocs.io) and runs in Python 3.10, 3.11, 3.12, 3.13, and/or 3.14 because these are the versions supported by [OTel Python](https://github.com/open-telemetry/opentelemetry-python/blob/main/tox.ini). Testing can be run inside a build container which provides all dependencies. Here is how to set up then run unit and integration tests locally:
 
 1. Create and run a Docker build container as described above.
-2. To run all tests for a specific version, provide tox options as a string. For example, to run in Python 3.9: `make tox OPTIONS="-e py39-test"`.
+2. To run all tests for a specific version, provide tox options as a string. For example, to run in Python 3.11: `make tox OPTIONS="-e py311-test"`.
 3. To run tests specific to Lambda instrumentation in Python 3.13: `make tox OPTIONS="-e py313-lambda"`.
 4. (WARNING: slow!) To run all tests for all supported Python environments, as well as linting and formatting: `make tox`
 
 Other regular `tox` arguments can be included in `OPTIONS`. Some examples:
 
 ```
-# Recreate tox environment for Python 3.9 tests
-make tox OPTIONS="--recreate -e py39-test"
+# Recreate tox environment for Python 3.11 tests
+make tox OPTIONS="--recreate -e py311-test"
 
 # Run only the Scenario 8 integration test, in all environments
 make tox OPTIONS="-- tests/integration/test_scenario_1.py"
@@ -73,10 +73,10 @@ Code formatting and linting are run using `black`, `isort`, `flake8`, and `pylin
 ./run_docker_dev.sh
 make tox OPTIONS="-e py312-lint -- --check-only"
 
-# Run formatting and linting tools for Python 3.9,
+# Run formatting and linting tools for Python 3.11,
 # and automatically fix issues if possible:
 ./run_docker_dev.sh
-make tox OPTIONS="-e py39-lint"
+make tox OPTIONS="-e py311-lint"
 ```
 
 `ruff` is also available to fix formatting: `make tox OPTIONS="-e ruff"`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Python solarwinds-apm
 
-[![Minimum Python Version](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
+[![Minimum Python Version](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Release](https://img.shields.io/github/v/release/solarwinds/apm-python?include_prereleases&style=)](https://github.com/solarwinds/apm-python/releases/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?color=red)](https://github.com/solarwinds/apm-python/blob/main/LICENSE)
 
@@ -8,7 +8,7 @@ An [OpenTelemetry Python](https://opentelemetry-python.readthedocs.io/) distribu
 
 ----
 ## Requirements
-All published artifacts support Python 3.9 or higher. A full list of system requirements is available at [SolarWinds Observability System Requirements](https://documentation.solarwinds.com/en/success_center/observability/default.htm#cshid=app-sysreqs-python-agent).
+All published artifacts support Python 3.10 or higher. A full list of system requirements is available at [SolarWinds Observability System Requirements](https://documentation.solarwinds.com/en/success_center/observability/default.htm#cshid=app-sysreqs-python-agent).
 
 See [CONTRIBUTING.md](https://github.com/solarwinds/apm-python/blob/main/CONTRIBUTING.md) for how to build for development.
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 skipsdist = True
 skip_missing_interpreters = True
 envlist =
-  py3{9,10,11,12,13}-test
-  py3{9,10,11,12,13,14}-lambda
-  py3{9,10,11,12,13}-lint
+  py3{10,11,12,13,14}-test
+  py3{10,11,12,13,14}-lambda
+  py3{10,11,12,13,14}-lint
   ruff
 
 [testenv]
@@ -18,7 +18,7 @@ deps =
 commands =
   pytest {posargs}
 
-[testenv:py3{9,10,11,12,13}-test]
+[testenv:py3{10,11,12,13,14}-test]
 changedir = tests
 deps =
   {[testenv]deps}
@@ -27,13 +27,13 @@ setenv =
   SW_APM_COLLECTOR = apm.collector.st-ssp.solarwinds.com
   SW_APM_SERVICE_KEY = foo-bar:service-key
 
-[testenv:py3{9,10,11,12,13,14}-lambda]
+[testenv:py3{10,11,12,13,14}-lambda]
 changedir = lambda/tests
 deps =
   {[testenv]deps}
   -r {toxinidir}/lambda/tests/requirements.txt
 
-[testenv:py3{9,10,11,12,13}-lint]
+[testenv:py3{10,11,12,13,14}-lint]
 deps =
   {[testenv]deps}
   opentelemetry-api


### PR DESCRIPTION
Removes stray Python 3.9 mentions and tox env that were missed and should have been removed with APM version 7.0.0. Makes 3.14 testing and doc mentions a bit more consistent also.